### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/cli/src/build/helpers/compile-vue-v2-file.ts
+++ b/packages/cli/src/build/helpers/compile-vue-v2-file.ts
@@ -192,7 +192,7 @@ function parseTemplate(code) {
 
     nodes[name].push({
       node: fragment.childNodes[i],
-      code: code.substr(start, end - start),
+      code: code.slice(start, end),
       attrs: getNodeAttrs(fragment.childNodes[i]),
     });
   }

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -23,7 +23,7 @@ export class File {
   exports: Map<string, string> = new Map();
 
   get module() {
-    return this.filename.substr(0, this.filename.lastIndexOf('.'));
+    return this.filename.substring(0, this.filename.lastIndexOf('.'));
   }
   get path() {
     return this.filename;
@@ -77,7 +77,7 @@ export class File {
 
 function removeExt(filename: string): string {
   const indx = filename.lastIndexOf('.');
-  return indx == -1 ? filename : filename.substr(0, indx);
+  return indx == -1 ? filename : filename.slice(0, indx);
 }
 
 const spaces: string[] = [''];

--- a/packages/core/src/parsers/liquid.ts
+++ b/packages/core/src/parsers/liquid.ts
@@ -118,7 +118,7 @@ const getConditionalAttr = (value: string, noEnd = false): string => {
         const index = statement.indexOf('&&');
         const branchValue =
           index > -1
-            ? getConditionalAttr(statement.substr(index + 2), true)
+            ? getConditionalAttr(statement.slice(index + 2), true)
             : getValue(statement);
 
         if (expression) {


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

