### PR TITLE
Fix: Vue onUpdate w/ dependencies

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1065,14 +1065,6 @@ exports[`Vue multipleOnUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
-const printOrStringify = (x) => {
-  if (typeof x === \\"object\\") {
-    return JSON.stringify(x);
-  } else {
-    return x.toString();
-  }
-};
-
 export default {
   name: \\"multiple-on-update-with-deps\\",
 
@@ -1089,10 +1081,16 @@ export default {
 
   computed: {
     onUpdateHook0() {
-      return \`\${printOrStringify(this.a)}|\${printOrStringify(this.b)}\`;
+      return {
+        0: this.a,
+        1: this.b,
+      };
     },
     onUpdateHook1() {
-      return \`\${printOrStringify(this.c)}|\${printOrStringify(this.d)}\`;
+      return {
+        0: this.c,
+        1: this.d,
+      };
     },
   },
 };
@@ -1141,14 +1139,6 @@ exports[`Vue onUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
-const printOrStringify = (x) => {
-  if (typeof x === \\"object\\") {
-    return JSON.stringify(x);
-  } else {
-    return x.toString();
-  }
-};
-
 export default {
   name: \\"on-update-with-deps\\",
 
@@ -1162,7 +1152,10 @@ export default {
 
   computed: {
     onUpdateHook0() {
-      return \`\${printOrStringify(this.a)}|\${printOrStringify(this.b)}\`;
+      return {
+        0: this.a,
+        1: this.b,
+      };
     },
   },
 };

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1065,6 +1065,14 @@ exports[`Vue multipleOnUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
+const printOrStringify = (x) => {
+  if (typeof x === \\"object\\") {
+    return JSON.stringify(x);
+  } else {
+    return x.toString();
+  }
+};
+
 export default {
   name: \\"multiple-on-update-with-deps\\",
 
@@ -1081,10 +1089,10 @@ export default {
 
   computed: {
     onUpdateHook0() {
-      return \`\${this.a}|\${this.b}\`;
+      return \`\${printOrStringify(this.a)}|\${printOrStringify(this.b)}\`;
     },
     onUpdateHook1() {
-      return \`\${this.c}|\${this.d}\`;
+      return \`\${printOrStringify(this.c)}|\${printOrStringify(this.d)}\`;
     },
   },
 };
@@ -1133,6 +1141,14 @@ exports[`Vue onUpdateWithDeps 1`] = `
   <div></div>
 </template>
 <script>
+const printOrStringify = (x) => {
+  if (typeof x === \\"object\\") {
+    return JSON.stringify(x);
+  } else {
+    return x.toString();
+  }
+};
+
 export default {
   name: \\"on-update-with-deps\\",
 
@@ -1146,7 +1162,7 @@ export default {
 
   computed: {
     onUpdateHook0() {
-      return \`\${this.a}|\${this.b}\`;
+      return \`\${printOrStringify(this.a)}|\${printOrStringify(this.b)}\`;
     },
   },
 };

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -325,11 +325,16 @@ const onUpdatePlugin: Plugin = (options) => ({
             component.state[
               getOnUpdateHookName(index)
             ] = `${methodLiteralPrefix}get ${getOnUpdateHookName(index)} () {
-            return \`${hook.deps
-              ?.slice(1, -1)
-              .split(',')
-              .map((dep) => `\${printOrStringify(${dep.trim()})}`)
-              .join('|')}\`
+            return {
+              ${hook.deps
+                ?.slice(1, -1)
+                .split(',')
+                .map((dep, k) => {
+                  const val = dep.trim();
+                  return `${k}: ${val}`;
+                })
+                .join(',')}
+            }
           }`;
           });
       }
@@ -456,29 +461,12 @@ export const componentToVue =
     const onUpdateWithoutDeps =
       component.hooks.onUpdate?.filter((hook) => !hook.deps?.length) || [];
 
-    const needsJsonStringifierHack = component.hooks.onUpdate?.some(
-      (hook) => hook.deps?.length,
-    );
-
     let str = dedent`
     <template>
       ${template}
     </template>
     <script>
       ${renderPreComponent(component)}
-      ${
-        needsJsonStringifierHack
-          ? `
-      const printOrStringify = (x) => {
-        if (typeof x === 'object') {
-          return JSON.stringify(x)
-        } else {
-          return x.toString()
-        }
-      }      
-      `
-          : ''
-      }
       ${
         component.meta.registerComponent
           ? options.registerComponentPrepend ?? ''


### PR DESCRIPTION
## Description

onUpdate dependencies could not be stringified: this caused a bug where changes in objects never caused updates since they are always represented by `[Object object]`. This PR fixes that