### PR TITLE
Add on update lifecycle method

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/BuilderIO/mitosis"
   },
   "scripts": {
-    "test": "jest",
+    "test": "jest -u",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
     "release:dev": "npm run build && npm version prerelease --no-git-tag-version && ALLOW_PUBLISH=true npm publish --tag dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/BuilderIO/mitosis"
   },
   "scripts": {
-    "test": "jest -u",
+    "test": "jest",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
     "release:dev": "npm run build && npm version prerelease --no-git-tag-version && ALLOW_PUBLISH=true npm publish --tag dev",

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -989,7 +989,6 @@ Object {
   "hooks": Object {
     "onMount": Object {
       "code": "",
-      "deps": "[]",
     },
   },
   "imports": Array [],

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -241,8 +241,6 @@ Object.assign(state, {
     }
   },
 });
-
-state.findAndRunScripts();
 ",
     "tsCode": "var props = state;
 
@@ -292,7 +290,7 @@ useState({
   },
 });
 
-onMount(() => {
+onUpdate(() => {
   state.findAndRunScripts();
 });
 ",
@@ -353,7 +351,10 @@ export default function MyComponent(props) {
   const elem = useRef();
 
   onMount(() => {
-    state.findAndRunScripts();
+    var props = state;
+    onUpdate(() => {
+      state.findAndRunScripts();
+    });
   });
 
   return (
@@ -438,8 +439,6 @@ Object.assign(state, {
     }
   },
 });
-
-state.findAndRunScripts();
 ",
     "tsCode": "var props = state;
 
@@ -489,7 +488,7 @@ useState({
   },
 });
 
-onMount(() => {
+onUpdate(() => {
   state.findAndRunScripts();
 });
 ",
@@ -550,7 +549,10 @@ export default function MyComponent(props) {
   const elem = useRef();
 
   onMount(() => {
-    state.findAndRunScripts();
+    var props = state;
+    onUpdate(() => {
+      state.findAndRunScripts();
+    });
   });
 
   return <div class=\\"builder-embed\\" ref={elem} innerHTML={props.content} />;
@@ -679,29 +681,6 @@ Object.assign(state, {
     return !!props.lazy && state.isBrowser();
   },
 });
-
-if (state.useLazyLoading()) {
-  // throttled scroll capture listener
-  const listener = () => {
-    if (pictureRef) {
-      const rect = pictureRef.getBoundingClientRect();
-      const buffer = window.innerHeight / 2;
-
-      if (rect.top < window.innerHeight + buffer) {
-        state.load = true;
-        state.scrollListener = null;
-        window.removeEventListener(\\"scroll\\", listener);
-      }
-    }
-  };
-
-  state.scrollListener = listener;
-  window.addEventListener(\\"scroll\\", listener, {
-    capture: true,
-    passive: true,
-  });
-  listener();
-}
 ",
     "tsCode": "var props = state;
 
@@ -723,7 +702,7 @@ useState({
   },
 });
 
-onMount(() => {
+onUpdate(() => {
   if (state.useLazyLoading()) {
     // throttled scroll capture listener
     const listener = () => {
@@ -779,28 +758,31 @@ export default function MyComponent(props) {
   const pictureRef = useRef();
 
   onMount(() => {
-    if (state.useLazyLoading()) {
-      // throttled scroll capture listener
-      const listener = () => {
-        if (pictureRef.current) {
-          const rect = pictureRef.current.getBoundingClientRect();
-          const buffer = window.innerHeight / 2;
+    var props = state;
+    onUpdate(() => {
+      if (state.useLazyLoading()) {
+        // throttled scroll capture listener
+        const listener = () => {
+          if (pictureRef.current) {
+            const rect = pictureRef.current.getBoundingClientRect();
+            const buffer = window.innerHeight / 2;
 
-          if (rect.top < window.innerHeight + buffer) {
-            state.load = true;
-            state.scrollListener = null;
-            window.removeEventListener(\\"scroll\\", listener);
+            if (rect.top < window.innerHeight + buffer) {
+              state.load = true;
+              state.scrollListener = null;
+              window.removeEventListener(\\"scroll\\", listener);
+            }
           }
-        }
-      };
+        };
 
-      state.scrollListener = listener;
-      window.addEventListener(\\"scroll\\", listener, {
-        capture: true,
-        passive: true,
-      });
-      listener();
-    }
+        state.scrollListener = listener;
+        window.addEventListener(\\"scroll\\", listener, {
+          capture: true,
+          passive: true,
+        });
+        listener();
+      }
+    });
   });
 
   return (
@@ -1787,22 +1769,12 @@ Object {
     "jsCode": "var props = state;
 
 Object.assign(state, { reviews: [], showReviewPrompt: false });
-
-fetch(
-  \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
-    props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
-  }&productId=\${props.productId || \\"2410511106127\\"}\`
-)
-  .then((res) => res.json())
-  .then((data) => {
-    state.reviews = data.data;
-  });
 ",
     "tsCode": "var props = state;
 
 useState({ reviews: [], showReviewPrompt: false });
 
-onMount(() => {
+onUpdate(() => {
   fetch(
     \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
       props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
@@ -1825,15 +1797,18 @@ export default function MyComponent(props) {
   const state = useState({ reviews: [], showReviewPrompt: false });
 
   onMount(() => {
-    fetch(
-      \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
-        props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
-      }&productId=\${props.productId || \\"2410511106127\\"}\`
-    )
-      .then((res) => res.json())
-      .then((data) => {
-        state.reviews = data.data;
-      });
+    var props = state;
+    onUpdate(() => {
+      fetch(
+        \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
+          props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
+        }&productId=\${props.productId || \\"2410511106127\\"}\`
+      )
+        .then((res) => res.json())
+        .then((data) => {
+          state.reviews = data.data;
+        });
+    });
   });
 
   return (

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -833,7 +833,7 @@ export default function MyComponent(props) {
 `;
 
 exports[`Builder Regenerate Image 1`] = `
-"import { useState } from \\"react\\";
+"import { useState, useEffect } from \\"react\\";
 import { Image } from \\"@components\\";
 
 export default function MyComponent(props) {
@@ -986,7 +986,12 @@ Object {
     "get": Object {},
     "set": Object {},
   },
-  "hooks": Object {},
+  "hooks": Object {
+    "onMount": Object {
+      "code": "",
+      "deps": "[]",
+    },
+  },
   "imports": Array [],
   "meta": Object {
     "useMetadata": Object {
@@ -1503,6 +1508,8 @@ exports[`Builder Section 1`] = `
 
     // Update with initial state on first load
     update();
+
+    // onMount
   })();
 </script>
 "

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -375,7 +375,7 @@ Object {
 `;
 
 exports[`Context Use and set context in complex components 2`] = `
-"import { useContext } from \\"react\\";
+"import { useContext, useEffect } from \\"react\\";
 import { getBlockComponentOptions } from \\"../functions/get-block-component-options\\";
 import { getBlockProperties } from \\"../functions/get-block-properties\\";
 import { getBlockStyles } from \\"../functions/get-block-styles\\";
@@ -448,7 +448,6 @@ export default function RenderBlock(props) {
 
   const builderContext = useContext(BuilderContext);
 
-  const TagNameRef = tagName();
   const ComponentRefRef = componentRef();
 
   return (
@@ -579,7 +578,7 @@ Object {
 `;
 
 exports[`Context Use and set context in components 2`] = `
-"import { useContext } from \\"react\\";
+"import { useContext, useEffect } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
 
@@ -608,7 +607,7 @@ export default function ComponentWithContext(props) {
 exports[`Context Use and set context in components 3`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
-import { useContext } from \\"react\\";
+import { useContext, useEffect } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
 

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -102,6 +102,16 @@ exports[`Html Stamped 1`] = `
       document.querySelectorAll(\\"[data-name='div-2']\\").forEach((el) => {
         el.innerText = getContext(el, \\"review\\").reviewMessage;
       });
+
+      fetch(
+        \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
+          props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
+        }&productId=\${props.productId || \\"2410511106127\\"}\`
+      )
+        .then((res) => res.json())
+        .then((data) => {
+          state.reviews = data.data;
+        });
     }
 
     // Event handler for 'click' event on button-1
@@ -118,18 +128,6 @@ exports[`Html Stamped 1`] = `
 
     // Update with initial state on first load
     update();
-
-    // onMount
-    fetch(
-      \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
-        props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
-      }&productId=\${props.productId || \\"2410511106127\\"}\`
-    )
-      .then((res) => res.json())
-      .then((data) => {
-        state.reviews = data.data;
-        update();
-      });
 
     // Helper to render loops
     function renderLoop(el, array, template, itemName) {

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -105,8 +105,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -188,8 +187,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -284,8 +282,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -380,8 +377,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -449,8 +445,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -501,8 +496,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -578,8 +572,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;
@@ -636,8 +629,7 @@ export const MyComponent_onMount = qHook(() => {
   const state = qObject({});
   (() => { 
   {
-    code: ,
-    deps: []
+    code: 
   }
   })()
   return state;

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -97,12 +97,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   </div>
 ));
 ",
-  "med.jsx": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.jsx": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -170,12 +180,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   </div>
 ));
 ",
-  "med.jsx": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.jsx": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -256,12 +276,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   )
 ));
 ",
-  "med.js": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.js": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -342,12 +372,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   )
 ));
 ",
-  "med.js": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.js": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -401,12 +441,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   )
 ));
 ",
-  "med.js": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.js": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -443,12 +493,22 @@ export const MyComponent_onRender = qHook((props, state) => (
 </div>
 ));
 ",
-  "med.jsx": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.jsx": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -510,12 +570,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   )
 ));
 ",
-  "med.js": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.js": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });
@@ -558,12 +628,22 @@ export const MyComponent_onRender = qHook((props, state) => (
   )
 ));
 ",
-  "med.js": "import { qComponent, qHook } from \\"@builder.io/qwik\\";
+  "med.js": "import { qComponent, qHook, qObject } from \\"@builder.io/qwik\\";
 
 
 export const onMountCreateEmptyState = qHook(() => ({}));
+export const MyComponent_onMount = qHook(() => {
+  const state = qObject({});
+  (() => { 
+  {
+    code: ,
+    deps: []
+  }
+  })()
+  return state;
+});
 export const MyComponent = qComponent({
-  onMount: qHook(\\"./med#onMountCreateEmptyState\\"),
+  onMount: qHook(\\"./med#MyComponent_onMount\\"),
   onRender: qHook(\\"./low#MyComponent_onRender\\"),
   styles: \\"./low#MyComponent_styles\\"
 });

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -151,7 +151,7 @@ export default function CustomCode(props) {
 
   useEffect(() => {
     findAndRunScripts();
-  }, []);
+  }, undefined);
 
   return (
     <View
@@ -222,7 +222,7 @@ export default function CustomCode(props) {
 
   useEffect(() => {
     findAndRunScripts();
-  }, []);
+  }, undefined);
 
   return (
     <View
@@ -550,7 +550,7 @@ export default function Image(props) {
       });
       listener();
     }
-  }, []);
+  }, undefined);
 
   return (
     <>
@@ -731,7 +731,7 @@ export default function SmileReviews(props) {
       .then((data) => {
         setReviews(data.data);
       });
-  }, []);
+  }, undefined);
 
   return (
     <View>

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`React Basic 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
-import { useState } from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"Steve\\");
@@ -21,6 +21,7 @@ export default function MyBasicComponent(props) {
 exports[`React Button 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function Button(props) {
   return (
@@ -53,6 +54,7 @@ export default function Button(props) {
 exports[`React Columns 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function Column(props) {
   function getColumns() {
@@ -238,7 +240,7 @@ export default function CustomCode(props) {
 exports[`React Form block 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
-import { useState, useRef } from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 import { BuilderBlockComponent as BuilderBlock } from \\"@fake\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
 import { BuilderBlocks } from \\"@fake\\";
@@ -592,6 +594,7 @@ const styles = StyleSheet.create({
 exports[`React Img 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 export default function ImgComponent(props) {
@@ -614,6 +617,7 @@ export default function ImgComponent(props) {
 exports[`React Input block 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 export default function FormInputComponent(props) {
@@ -640,6 +644,7 @@ export default function FormInputComponent(props) {
 exports[`React RawText 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function RawText(props) {
   return (
@@ -655,6 +660,7 @@ export default function RawText(props) {
 exports[`React Section 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function SectionComponent(props) {
   return (
@@ -678,6 +684,7 @@ export default function SectionComponent(props) {
 exports[`React Select block 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 export default function SelectComponent(props) {
@@ -787,6 +794,7 @@ const styles = StyleSheet.create({
 exports[`React Submit button block 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function SubmitButton(props) {
   return (
@@ -801,6 +809,7 @@ export default function SubmitButton(props) {
 exports[`React Text 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 export default function Text(props) {
@@ -817,6 +826,7 @@ export default function Text(props) {
 exports[`React Textarea 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function Textarea(props) {
   return (
@@ -835,6 +845,7 @@ export default function Textarea(props) {
 exports[`React Video 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
+import { useEffect } from \\"react\\";
 
 export default function Video(props) {
   return (

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`React Basic 1`] = `
-"import { useState } from \\"react\\";
+"import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"Steve\\");
@@ -17,7 +17,9 @@ export default function MyBasicComponent(props) {
 `;
 
 exports[`React Button 1`] = `
-"export default function Button(props) {
+"import { useEffect } from \\"react\\";
+
+export default function Button(props) {
   return (
     <>
       {props.link ? (
@@ -46,7 +48,9 @@ exports[`React Button 1`] = `
 `;
 
 exports[`React Columns 1`] = `
-"export default function Column(props) {
+"import { useEffect } from \\"react\\";
+
+export default function Column(props) {
   function getColumns() {
     return props.columns || [];
   }
@@ -230,7 +234,7 @@ export default function CustomCode(props) {
 `;
 
 exports[`React Form block 1`] = `
-"import { useState, useRef } from \\"react\\";
+"import { useState, useRef, useEffect } from \\"react\\";
 import { BuilderBlockComponent as BuilderBlock } from \\"@fake\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
 import { BuilderBlocks } from \\"@fake\\";
@@ -591,7 +595,8 @@ export default function Image(props) {
 `;
 
 exports[`React Img 1`] = `
-"import { Builder } from \\"@builder.io/sdk\\";
+"import { useEffect } from \\"react\\";
+import { Builder } from \\"@builder.io/sdk\\";
 
 export default function ImgComponent(props) {
   return (
@@ -611,7 +616,8 @@ export default function ImgComponent(props) {
 `;
 
 exports[`React Input block 1`] = `
-"import { Builder } from \\"@builder.io/sdk\\";
+"import { useEffect } from \\"react\\";
+import { Builder } from \\"@builder.io/sdk\\";
 
 export default function FormInputComponent(props) {
   return (
@@ -635,7 +641,9 @@ export default function FormInputComponent(props) {
 `;
 
 exports[`React RawText 1`] = `
-"export default function RawText(props) {
+"import { useEffect } from \\"react\\";
+
+export default function RawText(props) {
   return (
     <span
       className={props.attributes?.class || props.attributes?.className}
@@ -647,7 +655,9 @@ exports[`React RawText 1`] = `
 `;
 
 exports[`React Section 1`] = `
-"export default function SectionComponent(props) {
+"import { useEffect } from \\"react\\";
+
+export default function SectionComponent(props) {
   return (
     <section
       {...props.attributes}
@@ -667,7 +677,8 @@ exports[`React Section 1`] = `
 `;
 
 exports[`React Select block 1`] = `
-"import { Builder } from \\"@builder.io/sdk\\";
+"import { useEffect } from \\"react\\";
+import { Builder } from \\"@builder.io/sdk\\";
 
 export default function SelectComponent(props) {
   return (
@@ -778,7 +789,9 @@ const Img = styled.img\`
 `;
 
 exports[`React Submit button block 1`] = `
-"export default function SubmitButton(props) {
+"import { useEffect } from \\"react\\";
+
+export default function SubmitButton(props) {
   return (
     <button {...props.attributes} type=\\"submit\\">
       {props.text}
@@ -789,7 +802,8 @@ exports[`React Submit button block 1`] = `
 `;
 
 exports[`React Text 1`] = `
-"import { Builder } from \\"@builder.io/sdk\\";
+"import { useEffect } from \\"react\\";
+import { Builder } from \\"@builder.io/sdk\\";
 
 export default function Text(props) {
   return (
@@ -803,7 +817,9 @@ export default function Text(props) {
 `;
 
 exports[`React Textarea 1`] = `
-"export default function Textarea(props) {
+"import { useEffect } from \\"react\\";
+
+export default function Textarea(props) {
   return (
     <textarea
       {...props.attributes}
@@ -818,7 +834,9 @@ exports[`React Textarea 1`] = `
 `;
 
 exports[`React Video 1`] = `
-"export default function Video(props) {
+"import { useEffect } from \\"react\\";
+
+export default function Video(props) {
   return (
     <video
       {...props.attributes}

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -149,7 +149,7 @@ export default function CustomCode(props) {
 
   useEffect(() => {
     findAndRunScripts();
-  }, []);
+  }, undefined);
 
   return (
     <div
@@ -218,7 +218,7 @@ export default function CustomCode(props) {
 
   useEffect(() => {
     findAndRunScripts();
-  }, []);
+  }, undefined);
 
   return (
     <div
@@ -552,7 +552,7 @@ export default function Image(props) {
       });
       listener();
     }
-  }, []);
+  }, undefined);
 
   return (
     <>
@@ -721,7 +721,7 @@ export default function SmileReviews(props) {
       .then((data) => {
         setReviews(data.data);
       });
-  }, []);
+  }, undefined);
 
   return (
     <div>

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -151,10 +151,6 @@ export default function CustomCode(props) {
 
   const elem = useRef();
 
-  onMount(() => {
-    state.findAndRunScripts();
-  });
-
   return (
     <div
       class={
@@ -219,10 +215,6 @@ export default function CustomCode(props) {
   });
 
   const elem = useRef();
-
-  onMount(() => {
-    state.findAndRunScripts();
-  });
 
   return (
     <div
@@ -546,7 +538,7 @@ export default function FormComponent(props) {
 `;
 
 exports[`Solid Image 1`] = `
-"import { Show, onMount } from \\"solid-js\\";
+"import { Show } from \\"solid-js\\";
 
 import { createMutable } from \\"solid-js/store\\";
 import { css } from \\"solid-styled-components\\";
@@ -572,31 +564,6 @@ export default function Image(props) {
   });
 
   const pictureRef = useRef();
-
-  onMount(() => {
-    if (state.useLazyLoading()) {
-      // throttled scroll capture listener
-      const listener = () => {
-        if (pictureRef) {
-          const rect = pictureRef.getBoundingClientRect();
-          const buffer = window.innerHeight / 2;
-
-          if (rect.top < window.innerHeight + buffer) {
-            state.load = true;
-            state.scrollListener = null;
-            window.removeEventListener(\\"scroll\\", listener);
-          }
-        }
-      };
-
-      state.scrollListener = listener;
-      window.addEventListener(\\"scroll\\", listener, {
-        capture: true,
-        passive: true,
-      });
-      listener();
-    }
-  });
 
   return (
     <>

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -121,7 +121,8 @@ export default {
 
   data: () => ({ scriptsInserted: [], scriptsRun: [] }),
 
-  mounted() {
+  mounted() {},
+  updated() {
     this.findAndRunScripts();
   },
 
@@ -204,7 +205,8 @@ export default {
 
   data: () => ({ scriptsInserted: [], scriptsRun: [] }),
 
-  mounted() {
+  mounted() {},
+  updated() {
     this.findAndRunScripts();
   },
 
@@ -619,7 +621,8 @@ export default {
 
   data: () => ({ scrollListener: null, imageLoaded: false, load: false }),
 
-  mounted() {
+  mounted() {},
+  updated() {
     if (this.useLazyLoading()) {
       // throttled scroll capture listener
       const listener = () => {
@@ -875,7 +878,8 @@ export default {
 
   data: () => ({ reviews: [], showReviewPrompt: false }),
 
-  mounted() {
+  mounted() {},
+  updated() {
     fetch(
       \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
         this.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -12,6 +12,8 @@ export default {
   name: \\"my-basic-component\\",
 
   data: () => ({ name: \\"Steve\\" }),
+
+  mounted() {},
 };
 </script>
 "
@@ -37,6 +39,8 @@ export default {
   name: \\"button\\",
 
   props: [\\"link\\", \\"attributes\\", \\"openLinkInNewTab\\", \\"text\\"],
+
+  mounted() {},
 };
 </script>
 "
@@ -59,6 +63,8 @@ export default {
   name: \\"column\\",
 
   props: [\\"columns\\", \\"space\\"],
+
+  mounted() {},
 
   methods: {
     getColumns() {
@@ -345,6 +351,8 @@ export default {
     formErrorMessage: \\"\\",
     BuilderBlock,
   }),
+
+  mounted() {},
 
   computed: {
     submissionState() {
@@ -703,6 +711,8 @@ export default {
   ],
 
   data: () => ({ Builder }),
+
+  mounted() {},
 };
 </script>
 "
@@ -738,6 +748,8 @@ export default {
   ],
 
   data: () => ({ Builder }),
+
+  mounted() {},
 };
 </script>
 "
@@ -757,6 +769,8 @@ export default {
   name: \\"raw-text\\",
 
   props: [\\"attributes\\", \\"text\\"],
+
+  mounted() {},
 
   methods: {
     _classStringToObject(str) {
@@ -796,6 +810,8 @@ export default {
   name: \\"section-component\\",
 
   props: [\\"attributes\\", \\"maxWidth\\"],
+
+  mounted() {},
 };
 </script>
 "
@@ -828,6 +844,8 @@ export default {
   props: [\\"attributes\\", \\"value\\", \\"defaultValue\\", \\"name\\", \\"options\\"],
 
   data: () => ({ Builder }),
+
+  mounted() {},
 };
 </script>
 "
@@ -908,6 +926,8 @@ export default {
   name: \\"submit-button\\",
 
   props: [\\"attributes\\", \\"text\\"],
+
+  mounted() {},
 };
 </script>
 "
@@ -927,6 +947,8 @@ export default {
   name: \\"text\\",
 
   props: [\\"text\\", \\"content\\"],
+
+  mounted() {},
 };
 </script>
 "
@@ -947,6 +969,8 @@ export default {
   name: \\"textarea\\",
 
   props: [\\"attributes\\", \\"placeholder\\", \\"name\\", \\"value\\", \\"defaultValue\\"],
+
+  mounted() {},
 };
 </script>
 "
@@ -990,6 +1014,8 @@ export default {
     \\"controls\\",
     \\"loop\\",
   ],
+
+  mounted() {},
 };
 </script>
 "

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -206,7 +206,17 @@ export const componentToAngular = (
         !component.hooks.onMount
           ? ''
           : `ngOnInit() {
-              ${stripStateAndPropsRefs(component.hooks.onMount, {
+              ${stripStateAndPropsRefs(component.hooks.onMount.code, {
+                replaceWith: 'this.',
+              })}
+            }`
+      }
+
+      ${
+        !component.hooks.onUpdate
+          ? ''
+          : `ngAfterContentChecked() {
+              ${stripStateAndPropsRefs(component.hooks.onUpdate.code, {
                 replaceWith: 'this.',
               })}
             }`
@@ -216,7 +226,7 @@ export const componentToAngular = (
         !component.hooks.onUnMount
           ? ''
           : `ngOnDestroy() {
-              ${stripStateAndPropsRefs(component.hooks.onUnMount, {
+              ${stripStateAndPropsRefs(component.hooks.onUnMount.code, {
                 replaceWith: 'this.',
               })}
             }`

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -342,7 +342,7 @@ export const componentToBuilder = (options: ToBuilderOptions = {}) => ({
           !component.hooks.onMount
             ? ''
             : `onMount(() => {
-                ${component.hooks.onMount}
+                ${component.hooks.onMount.code}
               })`
         }
 

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -327,7 +327,7 @@ export const componentToBuilder = (options: ToBuilderOptions = {}) => ({
               )});`
         }
 
-        ${!component.hooks.onMount ? '' : component.hooks.onMount}
+        ${!component.hooks.onMount ? '' : component.hooks.onMount.code}
       `),
       tsCode: tryFormat(dedent`
         ${!hasProps(component) ? '' : `var props = state;`}
@@ -343,6 +343,14 @@ export const componentToBuilder = (options: ToBuilderOptions = {}) => ({
             ? ''
             : `onMount(() => {
                 ${component.hooks.onMount}
+              })`
+        }
+
+        ${
+          !component.hooks.onUpdate
+            ? ''
+            : `onUpdate(() => {
+                ${component.hooks.onUpdate.code}
               })`
         }
       `),

--- a/packages/core/src/generators/html.ts
+++ b/packages/core/src/generators/html.ts
@@ -450,6 +450,15 @@ export const componentToHtml = (options: ToHtmlOptions = {}): Transpiler => ({
             `;
             })
             .join('\n\n')}
+
+            ${
+              !json.hooks.onUpdate
+                ? ''
+                :
+                  `
+                  ${updateReferencesInCode(json.hooks.onUpdate.code, useOptions)} 
+                  `
+            }
         }
 
         ${useOptions.js}
@@ -466,7 +475,7 @@ export const componentToHtml = (options: ToHtmlOptions = {}): Transpiler => ({
               `
               // onMount
               ${updateReferencesInCode(
-                addUpdateAfterSetInCode(json.hooks.onMount, useOptions),
+                addUpdateAfterSetInCode(json.hooks.onMount.code, useOptions),
                 useOptions,
               )} 
               `
@@ -653,7 +662,7 @@ export const componentToCustomElement = (
           disconnectedCallback() {
             // onUnMount
             ${updateReferencesInCode(
-              addUpdateAfterSetInCode(json.hooks.onUnMount, useOptions),
+              addUpdateAfterSetInCode(json.hooks.onUnMount.code, useOptions),
               useOptions,
             )}
           }
@@ -672,7 +681,7 @@ export const componentToCustomElement = (
                 `
                 // onMount
                 ${updateReferencesInCode(
-                  addUpdateAfterSetInCode(json.hooks.onMount, useOptions),
+                  addUpdateAfterSetInCode(json.hooks.onMount.code, useOptions),
                   useOptions,
                 )}
                 `
@@ -693,6 +702,15 @@ export const componentToCustomElement = (
             `;
             })
             .join('\n\n')}
+
+            ${
+              !json.hooks.onUpdate
+                ? ''
+                :
+                  `
+                  ${updateReferencesInCode(json.hooks.onUpdate.code, useOptions)} 
+                  `
+            } 
         }
 
         ${

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -202,7 +202,7 @@ export const componentToMitosis = (
       }
       ${getRefsString(json)}
 
-      ${!json.hooks.onMount ? '' : `onMount(() => { ${json.hooks.onMount} })`}
+      ${!json.hooks.onMount?.code ? '' : `onMount(() => { ${json.hooks.onMount.code} })`}
 
       ${
         !json.hooks.onUnMount

--- a/packages/core/src/generators/react-native.ts
+++ b/packages/core/src/generators/react-native.ts
@@ -84,9 +84,10 @@ export const componentToReactNative = (
     }
   });
 
-  return componentToReact({
+  const res = componentToReact({
     ...options,
     stylesType: options.stylesType || 'react-native',
     type: 'native',
   })({ component: json, path });
+  return res
 };

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -369,7 +369,7 @@ const getInitCode = (
   json: MitosisComponent,
   options: ToReactOptions,
 ): string => {
-  return processBinding(json.hooks.init || '', options);
+  return processBinding(json.hooks.init?.code || '', options);
 };
 
 type ReactExports =
@@ -484,7 +484,7 @@ const _componentToReact = (
   if (refs.size) {
     reactLibImports.add('useRef');
   }
-  if (json.hooks.onMount || json.hooks.onUnMount) {
+  if (json.hooks.onMount || json.hooks.onUnMount || json.hooks.onUpdate) {
     reactLibImports.add('useEffect');
   }
 
@@ -565,7 +565,7 @@ const _componentToReact = (
         json.hooks.onMount
           ? `useEffect(() => {
             ${processBinding(
-              updateStateSettersInCode(json.hooks.onMount, options),
+              updateStateSettersInCode(json.hooks.onMount.code, options),
               options,
             )}
           }, [])`
@@ -573,10 +573,21 @@ const _componentToReact = (
       }
 
       ${
+        json.hooks.onUpdate?.code
+          ? `useEffect(() => {
+            ${processBinding(
+              updateStateSettersInCode(json.hooks.onUpdate.code, options),
+              options,
+            )}
+          }, ${json.hooks.onUpdate.deps})`
+          : ''
+      }
+
+      ${
         json.hooks.onUnMount
           ? `useEffect(() => {
             ${processBinding(
-              updateStateSettersInCode(json.hooks.onUnMount, options),
+              updateStateSettersInCode(json.hooks.onUnMount.code, options),
               options,
             )}
           }, [])`

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -562,7 +562,7 @@ const _componentToReact = (
       ${getInitCode(json, options)}
 
       ${
-        json.hooks.onMount
+        json.hooks.onMount?.code
           ? `useEffect(() => {
             ${processBinding(
               updateStateSettersInCode(json.hooks.onMount.code, options),
@@ -584,7 +584,7 @@ const _componentToReact = (
       }
 
       ${
-        json.hooks.onUnMount
+        json.hooks.onUnMount?.code
           ? `useEffect(() => {
             ${processBinding(
               updateStateSettersInCode(json.hooks.onUnMount.code, options),

--- a/packages/core/src/generators/solid.ts
+++ b/packages/core/src/generators/solid.ts
@@ -225,7 +225,7 @@ export const componentToSolid = (options: ToSolidOptions = {}): Transpiler => ({
       
       ${getRefsString(json)}
 
-      ${!json.hooks.onMount ? '' : `onMount(() => { ${json.hooks.onMount} })`}
+      ${!json.hooks.onMount ? '' : `onMount(() => { ${json.hooks.onMount.code} })`}
 
       return (${addWrapper ? '<>' : ''}
         ${json.children.map((item) => blockToSolid(item, options)).join('\n')}

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -214,6 +214,7 @@ export const componentToSvelte = (
   let str = dedent`
     <script>
       ${!json.hooks.onMount ? '' : `import { onMount } from 'svelte'`}
+      ${!json.hooks.onUpdate? '' : `import { afterUpdate } from 'svelte'`}
       ${!json.hooks.onUnMount ? '' : `import { onDestroy } from 'svelte'`}
       ${renderPreComponent(json)}
 
@@ -241,7 +242,15 @@ export const componentToSvelte = (
       ${
         !json.hooks.onMount
           ? ''
-          : `onMount(() => { ${stripStateAndPropsRefs(json.hooks.onMount, {
+          : `onMount(() => { ${stripStateAndPropsRefs(json.hooks.onMount.code, {
+              includeState: useOptions.stateType === 'variables',
+            })} });`
+      }
+
+      ${
+        !json.hooks.onMount
+          ? ''
+          : `onMount(() => { ${stripStateAndPropsRefs(json.hooks.onMount.code, {
               includeState: useOptions.stateType === 'variables',
             })} });`
       }
@@ -249,7 +258,7 @@ export const componentToSvelte = (
       ${
         !json.hooks.onUnMount
           ? ''
-          : `onDestroy(() => { ${stripStateAndPropsRefs(json.hooks.onUnMount, {
+          : `onDestroy(() => { ${stripStateAndPropsRefs(json.hooks.onUnMount.code, {
               includeState: useOptions.stateType === 'variables',
             })} });`
       }

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -464,14 +464,21 @@ export const componentToVue = (options: ToVueOptions = {}) =>
         ${
           component.hooks.onMount
             ? `mounted() {
-                ${processBinding(component.hooks.onMount, options, component)}
+                ${processBinding(component.hooks.onMount.code, options, component)}
+              },`
+            : ''
+        }
+        ${
+          component.hooks.onUpdate
+            ? `updated() {
+                ${processBinding(component.hooks.onUpdate.code, options, component)}
               },`
             : ''
         }
         ${
           component.hooks.onUnMount
             ? `unmounted() {
-                ${processBinding(component.hooks.onUnMount, options, component)}
+                ${processBinding(component.hooks.onUnMount.code, options, component)}
               },`
             : ''
         }

--- a/packages/core/src/helpers/map-refs.ts
+++ b/packages/core/src/helpers/map-refs.ts
@@ -75,9 +75,9 @@ export const mapRefs = (
   for (const key of Object.keys(
     component.hooks,
   ) as (keyof typeof component.hooks)[]) {
-    const hookCode = component.hooks[key];
+    const hookCode = component.hooks[key]?.code;
     if (hookCode) {
-      component.hooks[key] = replaceRefsInString(hookCode, refs, mapper);
+      component.hooks[key]!.code = replaceRefsInString(hookCode, refs, mapper);
     }
   }
 };

--- a/packages/core/src/helpers/process-http-requests.ts
+++ b/packages/core/src/helpers/process-http-requests.ts
@@ -4,7 +4,7 @@ export function processHttpRequests(json: MitosisComponent) {
   const httpRequests: Record<string, string> | undefined = (json.meta
     .useMetadata as any)?.httpRequests;
 
-  let onMount = json.hooks.onMount || '';
+  let onMount = json.hooks.onMount || {code: ''};
 
   if (httpRequests) {
     for (const key in httpRequests) {
@@ -16,7 +16,7 @@ export function processHttpRequests(json: MitosisComponent) {
 
       // TODO: unravel our proxy. aka parse out methods, header, etc
       // and remove our proxy from being used anymore
-      onMount += `
+      onMount.code += `
         fetch("${value}").then(res => res.json()).then(result => {
           state.${key} = result;
         })

--- a/packages/core/src/helpers/process-tag-references.ts
+++ b/packages/core/src/helpers/process-tag-references.ts
@@ -16,10 +16,10 @@ export function processTagReferences(json: MitosisComponent) {
         if (!namesFound.has(el.name)) {
           namesFound.add(el.name);
           if (typeof json.hooks.init !== 'string') {
-            json.hooks.init = '';
+            json.hooks.init = {code : ''};
           }
 
-          json.hooks.init += `
+          json.hooks.init.code += `
             const ${getRefName(el.name)} = ${el.name};
           `;
         }

--- a/packages/core/src/parsers/builder.ts
+++ b/packages/core/src/parsers/builder.ts
@@ -877,8 +877,8 @@ const builderContentPartToMitosisComponent = (
       ...builderContent.data?.state,
     },
     hooks: {
-      ...((parsed?.hooks.onMount || customCode) && {
-        onMount: parsed?.hooks.onMount || customCode,
+      ...((parsed?.hooks.onMount || {code: customCode}) && {
+        onMount: parsed?.hooks.onMount || {code: customCode, deps: '[]'},
       }),
     },
     children: (builderContent.data?.blocks || [])

--- a/packages/core/src/parsers/builder.ts
+++ b/packages/core/src/parsers/builder.ts
@@ -878,7 +878,7 @@ const builderContentPartToMitosisComponent = (
     },
     hooks: {
       ...((parsed?.hooks.onMount || {code: customCode}) && {
-        onMount: parsed?.hooks.onMount || {code: customCode, deps: '[]'},
+        onMount: parsed?.hooks.onMount || {code: customCode},
       }),
     },
     children: (builderContent.data?.blocks || [])

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -219,8 +219,7 @@ const componentFunctionToJson = (
               }
 
               hooks.onMount = {
-                code,
-                deps: '[]',
+                code
               };
             }
           }

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -209,11 +209,13 @@ const componentFunctionToJson = (
                 .replace(/^{/, '')
                 .replace(/}$/, '');
                   
-              if (types.isArrayExpression(secondArg) && secondArg.elements.length > 0){
-                const depsCode =  generate(secondArg).code
-                hooks.onUpdate = {
+              if (!secondArg || (types.isArrayExpression(secondArg) && secondArg.elements.length > 0)){
+                const depsCode = secondArg ? generate(secondArg).code : null;                hooks.onUpdate = {
                   code,
-                  deps: depsCode
+                }
+
+                if (depsCode){
+                  hooks.onUpdate.deps = depsCode;
                 }
                 continue;
               }

--- a/packages/core/src/types/mitosis-component.ts
+++ b/packages/core/src/types/mitosis-component.ts
@@ -31,6 +31,8 @@ export interface MitosisImport {
 
 type ContextInfo = { name: string; path: string };
 
+type extendedHook = { code: string, deps?: string };
+
 export type MitosisComponent = {
   '@type': '@builder.io/mitosis/component';
   name: string;
@@ -44,11 +46,12 @@ export type MitosisComponent = {
     set: { [key: string]: { name: string; value?: JSONObject } }; // TODO: support non object values
   };
   hooks: {
-    init?: string;
-    onMount?: string;
-    onUnMount?: string;
-    preComponent?: string;
-    postComponent?: string;
+    init?: extendedHook;
+    onMount?: extendedHook;
+    onUnMount?: extendedHook;
+    preComponent?: extendedHook;
+    postComponent?: extendedHook;
+    onUpdate?: extendedHook ;
   };
   children: MitosisNode[];
   subComponents: MitosisComponent[];


### PR DESCRIPTION
This PR brings the `onUpdate` lifecycle hook to Mitosis components; for example, it will be replaced with a `useEffect` hook with its dependencies array if the compilation target is Reactjs, it will also be replaced with the `updated` hook for vue and so on.

### How does it work?
It works by simply adding a `useEffect` hook with its dependencies in the dependencies array **(must)** _or_ by omitting the dependencies array.

```jsx
import {  useEffect } from "@builder.io/mitosis";

export default function MyComponent(props) {

  // with deps. array
  useEffect(() => {
    console.log("on mount");
  }, [dep1, dep2,...etc]);
 
  // without deps. array
  useEffect(() => {
    console.log("on update");
  });

  return (
    <div>
     ...
    </div>
  );
}

```

