### PR TITLE
docs(components): remove this and prefer state

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -23,7 +23,10 @@ export default function MyComponent(props) {
     newItemName: 'New item',
     list: ['hello', 'world'],
     addItem() {
-      this.list = [...this.list, this.newItemName];
+      state.list = [
+        ...state.list,
+        state.newItemName
+      ];
     },
   });
 
@@ -144,7 +147,7 @@ export default function MyComponent() {
   const state = useState({
     name: 'Steve',
     updateName(newName) {
-      this.name = newName;
+      state.name = newName;
     },
   });
 


### PR DESCRIPTION
we shouldn't show any code using `this` since it can be confusing since the compile code is correct even though the dev code is not correct


onMount(() => {
  this.something
})

^ this is a problem

onMount(() => {  <- because of this arrow function `this` should be the global context which is a JavaScript gotcha
  this.something
})

the code is compiled correctly but can be confusing and I don't want devs to refactor their code thinking they are fixing a js gotcha 

onMount(function () {  <- because of this arrow function `this` should be the global context which is a js gotcha
  this.something
})
