### PR TITLE
fix(examples): replace npm with yarn

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -4,16 +4,16 @@
 
 ```bash
 # install
-npm install
+yarn install
 
 # build
-npm run build
+yarn run build
 
 # run dev server that watches for changes
-npm run start
+yarn run start
 
 # test
-npm run test
+yarn run test
 ```
 
 ### Project structure

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "mitosis": "mitosis build",
-    "build": "npm run mitosis",
-    "start": "watch 'npm run mitosis' ./src ./overrides",
+    "build": "yarn run mitosis",
+    "start": "watch 'yarn run mitosis' ./src ./overrides",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Replace `npm` with `yarn` in the readme  setup instructions, because yarn.lock is tracked. This will avoid having yarn.lock and package-lock.json simultaneously which may cause inconsistencies in dependency tree.







