### PR TITLE
fix(react): process bindings in onUpdate deps

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -914,7 +914,7 @@ export default function OnUpdateWithDeps(props) {
 
   useEffect(() => {
     console.log(\\"Runs when a or b changes\\", a, b);
-  }, [state.a, state.b]);
+  }, [a, b]);
 
   return <View />;
 }

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -932,7 +932,7 @@ export default function OnUpdateWithDeps(props) {
 
   useEffect(() => {
     console.log(\\"Runs when a or b changes\\", a, b);
-  }, [state.a, state.b]);
+  }, [a, b]);
 
   return <div />;
 }

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -588,7 +588,8 @@ const _componentToReact = (
               updateStateSettersInCode(json.hooks.onUpdate.code, options),
               options,
             )}
-          }, ${
+          }, 
+          ${
             json.hooks.onUpdate.deps
               ? processBinding(
                   updateStateSettersInCode(json.hooks.onUpdate.deps, options),

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -588,7 +588,14 @@ const _componentToReact = (
               updateStateSettersInCode(json.hooks.onUpdate.code, options),
               options,
             )}
-          }, ${json.hooks.onUpdate.deps})`
+          }, ${
+            json.hooks.onUpdate.deps
+              ? processBinding(
+                  updateStateSettersInCode(json.hooks.onUpdate.deps, options),
+                  options,
+                )
+              : ''
+          })`
           : ''
       }
 


### PR DESCRIPTION
## Description

We were missing some stateSetter transforms for the `onUpdate` dependencies array :)