### PR TITLE
feat(qwik): Add support for compiling away `For` directives

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -110,6 +110,79 @@ export const MyComponent = qComponent({
 }
 `;
 
+exports[`qwik For 1`] = `
+Object {
+  "high.jsx": "
+",
+  "low.jsx": "import { h, qHook } from \\"@builder.io/qwik\\";
+
+
+export const MyComponent_styles = \`
+  .cvdfnp5{
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    margin-top: 0px;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 50px;
+    padding-bottom: 50px;
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+  }
+  .cz5wnof{
+    width: 100%;
+    align-self: stretch;
+    flex-grow: 1;
+    box-sizing: border-box;
+    max-width: 1200px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .cdrk993{
+    text-align: center;
+  }
+\`;
+
+export const MyComponent_onRender = qHook((props, state) => (
+  <div class=\\"cvdfnp5\\"
+      maxWidth={1200}>
+    <section class=\\"cz5wnof\\">
+      { (state.simpleList.results || []).forEach(() => (
+        <div class=\\"cdrk993\\">
+          <div class=\\"builder-text\\"
+              innerHTML={(() => {
+    try { var _virtual_index=state.resultsItem.data.title;return _virtual_index }
+    catch (err) {
+      console.warn('Builder code error', err);
+    }
+  })()}>
+          </div>
+        </div>
+      ))
+      }
+    </section>
+  </div>
+));
+",
+  "med.jsx": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+
+
+export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent = qComponent({
+  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onRender: qHook(\\"./low#MyComponent_onRender\\"),
+  styles: \\"./low#MyComponent_styles\\"
+});
+",
+}
+`;
+
 exports[`qwik Image 1`] = `
 Object {
   "high.js": "

--- a/packages/core/src/__tests__/qwik.test.for-loop.json
+++ b/packages/core/src/__tests__/qwik.test.for-loop.json
@@ -1,0 +1,59 @@
+{
+  "data": {
+    "title": "Builtin: For",
+    "inputs": [],
+    "blocks": [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        "id": "builder-a58a66676d9b4ecc826c1b8bc5ad91f1",
+        "component": {
+          "name": "Core:Section",
+          "options": { "maxWidth": 1200 }
+        },
+        "children": [
+          {
+            "@type": "@builder.io/sdk:Element",
+            "@version": 2,
+            "bindings": {
+              "component.options.text": "var _virtual_index=state.resultsItem.data.title;return _virtual_index"
+            },
+            "code": {
+              "bindings": {
+                "component.options.text": "state.resultsItem.data.title"
+              }
+            },
+            "repeat": { "collection": "state.simpleList.results" },
+            "id": "builder-927e0013cb8142a9bd46a4f3811d0865",
+            "component": {
+              "name": "Text",
+              "options": {
+                "text": "text_content"
+              }
+            },
+            "responsiveStyles": { "large": { "textAlign": "center" } }
+          }
+        ],
+        "responsiveStyles": {
+          "large": {
+            "display": "flex",
+            "flexDirection": "column",
+            "position": "relative",
+            "flexShrink": "0",
+            "boxSizing": "border-box",
+            "marginTop": "0px",
+            "paddingLeft": "20px",
+            "paddingRight": "20px",
+            "paddingTop": "50px",
+            "paddingBottom": "50px",
+            "width": "100vw",
+            "marginLeft": "calc(50% - 50vw)"
+          }
+        }
+      }
+    ],
+    "httpRequests": {
+      "simpleList": "https://cdn.builder.io/api/v2/content/simple-list?apiKey=23dfd7cef1104af59f281d58ec525923&includeRefs=true&fields=data&limit=10"
+    }
+  }
+}

--- a/packages/core/src/__tests__/qwik.test.ts
+++ b/packages/core/src/__tests__/qwik.test.ts
@@ -163,6 +163,22 @@ describe('qwik', () => {
     expect(toObj(fileSet)).toMatchSnapshot();
   });
 
+  test('For', async () => {
+    const component = builderContentToMitosisComponent(
+      require('./qwik.test.for-loop.json'),
+      {
+        includeBuilderExtras: true,
+        preserveTextBlocks: true,
+      },
+    );
+    compileAwayBuilderComponentsFromTree(component, compileAwayComponents);
+    const fileSet = createFileSet({ output: 'mjs', jsx: true });
+
+    addComponent(fileSet, component);
+    debugOutput(fileSet);
+    expect(toObj(fileSet)).toMatchSnapshot();
+  });
+
   describe('helper functions', () => {
     describe('isStatement', () => {
       test('is an expression', () => {
@@ -170,6 +186,7 @@ describe('qwik', () => {
         expect(isStatement('1?2:"bar"')).toBe(false);
         expect(isStatement('"var x; return foo + \'\\"\';"')).toBe(false);
         expect(isStatement('"foo" + `bar\nbaz`')).toBe(false);
+        expect(isStatement('(...)()')).toBe(false);
       });
 
       test('is a statement', () => {

--- a/packages/core/src/generators/qwik/directives.ts
+++ b/packages/core/src/generators/qwik/directives.ts
@@ -8,16 +8,20 @@ export const DIRECTIVES: Record<
   Show: (node: MitosisNode, blockFn: () => void) =>
     function(this: SrcBuilder) {
       const expr = node.bindings.when;
-      if (this.isJSX) {
-        this.emit('{', WS, INDENT, expr, WS, '?', NL);
-      } else {
-        this.emit(expr, WS, '?', INDENT, NL);
-      }
+      this.isJSX && this.emit('{', WS);
+      this.emit(expr, WS, '?', INDENT, NL);
       blockFn();
-      if (this.isJSX) {
-        this.emit(':', WS, 'null', UNINDENT, NL, '}', NL);
-      } else {
-        this.emit(':', WS, 'null', UNINDENT, NL);
-      }
+      this.emit(':', WS, 'null', UNINDENT, NL);
+      this.isJSX && this.emit('}', NL);
+    },
+  For: (node: MitosisNode, blockFn: () => void) =>
+    function(this: SrcBuilder) {
+      const expr = node.bindings.each;
+      this.isJSX && this.emit('{', WS);
+      this.emit('(', expr, WS, '||', WS, '[])');
+      this.emit('.forEach(', '()', WS, '=>', WS, '(', INDENT, NL);
+      blockFn();
+      this.emit(UNINDENT, ')', ')', NL);
+      this.isJSX && this.emit('}', NL);
     },
 };

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -254,7 +254,11 @@ export class SrcBuilder {
     }
     let first = true;
     for (const key in props) {
-      if (Object.prototype.hasOwnProperty.call(props, key) && !ignoreKey(key)) {
+      if (
+        Object.prototype.hasOwnProperty.call(props, key) &&
+        !ignoreKey(key) &&
+        !Object.prototype.hasOwnProperty.call(bindings, key)
+      ) {
         if (first) {
           first = false;
           this.isJSX && this.emit(RS, INDENT, INDENT);
@@ -443,7 +447,10 @@ function isWhitespace(ch: string) {
  * it is not 100% but a good enough approximation
  */
 export function isStatement(code: string) {
-  if (typeof code !== 'string') console.log(code, String(code));
+  if (code.startsWith('(')) {
+    // Code starting with `(` is most likely and IFF and hence is an expression.
+    return false;
+  }
   code = code.replace(STRING_LITERAL, 'STRING_LITERAL');
   const identifiers = code.split(EXPRESSION_SEPARATORS);
   return (


### PR DESCRIPTION
Compile away this:
```typescript
<For each={expr}>...</For>
```

into:
```typescript
{(expr||[]).forEach(() => (...))}
```