### PR TITLE
fix(qwik): handle statements by wrapping them in IIF.

### DIFF
--- a/packages/core/src/__tests__/qwik.test.ts
+++ b/packages/core/src/__tests__/qwik.test.ts
@@ -2,7 +2,7 @@ import { outputFileAsync } from 'fs-extra-promise';
 import { builderContentToMitosisComponent } from '..';
 import { File } from '../generators/qwik';
 import { addComponent, createFileSet, FileSet } from '../generators/qwik/index';
-import { isExpression } from '../generators/qwik/src-generator';
+import { isStatement } from '../generators/qwik/src-generator';
 import { parseJsx } from '../parsers/jsx';
 import {
   compileAwayBuilderComponentsFromTree,
@@ -164,16 +164,17 @@ describe('qwik', () => {
   });
 
   describe('helper functions', () => {
-    describe('isExpression', () => {
+    describe('isStatement', () => {
       test('is an expression', () => {
-        expect(isExpression('a.b')).toBe(true);
-        expect(isExpression('"var x; return foo + \'\\"\';"')).toBe(true);
-        expect(isExpression('"foo" + `bar\nbaz`')).toBe(true);
+        expect(isStatement('a.b')).toBe(false);
+        expect(isStatement('1?2:"bar"')).toBe(false);
+        expect(isStatement('"var x; return foo + \'\\"\';"')).toBe(false);
+        expect(isStatement('"foo" + `bar\nbaz`')).toBe(false);
       });
 
       test('is a statement', () => {
-        expect(isExpression('var x; return x;')).toBe(false);
-        expect(isExpression('var x')).toBe(false);
+        expect(isStatement('var x; return x;')).toBe(true);
+        expect(isStatement('var x')).toBe(true);
       });
     });
   });

--- a/packages/core/src/__tests__/qwik.test.ts
+++ b/packages/core/src/__tests__/qwik.test.ts
@@ -2,6 +2,7 @@ import { outputFileAsync } from 'fs-extra-promise';
 import { builderContentToMitosisComponent } from '..';
 import { File } from '../generators/qwik';
 import { addComponent, createFileSet, FileSet } from '../generators/qwik/index';
+import { isExpression } from '../generators/qwik/src-generator';
 import { parseJsx } from '../parsers/jsx';
 import {
   compileAwayBuilderComponentsFromTree,
@@ -160,6 +161,21 @@ describe('qwik', () => {
     addComponent(fileSet, component);
     debugOutput(fileSet);
     expect(toObj(fileSet)).toMatchSnapshot();
+  });
+
+  describe('helper functions', () => {
+    describe('isExpression', () => {
+      test('is an expression', () => {
+        expect(isExpression('a.b')).toBe(true);
+        expect(isExpression('"var x; return foo + \'\\"\';"')).toBe(true);
+        expect(isExpression('"foo" + `bar\nbaz`')).toBe(true);
+      });
+
+      test('is a statement', () => {
+        expect(isExpression('var x; return x;')).toBe(false);
+        expect(isExpression('var x')).toBe(false);
+      });
+    });
   });
 });
 

--- a/packages/core/src/generators/qwik/component.ts
+++ b/packages/core/src/generators/qwik/component.ts
@@ -8,6 +8,7 @@ import { renderJSXNodes } from './jsx';
 import {
   arrowFnValue,
   File,
+  iif,
   INDENT,
   invoke,
   NL,
@@ -189,7 +190,7 @@ function addComponentOnMount(
               INDENT,
               'const state = {};',
               NL,
-              component.hooks.onMount,
+              iif(component.hooks.onMount),
               NL,
               'return state;',
               UNINDENT,

--- a/packages/core/src/generators/qwik/jsx.ts
+++ b/packages/core/src/generators/qwik/jsx.ts
@@ -6,7 +6,7 @@ import {
   invoke,
   NL,
   SrcBuilder,
-  string,
+  quote,
   UNINDENT,
 } from './src-generator';
 import { CssStyles } from './styles';
@@ -35,7 +35,7 @@ export function renderJSXNodes(
         } else {
           this.isJSX
             ? this.emit(child.properties._text)
-            : this.jsxTextBinding(string(child.properties._text!));
+            : this.jsxTextBinding(quote(child.properties._text!));
         }
       } else {
         let childName = child.name;
@@ -125,7 +125,7 @@ function rewriteHandlers(
         } else if ((handlerBlock = handlers.get(binding))) {
           key = `on:${key.substr(2).toLowerCase()}`;
           binding = invoke(file.import(file.qwikModule, 'qHook'), [
-            string(file.qrlPrefix + 'high#' + handlerBlock),
+            quote(file.qrlPrefix + 'high#' + handlerBlock),
           ]);
         }
         outBindings[key] = binding;

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -280,7 +280,11 @@ export class SrcBuilder {
         this.isJSX ? this.emit(key) : this.emit(possiblyQuotePropertyName(key));
         this.isJSX ? this.emit('={') : this.emit(':', WS);
         const bindingExpressionOrStatement = bindings[key];
-        this.emit(isExpression(bindingExpressionOrStatement) ?  bindings[key] : iif(bindingExpressionOrStatement));
+        this.emit(
+          isExpression(bindingExpressionOrStatement)
+            ? bindings[key]
+            : iif(bindingExpressionOrStatement),
+        );
         this.isJSX ? this.emit('}') : this.emit();
       }
     }
@@ -410,7 +414,7 @@ export function arrowFnValue(args: string[], expression: any) {
 
 export function iif(code: any) {
   return function(this: SrcBuilder) {
-    this.emit('(()', WS, '=>', WS, '{' , WS, NL, code, NL, '}', ')()');
+    this.emit('(()', WS, '=>', WS, '{', WS, NL, code, NL, '}', ')()');
   };
 }
 
@@ -432,20 +436,27 @@ function isWhitespace(ch: string) {
 
 /**
  * Returns `true` if the code is an expression.
- * 
+ *
  * Code is an expression if it is a list of identifiers all connected with a valid separator
  * identifier: [a-z_$](a-z0-9_$)*
  * seperator: [()[]{}.-+/*,]
- * 
- * it is not 100% but a good approximation
+ *
+ * it is not 100% but a good enough approximation
  */
-function isExpression(code: string) {
+export function isExpression(code: string) {
+  code = code.replace(STRING_LITERAL, 'STRING_LITERAL');
   const identifiers = code.split(EXPRESSION_SEPARATORS);
-  return identifiers.filter((ident) => ident && !ident.match(EXPRESSION_IDENTIFIER)).length == 0;
+  return (
+    identifiers.filter((ident) => ident && !ident.match(EXPRESSION_IDENTIFIER))
+      .length == 0
+  );
 }
 
+// https://regexr.com/6cppf
+const STRING_LITERAL = /(["'`])((\\{2})*|((\n|.)*?[^\\](\\{2})*))\1/g;
+
 // https://regexr.com/6cpk4
-const EXPRESSION_SEPARATORS = /[()\[\]{}.\-+/*,]+/;
+const EXPRESSION_SEPARATORS = /[()\[\]{}.\?:\-+/*,]+/;
 
 // https://regexr.com/6cpka
 const EXPRESSION_IDENTIFIER = /^\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*$/;


### PR DESCRIPTION
- Binding expressions are sometimes statements and need to be converted into IIF.
- `OnMount` code can declare `state` which fails execution. Wrapping it in IIF solves it.

https://builder-io.atlassian.net/browse/ENG-2020