### PR TITLE
Feature/on update vue

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -905,12 +905,16 @@ export default function OnUpdate(props) {
 exports[`React onUpdateWithDeps 1`] = `
 "import * as React from \\"react\\";
 import { View, StyleSheet, Image, Text } from \\"react-native\\";
-import { useEffect } from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function OnUpdateWithDeps(props) {
+  const [a, setA] = useState(() => \\"a\\");
+
+  const [b, setB] = useState(() => \\"b\\");
+
   useEffect(() => {
-    console.log(\\"Runs when a or b changes\\");
-  }, [a, b]);
+    console.log(\\"Runs when a or b changes\\", a, b);
+  }, [state.a, state.b]);
 
   return <View />;
 }

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -923,12 +923,16 @@ export default function OnUpdate(props) {
 `;
 
 exports[`React onUpdateWithDeps 1`] = `
-"import { useEffect } from \\"react\\";
+"import { useState, useEffect } from \\"react\\";
 
 export default function OnUpdateWithDeps(props) {
+  const [a, setA] = useState(() => \\"a\\");
+
+  const [b, setB] = useState(() => \\"b\\");
+
   useEffect(() => {
-    console.log(\\"Runs when a or b changes\\");
-  }, [a, b]);
+    console.log(\\"Runs when a or b changes\\", a, b);
+  }, [state.a, state.b]);
 
   return <div />;
 }

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1084,37 +1084,21 @@ exports[`Vue onUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
+export default {
+  name: \\"on-update-with-deps\\",
 
+  watch: {
+    onUpdateHook() {
+      console.log(\\"Runs when a or b changes\\");
+    },
+  },
 
-
-
-
-
-    export default {
-      name: 'on-update-with-deps',
-
-
-
-
-
-
-
-
-
-            watch() {
-              onUpdateHook() {
-                console.log('Runs when a or b changes')
-              }
-            },
-
-
-
-        computed: {  onUpdateHook() {
-return \`\${this.a}|\${this.b}\`;
-},},
-
-
-    }
+  computed: {
+    onUpdateHook() {
+      return \`\${this.a}|\${this.b}\`;
+    },
+  },
+};
 </script>
 "
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1084,13 +1084,37 @@ exports[`Vue onUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
-export default {
-  name: \\"on-update-with-deps\\",
 
-  updated() {
-    console.log(\\"Runs when a or b changes\\");
-  },
-};
+
+
+
+
+
+    export default {
+      name: 'on-update-with-deps',
+
+
+
+
+
+
+
+
+
+            watch() {
+              onUpdateHook() {
+                console.log('Runs when a or b changes')
+              }
+            },
+
+
+
+        computed: {  onUpdateHook() {
+return \`\${this.a}|\${this.b}\`;
+},},
+
+
+    }
 </script>
 "
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1087,9 +1087,11 @@ exports[`Vue onUpdateWithDeps 1`] = `
 export default {
   name: \\"on-update-with-deps\\",
 
+  data: () => ({ a: \\"a\\", b: \\"b\\" }),
+
   watch: {
     onUpdateHook() {
-      console.log(\\"Runs when a or b changes\\");
+      console.log(\\"Runs when a or b changes\\", this.a, this.b);
     },
   },
 

--- a/packages/core/src/__tests__/data/blocks/onUpdateWithDeps.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/onUpdateWithDeps.raw.tsx
@@ -1,11 +1,14 @@
-import { onUpdate } from '@builder.io/mitosis';
+import { onUpdate, useState } from '@builder.io/mitosis';
 
 export default function OnUpdateWithDeps() {
-  let a, b;
+  const state = useState({
+    a: 'a',
+    b: 'b',
+  });
 
   onUpdate(() => {
-    console.log('Runs when a or b changes');
-  }, [a, b]);
+    console.log('Runs when a or b changes', state.a, state.b);
+  }, [state.a, state.b]);
 
   return <div />;
 }

--- a/packages/core/src/__tests__/vue.test.ts
+++ b/packages/core/src/__tests__/vue.test.ts
@@ -24,7 +24,7 @@ const onMount = require('./data/blocks/onMount.raw');
 const path = 'test-path';
 
 describe('Vue', () => {
-  test.only('Basic', () => {
+  test('Basic', () => {
     const component = parseJsx(basic);
     const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
@@ -132,7 +132,7 @@ describe('Vue', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test.only('onUpdateWithDeps', () => {
+  test('onUpdateWithDeps', () => {
     const component = parseJsx(onUpdateWithDeps);
     const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();

--- a/packages/core/src/__tests__/vue.test.ts
+++ b/packages/core/src/__tests__/vue.test.ts
@@ -24,7 +24,7 @@ const onMount = require('./data/blocks/onMount.raw');
 const path = 'test-path';
 
 describe('Vue', () => {
-  test('Basic', () => {
+  test.only('Basic', () => {
     const component = parseJsx(basic);
     const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();
@@ -132,7 +132,7 @@ describe('Vue', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test('onUpdateWithDeps', () => {
+  test.only('onUpdateWithDeps', () => {
     const component = parseJsx(onUpdateWithDeps);
     const output = componentToVue()({ component, path });
     expect(output).toMatchSnapshot();

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -316,9 +316,8 @@ function getContextProvideString(
 const onUpdatePlugin: Plugin = (options) => ({
   json: {
     post: (component) => {
-      // ATTENTION: we need to run this _before_ the `getStateObjectStringFromComponent` that handles getters.
       if (component.hooks.onUpdate?.deps) {
-        // once we allow multiple `onUpdate` per file, we will need to iterate over them and suffix with `_${index}`.
+        // TO-DO: once we allow multiple `onUpdate` hooks per file, we will need to iterate over them and suffix with `_${index}`.
         component.state[
           ON_UPDATE_HOOK_NAME
         ] = `${methodLiteralPrefix}get ${ON_UPDATE_HOOK_NAME}() {

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -350,7 +350,7 @@ export const componentToVue =
   // hack while we migrate all other transpilers to receive/handle path
   // TO-DO: use `Transpiler` once possible
   ({ component, path }: TranspilerArgs & { path: string }) => {
-    const options = mergeOptions(userOptions, BASE_OPTIONS);
+    const options = mergeOptions(BASE_OPTIONS, userOptions);
     // Make a copy we can safely mutate, similar to babel's toolchain can be used
     component = fastClone(component);
     processHttpRequests(component);

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -324,7 +324,7 @@ const onUpdatePlugin: Plugin = (options) => ({
         return \`${component.hooks.onUpdate.deps
           .slice(1, -1)
           .split(',')
-          .map((dep) => `\${this.${dep.trim()}}`)
+          .map((dep) => `\${${dep.trim()}}`)
           .join('|')}\`
       }`;
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,19 @@
 export * from './flow';
 
+export type Context<T> = {};
+
 // These compile away
 export const useState = <T>(obj: T) => obj;
 export const useRef = () => null as any;
-export const useContext = (key: any) => null as any;
-export const createContext = (value: { [key: string]: any }) => null as any;
-export const setContext = (key: any, value: { [key: string]: any }) =>
-  null as any;
+export const useContext = <T = { [key: string]: any }>(key: Context<T>): T =>
+  null as unknown as T;
+export const createContext = <T = { [key: string]: any }>(
+  value: T,
+): Context<T> => null as unknown as Context<T>;
+export const setContext = <T = { [key: string]: any }>(
+  key: Context<T>,
+  value: Partial<T>,
+): void => {};
 export const onMount = (fn: () => any) => null as any;
 export const onUpdate = (fn: () => any, deps?: any[]) => null as any;
 export const onCreate = (fn: () => any) => null as any;

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -229,11 +229,11 @@ const componentFunctionToJson = (
                   secondArg.elements.length > 0)
               ) {
                 const depsCode = secondArg ? generate(secondArg).code : '';
+
                 hooks.onUpdate = {
                   code,
+                  deps: depsCode,
                 };
-
-                hooks.onUpdate.deps = depsCode;
               }
             }
           } else if (expression.callee.name === 'onUnMount') {

--- a/packages/core/src/types/mitosis-component.ts
+++ b/packages/core/src/types/mitosis-component.ts
@@ -31,7 +31,7 @@ export interface MitosisImport {
 
 type ContextInfo = { name: string; path: string };
 
-type extendedHook = { code: string; deps?: string };
+export type extendedHook = { code: string; deps?: string };
 
 export type MitosisComponentInput = {
   name: string;


### PR DESCRIPTION
## Description

`onUpdate` in Vue was not feature-complete: it always used `updated() {}` which re-runs on every render. There was no notion of tracking dependencies.

- this PR relies on a `computed` + `watch` trick to track dependencies
- adds generics to `Context` compile-away functions 

