### PR TITLE
Feature: Configurable Target Options (Core)

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -5465,9 +5465,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
     },
     "ua-parser-js": {
       "version": "0.7.28",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "svelte": "^3.30.0",
     "traverse": "^0.6.6",
     "ts-node": "^9.0.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.5.4",
     "vue-template-compiler": "^2.6.12"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -604,3 +604,34 @@ export default function ComponentWithContext(props) {
 }
 "
 `;
+
+exports[`Context Use and set context in components 3`] = `
+"import * as React from \\"react\\";
+import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useContext } from \\"react\\";
+import Context1 from \\"@dummy/1\\";
+import Context2 from \\"@dummy/2\\";
+
+export default function ComponentWithContext(props) {
+  const foo = useContext(Context1);
+
+  return (
+    <Context2.Provider
+      value={{
+        bar: \\"baz\\",
+      }}
+    >
+      <Context1.Provider
+        value={{
+          foo: \\"bar\\",
+        }}
+      >
+        <>
+          <Text>{foo.value}</Text>
+        </>
+      </Context1.Provider>
+    </Context2.Provider>
+  );
+}
+"
+`;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -272,23 +272,23 @@ exports[`Vue Form block 1`] = `
     :name=\\"name\\"
     @submit=\\"onSubmit(event)\\"
   >
-    <BuilderBlockComponent
+    <builder-block-component
       v-for=\\"(block, index) in builderBlock?.children\\"
       :block=\\"block\\"
       :key=\\"block.id\\"
-    ></BuilderBlockComponent>
+    ></builder-block-component>
 
-    <BuilderBlocks
+    <builder-blocks
       dataPath=\\"errorMessage\\"
       v-if=\\"submissionState === 'error'\\"
       :blocks=\\"errorMessage\\"
-    ></BuilderBlocks>
+    ></builder-blocks>
 
-    <BuilderBlocks
+    <builder-blocks
       dataPath=\\"sendingMessage\\"
       v-if=\\"submissionState === 'sending'\\"
       :blocks=\\"sendingMessage\\"
-    ></BuilderBlocks>
+    ></builder-blocks>
 
     <pre
       class=\\"builder-form-error-text pre\\"
@@ -298,11 +298,11 @@ exports[`Vue Form block 1`] = `
       </pre
     >
 
-    <BuilderBlocks
+    <builder-blocks
       dataPath=\\"successMessage\\"
       v-if=\\"submissionState === 'success'\\"
       :blocks=\\"successMessage\\"
-    ></BuilderBlocks>
+    ></builder-blocks>
   </form>
 </template>
 <script>

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../parsers/builder';
 import { parseJsx } from '../parsers/jsx';
 import { compileAwayBuilderComponents } from '../plugins/compile-away-builder-components';
-import { componentToReact } from '..';
+import { componentToReact, ToMitosisOptions } from '..';
 
 /**
  * Load a file using nodejs resolution as a string.
@@ -28,6 +28,10 @@ const lazyLoadSection = JSON.parse(
   fixture('./data/builder/lazy-load-section.json'),
 );
 
+const mitosisOptions: ToMitosisOptions = {
+  format: 'legacy',
+};
+
 describe('Builder', () => {
   test('extractStateHook', () => {
     const code = `useState({ foo: 'bar' }); alert('hi');`;
@@ -43,61 +47,61 @@ describe('Builder', () => {
   });
 
   test('Stamped', () => {
-    const json = parseJsx(stamped);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(stamped);
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
 
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis);
+    const mitosis = componentToMitosis()({ component: backToMitosis });
     expect(mitosis).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(customCode);
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
 
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis);
+    const mitosis = componentToMitosis()({ component: backToMitosis });
     expect(mitosis).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(embed);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(embed);
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
 
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis);
+    const mitosis = componentToMitosis()({ component: backToMitosis });
     expect(mitosis).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(image);
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
 
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis);
+    const mitosis = componentToMitosis()({ component: backToMitosis });
     expect(mitosis).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(columns);
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
 
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis);
+    const mitosis = componentToMitosis()({ component: backToMitosis });
     expect(mitosis).toMatchSnapshot();
   });
 
   test('Section', async () => {
-    const mitosisComponent = builderContentToMitosisComponent(lazyLoadSection);
+    const component = builderContentToMitosisComponent(lazyLoadSection);
 
-    const html = await componentToHtml(mitosisComponent, {
+    const html = await componentToHtml({
       plugins: [compileAwayBuilderComponents()],
-    });
+    })({ component });
 
     expect(html).toMatchSnapshot();
   });
@@ -130,16 +134,16 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    const builderJson = componentToBuilder()({ component });
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
-    const react = componentToReact(json, {
+    const react = componentToReact({
       plugins: [compileAwayBuilderComponents()],
-    });
+    })({ component });
     expect(react).toMatchSnapshot();
   });
 
@@ -168,11 +172,11 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    const builderJson = componentToBuilder()({ component });
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
   });
@@ -201,11 +205,11 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    const builderJson = componentToBuilder()({ component });
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
   });
@@ -236,14 +240,14 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    expect(json).toMatchSnapshot();
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    expect(component).toMatchSnapshot();
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
     const backToMitosis = builderContentToMitosisComponent(builderJson);
     expect(backToMitosis).toMatchSnapshot();
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
   });
@@ -264,14 +268,14 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    expect(json).toMatchSnapshot();
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    expect(component).toMatchSnapshot();
+    const builderJson = componentToBuilder()({ component });
     expect(builderJson).toMatchSnapshot();
     const backToMitosis = builderContentToMitosisComponent(builderJson);
     expect(backToMitosis).toMatchSnapshot();
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
   });
@@ -299,11 +303,11 @@ describe('Builder', () => {
       }
     `;
 
-    const json = parseJsx(code);
-    const builderJson = componentToBuilder(json);
+    const component = parseJsx(code);
+    const builderJson = componentToBuilder()({ component });
     const backToMitosis = builderContentToMitosisComponent(builderJson);
-    const mitosis = componentToMitosis(backToMitosis, {
-      format: 'legacy',
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
     });
     expect(mitosis.trim()).toEqual(code.trim());
   });

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -2,6 +2,7 @@ import { parseJsx } from '../parsers/jsx';
 import { contextToReact } from '../generators/context/react';
 import { parseContext } from '../parsers/context';
 import { componentToReact } from '../generators/react';
+import { componentToReactNative } from '../generators/react-native';
 
 const simpleExample = require('./data/context/simple.context.lite');
 const componentWithContext = require('./data/context/component-with-context.lite');
@@ -9,26 +10,29 @@ const renderBlock = require('./data/blocks/builder-render-block.raw');
 
 describe('Context', () => {
   test('Parse context', () => {
-    const json = parseContext(simpleExample, { name: 'SimpleExample' });
-    if (!json) {
+    const component = parseContext(simpleExample, { name: 'SimpleExample' });
+    if (!component) {
       throw new Error('No parseable context found for simple.context.lite.ts');
     }
-    expect(json).toMatchSnapshot();
-    const reactContext = contextToReact(json);
+    expect(component).toMatchSnapshot();
+    const reactContext = contextToReact()({ context: component });
     expect(reactContext).toMatchSnapshot();
   });
 
   test('Use and set context in components', () => {
-    const json = parseJsx(componentWithContext);
-    expect(json).toMatchSnapshot();
-    const reactComponent = componentToReact(json);
+    const component = parseJsx(componentWithContext);
+    expect(component).toMatchSnapshot();
+    const reactComponent = componentToReact()({ component });
     expect(reactComponent).toMatchSnapshot();
+
+    const reactNativeComponent = componentToReactNative()({ component });
+    expect(reactNativeComponent).toMatchSnapshot();
   });
 
   test('Use and set context in complex components', () => {
-    const json = parseJsx(renderBlock);
-    expect(json).toMatchSnapshot();
-    const reactComponent = componentToReact(json);
+    const component = parseJsx(renderBlock);
+    expect(component).toMatchSnapshot();
+    const reactComponent = componentToReact()({ component });
     expect(reactComponent).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/html.test.ts
+++ b/packages/core/src/__tests__/html.test.ts
@@ -5,8 +5,8 @@ const stamped = require('./data/blocks/stamped-io.raw');
 
 describe('Html', () => {
   test('Stamped', () => {
-    const json = parseJsx(stamped);
-    const html = componentToHtml(json);
+    const component = parseJsx(stamped);
+    const html = componentToHtml()({ component });
     expect(html).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/liquid.test.ts
+++ b/packages/core/src/__tests__/liquid.test.ts
@@ -20,104 +20,104 @@ const columns = require('./data/blocks/columns.raw');
 
 describe('Liquid', () => {
   test('Basic', () => {
-    const json = parseJsx(basic);
-    const output = componentToLiquid(json);
+    const component = parseJsx(basic);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Input block', () => {
-    const json = parseJsx(inputBlock);
-    const output = componentToLiquid(json);
+    const component = parseJsx(inputBlock);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Submit button block', () => {
-    const json = parseJsx(submitButtonBlock);
-    const output = componentToLiquid(json);
+    const component = parseJsx(submitButtonBlock);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Select block', () => {
-    const json = parseJsx(selectBlock);
-    const output = componentToLiquid(json);
+    const component = parseJsx(selectBlock);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Form block', () => {
-    const json = parseJsx(formBlock);
-    const output = componentToLiquid(json);
+    const component = parseJsx(formBlock);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Button', () => {
-    const json = parseJsx(button);
-    const output = componentToLiquid(json);
+    const component = parseJsx(button);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Textarea', () => {
-    const json = parseJsx(textarea);
-    const output = componentToLiquid(json);
+    const component = parseJsx(textarea);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Img', () => {
-    const json = parseJsx(img);
-    const output = componentToLiquid(json);
+    const component = parseJsx(img);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Video', () => {
-    const json = parseJsx(video);
-    const output = componentToLiquid(json);
+    const component = parseJsx(video);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Section', () => {
-    const json = parseJsx(section);
-    const output = componentToLiquid(json);
+    const component = parseJsx(section);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Text', () => {
-    const json = parseJsx(text);
-    const output = componentToLiquid(json);
+    const component = parseJsx(text);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('RawText', () => {
-    const json = parseJsx(rawText);
-    const output = componentToLiquid(json);
+    const component = parseJsx(rawText);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Stamped.io', () => {
-    const json = parseJsx(stamped);
-    const output = componentToLiquid(json);
+    const component = parseJsx(stamped);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const output = componentToLiquid(json);
+    const component = parseJsx(customCode);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(customCode);
-    const output = componentToLiquid(json);
+    const component = parseJsx(customCode);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const output = componentToLiquid(json);
+    const component = parseJsx(image);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const output = componentToLiquid(json);
+    const component = parseJsx(columns);
+    const output = componentToLiquid()({ component });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/react-native.test.ts
+++ b/packages/core/src/__tests__/react-native.test.ts
@@ -20,106 +20,106 @@ const columns = require('./data/blocks/columns.raw');
 
 describe('React', () => {
   test('Basic', () => {
-    const json = parseJsx(basic);
-    const output = componentToReactNative(json);
+    const component = parseJsx(basic);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Input block', () => {
-    const json = parseJsx(inputBlock);
-    const output = componentToReactNative(json);
+    const component = parseJsx(inputBlock);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Submit button block', () => {
-    const json = parseJsx(submitButtonBlock);
-    const output = componentToReactNative(json);
+    const component = parseJsx(submitButtonBlock);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Select block', () => {
-    const json = parseJsx(selectBlock);
-    const output = componentToReactNative(json);
+    const component = parseJsx(selectBlock);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Form block', () => {
-    const json = parseJsx(formBlock);
-    const output = componentToReactNative(json);
+    const component = parseJsx(formBlock);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Button', () => {
-    const json = parseJsx(button);
-    const output = componentToReactNative(json);
+    const component = parseJsx(button);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Textarea', () => {
-    const json = parseJsx(textarea);
-    const output = componentToReactNative(json);
+    const component = parseJsx(textarea);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Img', () => {
-    const json = parseJsx(img);
-    const output = componentToReactNative(json);
+    const component = parseJsx(img);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Video', () => {
-    const json = parseJsx(video);
-    const output = componentToReactNative(json);
+    const component = parseJsx(video);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Section', () => {
-    const json = parseJsx(section);
-    const output = componentToReactNative(json);
+    const component = parseJsx(section);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Text', () => {
-    const json = parseJsx(text);
-    const output = componentToReactNative(json);
+    const component = parseJsx(text);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('RawText', () => {
-    const json = parseJsx(rawText);
-    const output = componentToReactNative(json);
+    const component = parseJsx(rawText);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Stamped.io', () => {
-    const json = parseJsx(stamped);
-    const output = componentToReactNative(json, {
+    const component = parseJsx(stamped);
+    const output = componentToReactNative({
       stateType: 'useState',
-    });
+    })({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const output = componentToReactNative(json);
+    const component = parseJsx(customCode);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(customCode);
-    const output = componentToReactNative(json);
+    const component = parseJsx(customCode);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const output = componentToReactNative(json);
+    const component = parseJsx(image);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const output = componentToReactNative(json);
+    const component = parseJsx(columns);
+    const output = componentToReactNative()({ component });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/react.test.ts
+++ b/packages/core/src/__tests__/react.test.ts
@@ -20,107 +20,107 @@ const columns = require('./data/blocks/columns.raw');
 
 describe('React', () => {
   test('Basic', () => {
-    const json = parseJsx(basic);
-    const output = componentToReact(json);
+    const component = parseJsx(basic);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Input block', () => {
-    const json = parseJsx(inputBlock);
-    const output = componentToReact(json);
+    const component = parseJsx(inputBlock);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Submit button block', () => {
-    const json = parseJsx(submitButtonBlock);
-    const output = componentToReact(json);
+    const component = parseJsx(submitButtonBlock);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Select block', () => {
-    const json = parseJsx(selectBlock);
-    const output = componentToReact(json);
+    const component = parseJsx(selectBlock);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Form block', () => {
-    const json = parseJsx(formBlock);
-    const output = componentToReact(json);
+    const component = parseJsx(formBlock);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Button', () => {
-    const json = parseJsx(button);
-    const output = componentToReact(json);
+    const component = parseJsx(button);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Textarea', () => {
-    const json = parseJsx(textarea);
-    const output = componentToReact(json);
+    const component = parseJsx(textarea);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Img', () => {
-    const json = parseJsx(img);
-    const output = componentToReact(json);
+    const component = parseJsx(img);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Video', () => {
-    const json = parseJsx(video);
-    const output = componentToReact(json);
+    const component = parseJsx(video);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Section', () => {
-    const json = parseJsx(section);
-    const output = componentToReact(json);
+    const component = parseJsx(section);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Text', () => {
-    const json = parseJsx(text);
-    const output = componentToReact(json);
+    const component = parseJsx(text);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('RawText', () => {
-    const json = parseJsx(rawText);
-    const output = componentToReact(json);
+    const component = parseJsx(rawText);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Stamped.io', () => {
-    const json = parseJsx(stamped);
-    const output = componentToReact(json, {
+    const component = parseJsx(stamped);
+    const output = componentToReact({
       stylesType: 'styled-components',
       stateType: 'useState',
-    });
+    })({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const output = componentToReact(json);
+    const component = parseJsx(customCode);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(customCode);
-    const output = componentToReact(json);
+    const component = parseJsx(customCode);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const output = componentToReact(json);
+    const component = parseJsx(image);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const output = componentToReact(json);
+    const component = parseJsx(columns);
+    const output = componentToReact()({ component });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/solid.test.ts
+++ b/packages/core/src/__tests__/solid.test.ts
@@ -19,98 +19,98 @@ const columns = require('./data/blocks/columns.raw');
 
 describe('Solid', () => {
   test('Basic', () => {
-    const json = parseJsx(basic);
-    const output = componentToSolid(json);
+    const component = parseJsx(basic);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Input block', () => {
-    const json = parseJsx(inputBlock);
-    const output = componentToSolid(json);
+    const component = parseJsx(inputBlock);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Submit button block', () => {
-    const json = parseJsx(submitButtonBlock);
-    const output = componentToSolid(json);
+    const component = parseJsx(submitButtonBlock);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Select block', () => {
-    const json = parseJsx(selectBlock);
-    const output = componentToSolid(json);
+    const component = parseJsx(selectBlock);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Form block', () => {
-    const json = parseJsx(formBlock);
-    const output = componentToSolid(json);
+    const component = parseJsx(formBlock);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Button', () => {
-    const json = parseJsx(button);
-    const output = componentToSolid(json);
+    const component = parseJsx(button);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Textarea', () => {
-    const json = parseJsx(textarea);
-    const output = componentToSolid(json);
+    const component = parseJsx(textarea);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Img', () => {
-    const json = parseJsx(img);
-    const output = componentToSolid(json);
+    const component = parseJsx(img);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Video', () => {
-    const json = parseJsx(video);
-    const output = componentToSolid(json);
+    const component = parseJsx(video);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Section', () => {
-    const json = parseJsx(section);
-    const output = componentToSolid(json);
+    const component = parseJsx(section);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Text', () => {
-    const json = parseJsx(text);
-    const output = componentToSolid(json);
+    const component = parseJsx(text);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('RawText', () => {
-    const json = parseJsx(rawText);
-    const output = componentToSolid(json);
+    const component = parseJsx(rawText);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const output = componentToSolid(json);
+    const component = parseJsx(customCode);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(customCode);
-    const output = componentToSolid(json);
+    const component = parseJsx(customCode);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const output = componentToSolid(json);
+    const component = parseJsx(image);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const output = componentToSolid(json);
+    const component = parseJsx(columns);
+    const output = componentToSolid()({ component });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/core/src/__tests__/vue.test.ts
+++ b/packages/core/src/__tests__/vue.test.ts
@@ -18,106 +18,108 @@ const embed = require('./data/blocks/embed.raw');
 const image = require('./data/blocks/image.raw');
 const columns = require('./data/blocks/columns.raw');
 
+const path = 'test-path';
+
 describe('Vue', () => {
   test('Basic', () => {
-    const json = parseJsx(basic);
-    const output = componentToVue(json);
+    const component = parseJsx(basic);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Input block', () => {
-    const json = parseJsx(inputBlock);
-    const output = componentToVue(json);
+    const component = parseJsx(inputBlock);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Submit button block', () => {
-    const json = parseJsx(submitButtonBlock);
-    const output = componentToVue(json);
+    const component = parseJsx(submitButtonBlock);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Select block', () => {
-    const json = parseJsx(selectBlock);
-    const output = componentToVue(json);
+    const component = parseJsx(selectBlock);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Form block', () => {
-    const json = parseJsx(formBlock);
-    const output = componentToVue(json);
+    const component = parseJsx(formBlock);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Button', () => {
-    const json = parseJsx(button);
-    const output = componentToVue(json);
+    const component = parseJsx(button);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Textarea', () => {
-    const json = parseJsx(textarea);
-    const output = componentToVue(json);
+    const component = parseJsx(textarea);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Img', () => {
-    const json = parseJsx(img);
-    const output = componentToVue(json);
+    const component = parseJsx(img);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Video', () => {
-    const json = parseJsx(video);
-    const output = componentToVue(json);
+    const component = parseJsx(video);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Section', () => {
-    const json = parseJsx(section);
-    const output = componentToVue(json);
+    const component = parseJsx(section);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Text', () => {
-    const json = parseJsx(text);
-    const output = componentToVue(json);
+    const component = parseJsx(text);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('RawText', () => {
-    const json = parseJsx(rawText);
-    const output = componentToVue(json);
+    const component = parseJsx(rawText);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Stamped.io', () => {
-    const json = parseJsx(stamped);
-    const output = componentToVue(json);
+    const component = parseJsx(stamped);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('CustomCode', () => {
-    const json = parseJsx(customCode);
-    const output = componentToVue(json);
+    const component = parseJsx(customCode);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Embed', () => {
-    const json = parseJsx(customCode);
-    const output = componentToVue(json);
+    const component = parseJsx(customCode);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Image', () => {
-    const json = parseJsx(image);
-    const output = componentToVue(json);
+    const component = parseJsx(image);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 
   test('Columns', () => {
-    const json = parseJsx(columns);
-    const output = componentToVue(json);
+    const component = parseJsx(columns);
+    const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -8,10 +8,8 @@ import { mapRefs } from '../helpers/map-refs';
 import { renderPreComponent } from '../helpers/render-imports';
 import { stripStateAndPropsRefs } from '../helpers/strip-state-and-props-refs';
 import { selfClosingTags } from '../parsers/jsx';
-import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -22,11 +20,9 @@ import { getProps } from '../helpers/get-props';
 import { kebabCase } from 'lodash';
 import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { removeSurroundingBlock } from '../helpers/remove-surrounding-block';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
 
-export type ToAngularOptions = {
-  prettier?: boolean;
-  plugins?: Plugin[];
-};
+export interface ToAngularOptions extends BaseTranspilerOptions {}
 
 const mappers: {
   [key: string]: (json: MitosisNode, options: ToAngularOptions) => string;
@@ -142,16 +138,15 @@ const indent = (str: string, spaces = 4) =>
   str.replace(/\n([^\n])/g, `\n${' '.repeat(spaces)}$1`);
 
 export const componentToAngular = (
-  componentJson: MitosisComponent,
   options: ToAngularOptions = {},
-) => {
+): Transpiler => ({ component }) => {
   // Make a copy we can safely mutate, similar to babel's toolchain
-  let json = fastClone(componentJson);
+  let json = fastClone(component);
   if (options.plugins) {
     json = runPreJsonPlugins(json, options.plugins);
   }
 
-  const props = getProps(componentJson);
+  const props = getProps(component);
 
   const refs = Array.from(getRefs(json));
   mapRefs(json, (refName) => `this.${refName}.nativeElement`);
@@ -198,7 +193,7 @@ export const componentToAngular = (
           : ''
       }
     })
-    export default class ${componentJson.name} {
+    export default class ${component.name} {
       ${Array.from(props)
         .map((item) => `@Input() ${item}: any`)
         .join('\n')}
@@ -208,20 +203,20 @@ export const componentToAngular = (
         .join('\n')}
 
       ${
-        !componentJson.hooks.onMount
+        !component.hooks.onMount
           ? ''
           : `ngOnInit() {
-              ${stripStateAndPropsRefs(componentJson.hooks.onMount, {
+              ${stripStateAndPropsRefs(component.hooks.onMount, {
                 replaceWith: 'this.',
               })}
             }`
       }
 
       ${
-        !componentJson.hooks.onUnMount
+        !component.hooks.onUnMount
           ? ''
           : `ngOnDestroy() {
-              ${stripStateAndPropsRefs(componentJson.hooks.onUnMount, {
+              ${stripStateAndPropsRefs(component.hooks.onUnMount, {
                 replaceWith: 'this.',
               })}
             }`

--- a/packages/core/src/generators/context/react.ts
+++ b/packages/core/src/generators/context/react.ts
@@ -6,10 +6,11 @@ type ContextToReactOptions = {
   format?: boolean;
 };
 
-export function contextToReact(
-  context: MitosisContext,
-  options: ContextToReactOptions = {},
-): string {
+export const contextToReact = (options: ContextToReactOptions = {}) => ({
+  context,
+}: {
+  context: MitosisContext;
+}): string => {
   let str = `
   import { createContext } from 'react';
 
@@ -31,4 +32,4 @@ export function contextToReact(
   }
 
   return str;
-}
+};

--- a/packages/core/src/generators/liquid.ts
+++ b/packages/core/src/generators/liquid.ts
@@ -3,10 +3,8 @@ import { collectCss } from '../helpers/collect-styles';
 import { fastClone } from '../helpers/fast-clone';
 import { stripStateAndPropsRefs } from '../helpers/strip-state-and-props-refs';
 import { selfClosingTags } from '../parsers/jsx';
-import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -14,6 +12,11 @@ import {
 } from '../modules/plugins';
 import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { getStateObjectStringFromComponent } from '../helpers/get-state-object-string';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
+
+export interface ToLiquidOptions extends BaseTranspilerOptions {
+  reactive?: boolean;
+}
 
 /**
  * Test if the binding expression would be likely to generate
@@ -33,12 +36,6 @@ export const isValidLiquidBinding = (str = '') => {
     // e.g. `state.product.price` -> `{{product.price}}	    // we regex out later to transform back into valid liquid expressions
     Boolean(str.match(/^[a-z0-9_\.\s]+$/i))
   );
-};
-
-type ToLiquidOptions = {
-  prettier?: boolean;
-  plugins?: Plugin[];
-  reactive?: boolean;
 };
 
 const mappers: {
@@ -156,10 +153,9 @@ const blockToLiquid = (
 
 // TODO: add JS support similar to componentToHtml()
 export const componentToLiquid = (
-  componentJson: MitosisComponent,
   options: ToLiquidOptions = {},
-) => {
-  let json = fastClone(componentJson);
+): Transpiler => ({ component }) => {
+  let json = fastClone(component);
   if (options.plugins) {
     json = runPreJsonPlugins(json, options.plugins);
   }

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -1,6 +1,7 @@
 import dedent from 'dedent';
 import json5 from 'json5';
 import { format } from 'prettier/standalone';
+import { Transpiler } from '..';
 import { fastClone } from '../helpers/fast-clone';
 import { getComponents } from '../helpers/get-components';
 import { getRefs } from '../helpers/get-refs';
@@ -12,19 +13,18 @@ import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 
-export const DEFAULT_FORMAT = 'legacy';
+export interface ToMitosisOptions {
+  prettier?: boolean;
+  format: 'react' | 'legacy';
+}
 
-export type MitosisFormat = 'react' | 'legacy';
+export const DEFAULT_FORMAT: ToMitosisOptions['format'] = 'legacy';
 
 // Special isValidAttributeName for Mitosis so we can allow for $ in names
 const isValidAttributeName = (str: string) => {
   return Boolean(str && /^[$a-z0-9\-_:]+$/i.test(str));
 };
 
-export type ToMitosisOptions = {
-  prettier?: boolean;
-  format: MitosisFormat;
-};
 export const blockToMitosis = (
   json: MitosisNode,
   toMitosisOptions: Partial<ToMitosisOptions> = {},
@@ -129,24 +129,23 @@ const getRefsString = (json: MitosisComponent, refs = getRefs(json)) => {
 const mitosisCoreComponents = ['Show', 'For'];
 
 export const componentToMitosis = (
-  componentJson: MitosisComponent,
   toMitosisOptions: Partial<ToMitosisOptions> = {},
-) => {
+): Transpiler => ({ component }) => {
   const options: ToMitosisOptions = {
     format: DEFAULT_FORMAT,
     ...toMitosisOptions,
   };
 
   if (options.format === 'react') {
-    return componentToReact(componentJson, {
+    return componentToReact({
       format: 'lite',
       stateType: 'useState',
       stylesType: 'emotion',
       prettier: options.prettier,
-    });
+    })({ component });
   }
 
-  const json = fastClone(componentJson);
+  const json = fastClone(component);
 
   const refs = getRefs(json);
 
@@ -163,7 +162,7 @@ export const componentToMitosis = (
     (item) => !mitosisCoreComponents.includes(item),
   );
 
-  const hasState = Boolean(Object.keys(componentJson.state).length);
+  const hasState = Boolean(Object.keys(component.state).length);
 
   const needsMitosisCoreImport = Boolean(
     hasState || refs.size || mitosisComponents.length,
@@ -186,14 +185,14 @@ export const componentToMitosis = (
     ${renderPreComponent(json)}
 
     ${
-      !componentJson.meta.metadataHook
+      !component.meta.metadataHook
         ? ''
         : `${METADATA_HOOK_NAME}(${json5.stringify(
-            componentJson.meta.metadataHook,
+            component.meta.metadataHook,
           )})`
     }
 
-    export default function ${componentJson.name}(props) {
+    export default function ${component.name}(props) {
       ${
         !hasState
           ? ''

--- a/packages/core/src/generators/react-native.ts
+++ b/packages/core/src/generators/react-native.ts
@@ -4,16 +4,14 @@ import { fastClone } from '../helpers/fast-clone';
 import traverse from 'traverse';
 import { ClassStyleMap } from '../helpers/collect-styles';
 import { isMitosisNode } from '../helpers/is-mitosis-node';
-import { Plugin } from '../modules/plugins';
 import { MitosisComponent } from '../types/mitosis-component';
 import { componentToReact } from './react';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
 
-type ToReactNativeOptions = {
-  prettier?: boolean;
+export interface ToReactNativeOptions extends BaseTranspilerOptions {
   stylesType?: 'emotion' | 'react-native';
   stateType?: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder';
-  plugins?: Plugin[];
-};
+}
 
 const stylePropertiesThatMustBeNumber = new Set(['lineHeight']);
 
@@ -67,10 +65,9 @@ export const collectReactNativeStyles = (
 };
 
 export const componentToReactNative = (
-  componentJson: MitosisComponent,
   options: ToReactNativeOptions = {},
-) => {
-  const json = fastClone(componentJson);
+): Transpiler => ({ component, path }) => {
+  const json = fastClone(component);
   traverse(json).forEach((node) => {
     if (isMitosisNode(node)) {
       // TODO: handle TextInput, Image, etc
@@ -87,9 +84,9 @@ export const componentToReactNative = (
     }
   });
 
-  return componentToReact(json, {
+  return componentToReact({
     ...options,
     stylesType: options.stylesType || 'react-native',
     type: 'native',
-  });
+  })({ component: json, path });
 };

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -2,6 +2,7 @@ import { types } from '@babel/core';
 import dedent from 'dedent';
 import json5 from 'json5';
 import { format } from 'prettier/standalone';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
 import traverse from 'traverse';
 import { functionLiteralPrefix } from '../constants/function-literal-prefix';
 import { methodLiteralPrefix } from '../constants/method-literal-prefix';
@@ -32,7 +33,6 @@ import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings'
 import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { stripStateAndPropsRefs } from '../helpers/strip-state-and-props-refs';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -43,14 +43,12 @@ import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import { collectReactNativeStyles } from './react-native';
 
-type ToReactOptions = {
-  prettier?: boolean;
+export interface ToReactOptions extends BaseTranspilerOptions {
   stylesType?: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native';
   stateType?: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder';
   format?: 'lite' | 'safe';
   type?: 'dom' | 'native';
-  plugins?: Plugin[];
-};
+}
 
 const wrapInFragment = (json: MitosisComponent | MitosisNode) =>
   json.children.length !== 1;
@@ -369,10 +367,9 @@ type ReactExports =
   | 'useContext';
 
 export const componentToReact = (
-  componentJson: MitosisComponent,
   reactOptions: ToReactOptions = {},
-) => {
-  let json = fastClone(componentJson);
+): Transpiler => ({ component }) => {
+  let json = fastClone(component);
   const options: ToReactOptions = {
     stateType: 'useState',
     stylesType: 'styled-jsx',

--- a/packages/core/src/generators/solid.ts
+++ b/packages/core/src/generators/solid.ts
@@ -8,7 +8,6 @@ import { selfClosingTags } from '../parsers/jsx';
 import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -19,6 +18,9 @@ import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { getComponentsUsed } from '../helpers/get-components-used';
 import traverse from 'traverse';
 import { isMitosisNode } from '../helpers/is-mitosis-node';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
+
+export interface ToSolidOptions extends BaseTranspilerOptions {}
 
 // Transform <foo.bar key="value" /> to <component :is="foo.bar" key="value" />
 function processDynamicComponents(
@@ -94,10 +96,6 @@ const collectClassString = (json: MitosisNode): string | null => {
   return null;
 };
 
-type ToSolidOptions = {
-  prettier?: boolean;
-  plugins?: Plugin[];
-};
 const blockToSolid = (
   json: MitosisNode,
   options: ToSolidOptions = {},
@@ -181,11 +179,10 @@ const getRefsString = (json: MitosisComponent, refs = getRefs(json)) => {
   return str;
 };
 
-export const componentToSolid = (
-  componentJson: MitosisComponent,
-  options: ToSolidOptions = {},
-) => {
-  let json = fastClone(componentJson);
+export const componentToSolid = (options: ToSolidOptions = {}): Transpiler => ({
+  component,
+}) => {
+  let json = fastClone(component);
   if (options.plugins) {
     json = runPreJsonPlugins(json, options.plugins);
   }
@@ -198,7 +195,7 @@ export const componentToSolid = (
   const foundDynamicComponents = processDynamicComponents(json, options);
 
   const stateString = getStateObjectStringFromComponent(json);
-  const hasState = Boolean(Object.keys(componentJson.state).length);
+  const hasState = Boolean(Object.keys(component.state).length);
   const componentsUsed = getComponentsUsed(json);
 
   const hasShowComponent = componentsUsed.has('Show');

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -13,7 +13,6 @@ import { selfClosingTags } from '../parsers/jsx';
 import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -22,12 +21,11 @@ import {
 import isChildren from '../helpers/is-children';
 import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { removeSurroundingBlock } from '../helpers/remove-surrounding-block';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
 
-export type ToSvelteOptions = {
-  prettier?: boolean;
+export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';
-  plugins?: Plugin[];
-};
+}
 
 const mappers: {
   [key: string]: (json: MitosisNode, options: ToSvelteOptions) => string;
@@ -149,15 +147,14 @@ const useBindValue = (json: MitosisComponent, options: ToSvelteOptions) => {
 };
 
 export const componentToSvelte = (
-  componentJson: MitosisComponent,
   options: ToSvelteOptions = {},
-) => {
+): Transpiler => ({ component }) => {
   const useOptions: ToSvelteOptions = {
     ...options,
     stateType: 'variables',
   };
   // Make a copy we can safely mutate, similar to babel's toolchain
-  let json = fastClone(componentJson);
+  let json = fastClone(component);
   if (useOptions.plugins) {
     json = runPreJsonPlugins(json, useOptions.plugins);
   }

--- a/packages/core/src/generators/swift-ui.ts
+++ b/packages/core/src/generators/swift-ui.ts
@@ -11,6 +11,7 @@ import { isMitosisNode } from '../helpers/is-mitosis-node';
 import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import { MitosisStyles } from '../types/mitosis-styles';
+import { Transpiler } from '..';
 
 export type ToSwiftOptions = {
   prettier?: boolean;
@@ -299,11 +300,10 @@ function getInputBindings(json: MitosisComponent, options: ToSwiftOptions) {
   }
   return str;
 }
-export const componentToSwift = (
-  componentJson: MitosisComponent,
-  options: ToSwiftOptions = {},
-) => {
-  const json = fastClone(componentJson);
+export const componentToSwift = (options: ToSwiftOptions = {}): Transpiler => ({
+  component,
+}) => {
+  const json = fastClone(component);
   mapDataForSwiftCompatability(json);
 
   const hasDyanmicData = componentHasDynamicData(json);
@@ -331,7 +331,7 @@ export const componentToSwift = (
     `
     }
 
-    struct ${componentJson.name}: View {
+    struct ${component.name}: View {
       ${
         !hasDyanmicData
           ? ''

--- a/packages/core/src/generators/template.ts
+++ b/packages/core/src/generators/template.ts
@@ -1,12 +1,9 @@
 import { format } from 'prettier/standalone';
 import { collectCss } from '../helpers/collect-styles';
 import { fastClone } from '../helpers/fast-clone';
-import {} from '../helpers/strip-state-and-props-refs';
 import { selfClosingTags } from '../parsers/jsx';
-import { MitosisComponent } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import {
-  Plugin,
   runPostCodePlugins,
   runPostJsonPlugins,
   runPreCodePlugins,
@@ -14,11 +11,9 @@ import {
 } from '../modules/plugins';
 import dedent from 'dedent';
 import { getStateObjectStringFromComponent } from '../helpers/get-state-object-string';
+import { BaseTranspilerOptions, Transpiler } from '../types/config';
 
-type ToTemplateOptions = {
-  prettier?: boolean;
-  plugins?: Plugin[];
-};
+export interface ToTemplateOptions extends BaseTranspilerOptions {}
 
 const mappers: {
   [key: string]: (json: MitosisNode, options: ToTemplateOptions) => string;
@@ -116,10 +111,9 @@ const blockToTemplate = (
 
 // TODO: add JS support similar to componentToHtml()
 export const componentToTemplate = (
-  componentJson: MitosisComponent,
   options: ToTemplateOptions = {},
-) => {
-  let json = fastClone(componentJson);
+): Transpiler => ({ component }) => {
+  let json = fastClone(component);
   if (options.plugins) {
     json = runPreJsonPlugins(json, options.plugins);
   }

--- a/packages/core/src/helpers/json.ts
+++ b/packages/core/src/helpers/json.ts
@@ -1,0 +1,10 @@
+import json5 from 'json5';
+
+export const tryParseJson = (jsonStr: string) => {
+  try {
+    return json5.parse(jsonStr);
+  } catch (err) {
+    console.error('Could not JSON5 parse object:\n', jsonStr);
+    throw err;
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,9 @@ export * from './helpers/is-mitosis-node';
 
 export * from './types/mitosis-node';
 export * from './types/mitosis-component';
+export * from './types/config';
 
 export * from './plugins/compile-away-builder-components';
 export * from './plugins/map-styles';
+
+export * from './targets';

--- a/packages/core/src/modules/plugins.ts
+++ b/packages/core/src/modules/plugins.ts
@@ -1,21 +1,7 @@
 import { MitosisComponent } from '../types/mitosis-component';
+import { Plugin } from '../types/plugins';
 
-export type Plugin = (
-  options?: any,
-) => {
-  json?: {
-    // Happens before any modifiers
-    pre?: (json: MitosisComponent) => MitosisComponent | void;
-    // Happens after built in modifiers
-    post?: (json: MitosisComponent) => MitosisComponent | void;
-  };
-  code?: {
-    // Happens before formatting
-    pre?: (code: string) => string;
-    // Happens after formatting
-    post?: (code: string) => string;
-  };
-};
+export { Plugin };
 
 export const runPreJsonPlugins = (
   json: MitosisComponent,

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -1,6 +1,5 @@
 import * as babel from '@babel/core';
 import generate from '@babel/generator';
-import * as JSON5 from 'json5';
 import { traceReferenceToModulePath } from '../helpers/trace-reference-to-module-path';
 import traverse from 'traverse';
 import { functionLiteralPrefix } from '../constants/function-literal-prefix';
@@ -15,6 +14,7 @@ import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings'
 import { JSONObject, JSONOrNode, JSONOrNodeObject } from '../types/json';
 import { MitosisComponent, MitosisImport } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
+import { tryParseJson } from '../helpers/json';
 
 const jsxPlugin = require('@babel/plugin-syntax-jsx');
 const tsPreset = require('@babel/preset-typescript');
@@ -149,27 +149,13 @@ export const parseStateObject = (object: babel.types.ObjectExpression) => {
   });
 
   const newObject = types.objectExpression(useProperties);
-  let code;
-  let obj;
-  try {
-    code = generate(newObject).code!;
-    obj = JSON5.parse(code);
-  } catch (err) {
-    console.error('Could not JSON5 parse object:\n', code);
-    throw err;
-  }
+  const obj = parseCodeJson(newObject);
   return obj;
 };
 
-const parseJson = (node: babel.types.Node) => {
-  let code: string | undefined;
-  try {
-    code = generate(node).code!;
-    return JSON5.parse(code);
-  } catch (err) {
-    console.error('Could not JSON5 parse object:\n', code);
-    throw err;
-  }
+const parseCodeJson = (node: babel.types.Node) => {
+  const code = generate(node).code;
+  return tryParseJson(code);
 };
 
 const componentFunctionToJson = (
@@ -248,11 +234,11 @@ const componentFunctionToJson = (
             // Function as init, like:
             // useState(() => true)
             if (types.isArrowFunctionExpression(value)) {
-              state[varName] = parseJson(value.body);
+              state[varName] = parseCodeJson(value.body);
             } else {
               // Value as init, like:
               // useState(true)
-              state[varName] = parseJson(value);
+              state[varName] = parseCodeJson(value);
             }
           }
         }
@@ -406,17 +392,15 @@ const jsxElementToJson = (
   const nodeName = generate(node.openingElement.name).code;
 
   if (nodeName === 'Show') {
-    const whenAttr:
-      | babel.types.JSXAttribute
-      | undefined = node.openingElement.attributes.find(
-      (item) => types.isJSXAttribute(item) && item.name.name === 'when',
-    ) as any;
+    const whenAttr: babel.types.JSXAttribute | undefined =
+      node.openingElement.attributes.find(
+        (item) => types.isJSXAttribute(item) && item.name.name === 'when',
+      ) as any;
 
-    const elseAttr:
-      | babel.types.JSXAttribute
-      | undefined = node.openingElement.attributes.find(
-      (item) => types.isJSXAttribute(item) && item.name.name === 'else',
-    ) as any;
+    const elseAttr: babel.types.JSXAttribute | undefined =
+      node.openingElement.attributes.find(
+        (item) => types.isJSXAttribute(item) && item.name.name === 'else',
+      ) as any;
 
     const whenValue =
       whenAttr &&
@@ -457,8 +441,10 @@ const jsxElementToJson = (
           name: 'For',
           bindings: {
             each: generate(
-              ((node.openingElement.attributes[0] as babel.types.JSXAttribute)
-                .value as babel.types.JSXExpressionContainer).expression,
+              (
+                (node.openingElement.attributes[0] as babel.types.JSXAttribute)
+                  .value as babel.types.JSXExpressionContainer
+              ).expression,
             ).code,
           },
           properties: {
@@ -547,12 +533,11 @@ const collectMetadata = (
       return true;
     }
     if (types.isIdentifier(hook.callee) && hookNames.has(hook.callee.name)) {
-      const code = generate(hook.arguments[0]).code;
       try {
-        component.meta[hook.callee.name] = JSON5.parse(code);
+        component.meta[hook.callee.name] = parseCodeJson(hook.arguments[0]);
         return false;
       } catch (e) {
-        console.error(`Error parsing metadata hook ${hook.callee.name}`, code);
+        console.error(`Error parsing metadata hook ${hook.callee.name}`);
         throw e;
       }
     }
@@ -621,7 +606,7 @@ function mapReactIdentifiers(json: MitosisComponent) {
     }
   }
 
-  traverse(json).forEach(function(item) {
+  traverse(json).forEach(function (item) {
     if (isMitosisNode(item)) {
       for (const key in item.bindings) {
         const value = item.bindings[key];
@@ -650,8 +635,10 @@ function mapReactIdentifiers(json: MitosisComponent) {
 
 const expressionToNode = (str: string) => {
   const code = `export default ${str}`;
-  return ((babel.parse(code) as babel.types.File).program
-    .body[0] as babel.types.ExportDefaultDeclaration).declaration;
+  return (
+    (babel.parse(code) as babel.types.File).program
+      .body[0] as babel.types.ExportDefaultDeclaration
+  ).declaration;
 };
 
 /**
@@ -659,7 +646,7 @@ const expressionToNode = (str: string) => {
  * MitosisComponent tree
  */
 function extractContextComponents(json: MitosisComponent) {
-  traverse(json).forEach(function(item) {
+  traverse(json).forEach(function (item) {
     if (isMitosisNode(item)) {
       if (item.name.endsWith('.Provider')) {
         const value = item.bindings.value;
@@ -687,6 +674,9 @@ function extractContextComponents(json: MitosisComponent) {
   });
 }
 
+const isImportOrDefaultExport = (node: babel.Node) =>
+  types.isExportDefaultDeclaration(node) || types.isImportDeclaration(node);
+
 export function parseJsx(
   jsx: string,
   options: Partial<ParseMitosisOptions> = {},
@@ -704,27 +694,20 @@ export function parseJsx(
     presets: [[tsPreset, { isTSX: true, allExtensions: true }]],
     plugins: [
       jsxPlugin,
-      () => ({
+      (): babel.PluginObj<Context> => ({
         visitor: {
-          JSXExpressionContainer(
-            path: babel.NodePath<babel.types.JSXExpressionContainer>,
-            context: Context,
-          ) {
+          JSXExpressionContainer(path, context) {
             if (types.isJSXEmptyExpression(path.node.expression)) {
               path.remove();
             }
           },
-          Program(path: babel.NodePath<babel.types.Program>, context: Context) {
+          Program(path, context) {
             if (context.builder) {
               return;
             }
             context.builder = {
               component: createMitosisComponent(),
             };
-
-            const isImportOrDefaultExport = (node: babel.Node) =>
-              types.isExportDefaultDeclaration(node) ||
-              types.isImportDeclaration(node);
 
             const keepStatements = path.node.body.filter((statement) =>
               isImportOrDefaultExport(statement),
@@ -754,10 +737,7 @@ export function parseJsx(
 
             path.replaceWith(types.program(keepStatements));
           },
-          FunctionDeclaration(
-            path: babel.NodePath<babel.types.FunctionDeclaration>,
-            context: Context,
-          ) {
+          FunctionDeclaration(path, context) {
             const { node } = path;
             if (types.isIdentifier(node.id)) {
               const name = node.id.name;
@@ -768,10 +748,7 @@ export function parseJsx(
               }
             }
           },
-          ImportDeclaration(
-            path: babel.NodePath<babel.types.ImportDeclaration>,
-            context: Context,
-          ) {
+          ImportDeclaration(path, context) {
             // @builder.io/mitosis or React imports compile away
             if (
               ['react', '@builder.io/mitosis', '@emotion/react'].includes(
@@ -800,12 +777,10 @@ export function parseJsx(
 
             path.remove();
           },
-          ExportDefaultDeclaration(
-            path: babel.NodePath<babel.types.ExportDefaultDeclaration>,
-          ) {
+          ExportDefaultDeclaration(path) {
             path.replaceWith(path.node.declaration);
           },
-          JSXElement(path: babel.NodePath<babel.types.JSXElement>) {
+          JSXElement(path) {
             const { node } = path;
             path.replaceWith(jsonToAst(jsxElementToJson(node)));
           },
@@ -825,14 +800,7 @@ export function parseJsx(
       .replace(/^\({/, '{')
       .replace(/}\);$/, '}'),
   );
-  let parsed: MitosisComponent;
-  try {
-    parsed = JSON5.parse(toParse);
-  } catch (err) {
-    debugger;
-    console.error('Could not parse code', toParse);
-    throw err;
-  }
+  const parsed = tryParseJson(toParse);
 
   mapReactIdentifiers(parsed);
   extractContextComponents(parsed);

--- a/packages/core/src/parsers/liquid.ts
+++ b/packages/core/src/parsers/liquid.ts
@@ -578,7 +578,7 @@ const isSerializedBlock = (str: string) => {
 };
 
 const deserializeBlock = (str: string) => {
-  const parts = [];
+  const parts: string[] = [];
   let attribute = str;
   let matches = str.match(/<builder-serialized-block block='([^']*)'/);
   while (matches?.[1]) {
@@ -2097,7 +2097,7 @@ const matchConditionalTagsWithEndings = (nodes: BuilderElement[]) => {
 
         // cursor at condition now
         let condition = tag;
-        let hoistedCondition = null;
+        let hoistedCondition: any = null;
         /* originalIndex is where the open tag was, e.g 
           {% if test %} TEXT<span> in span</span> <div class = '''>
           it'll be 2,
@@ -2660,7 +2660,7 @@ export const preprocessLiquid = async (
   const captureGroupRegex = /{%-?\s*capture\s*(.+?)-?%}([\s\S]*?){%-?\s*endcapture\s*-?%}/gi;
   let matchedCaptureGroup;
 
-  const allCaptureGroupMatches = [];
+  const allCaptureGroupMatches: any[] = [];
   while (
     (matchedCaptureGroup = captureGroupRegex.exec(processedLiquid)) !== null
   ) {

--- a/packages/core/src/targets.ts
+++ b/packages/core/src/targets.ts
@@ -1,0 +1,31 @@
+import { componentToAngular as angular } from './generators/angular';
+import { componentToBuilder as builder } from './generators/builder';
+import {
+  componentToCustomElement as customElement,
+  componentToHtml as html,
+} from './generators/html';
+import { componentToMitosis as mitosis } from './generators/mitosis';
+import { componentToLiquid as liquid } from './generators/liquid';
+import { componentToReact as react } from './generators/react';
+import { componentToReactNative as reactNative } from './generators/react-native';
+import { componentToSolid as solid } from './generators/solid';
+import { componentToSvelte as svelte } from './generators/svelte';
+import { componentToSwift as swift } from './generators/swift-ui';
+import { componentToTemplate as template } from './generators/template';
+import { componentToVue as vue } from './generators/vue';
+
+export const targets = {
+  angular,
+  builder,
+  customElement,
+  html,
+  mitosis,
+  liquid,
+  react,
+  reactNative,
+  solid,
+  svelte,
+  swift,
+  template,
+  vue,
+};

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,0 +1,36 @@
+import { MitosisComponent } from '..';
+import { Plugin } from './plugins';
+
+type Targets = typeof import('src/targets').targets;
+export type Target = keyof Targets;
+export type GeneratorOptions = {
+  [K in keyof Targets]: NonNullable<Parameters<Targets[K]>[0]>;
+};
+
+type FileInfo = {
+  path: string;
+  content: string;
+  target: string;
+};
+
+export interface TranspilerArgs {
+  path?: string;
+  component: MitosisComponent;
+}
+
+export type Transpiler = (args: TranspilerArgs) => string;
+
+export interface BaseTranspilerOptions {
+  prettier?: boolean;
+  plugins?: Plugin[];
+}
+
+export type MitosisConfig = {
+  type?: 'library'; // Only one type right now
+  targets: Target[];
+  dest?: string;
+  files?: string | string[];
+  overridesDir?: string;
+  mapFile?: (info: FileInfo) => FileInfo | Promise<FileInfo>;
+  options: Partial<GeneratorOptions>;
+};

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -1,0 +1,18 @@
+import { MitosisComponent } from './mitosis-component';
+
+export type Plugin = (
+  options?: any,
+) => {
+  json?: {
+    // Happens before any modifiers
+    pre?: (json: MitosisComponent) => MitosisComponent | void;
+    // Happens after built in modifiers
+    post?: (json: MitosisComponent) => MitosisComponent | void;
+  };
+  code?: {
+    // Happens before formatting
+    pre?: (code: string) => string;
+    // Happens after formatting
+    post?: (code: string) => string;
+  };
+};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "preserve",
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
+    "exactOptionalPropertyTypes": false,
     "esModuleInterop": true,
     "target": "ES5",
     "baseUrl": ".",


### PR DESCRIPTION
### Main changes:
- added an `options` object in `MitosisConfig` containing options for each framework (starting with Vue).
- remove our harcoded builder config relating to injecting a `registerComponent` import for our Vue SDK.
- added `path` as an (optional) argument for transpilers.
- all framework transpilers are now curried with signature `(options) => ({ component, path }) => string`. This makes it easier to add arguments to transpilers in the future, and allows us to initialize the transpilers at a higher level, before components are provided for transpilation.