### PR TITLE
fix(svelte): support self-referencing component (#291)

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -30,3 +30,19 @@ exports[`Svelte onUpdate 1`] = `
 <div />
 "
 `;
+
+exports[`Svelte selfReferencingComponent 1`] = `
+"<script>
+  export let name;
+
+</script>
+
+<div>
+  {name}
+
+  {#if name === 'Batman'}
+    <svelte:self name={'Bruce Wayne'} />
+  {/if}
+</div>
+"
+`;

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -46,3 +46,23 @@ exports[`Svelte selfReferencingComponent 1`] = `
 </div>
 "
 `;
+
+exports[`Svelte selfReferencingComponentWithChildren 1`] = `
+"<script>
+  export let name;
+
+</script>
+
+<div>
+  {name}
+
+  <slot />
+
+  {#if name === 'Batman'}
+    <svelte:self name={'Bruce'}>
+      <div>Wayne</div>
+    </svelte:self>
+  {/if}
+</div>
+"
+`;

--- a/packages/core/src/__tests__/data/blocks/self-referencing-component-with-children.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/self-referencing-component-with-children.raw.tsx
@@ -1,0 +1,15 @@
+import { Show } from '@builder.io/mitosis';
+
+export default function MyComponent(props: any) {
+  return (
+    <div>
+      {props.name}
+      {props.children}
+      <Show when={props.name === 'Batman'}>
+        <MyComponent name={'Bruce'}>
+          <div>Wayne</div>
+        </MyComponent>
+      </Show>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/data/blocks/self-referencing-component.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/self-referencing-component.raw.tsx
@@ -1,0 +1,12 @@
+import { Show } from '@builder.io/mitosis';
+
+export default function MyComponent(props: any) {
+  return (
+    <div>
+      {props.name}
+      <Show when={props.name === 'Batman'}>
+        <MyComponent name={'Bruce Wayne'} />
+      </Show>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/svelte.test.ts
+++ b/packages/core/src/__tests__/svelte.test.ts
@@ -3,6 +3,7 @@ import { parseJsx } from '../parsers/jsx';
 
 const onUpdate = require('./data/blocks/onUpdate.raw');
 const multipleOUpdate = require('./data/blocks/multiple-onUpdate.raw');
+const selfReferencingComponent = require('./data/blocks/self-referencing-component.raw');
 
 describe('Svelte', () => {
   test('onUpdate', () => {
@@ -13,6 +14,12 @@ describe('Svelte', () => {
 
   test('multipleOnUpdate', () => {
     const component = parseJsx(multipleOUpdate);
+    const output = componentToSvelte()({ component });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('selfReferencingComponent', () => {
+    const component = parseJsx(selfReferencingComponent);
     const output = componentToSvelte()({ component });
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/svelte.test.ts
+++ b/packages/core/src/__tests__/svelte.test.ts
@@ -4,6 +4,7 @@ import { parseJsx } from '../parsers/jsx';
 const onUpdate = require('./data/blocks/onUpdate.raw');
 const multipleOUpdate = require('./data/blocks/multiple-onUpdate.raw');
 const selfReferencingComponent = require('./data/blocks/self-referencing-component.raw');
+const selfReferencingComponentWithChildren = require('./data/blocks/self-referencing-component-with-children.raw');
 
 describe('Svelte', () => {
   test('onUpdate', () => {
@@ -20,6 +21,12 @@ describe('Svelte', () => {
 
   test('selfReferencingComponent', () => {
     const component = parseJsx(selfReferencingComponent);
+    const output = componentToSvelte()({ component });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('selfReferencingComponentWithChildren', () => {
+    const component = parseJsx(selfReferencingComponentWithChildren);
     const output = componentToSvelte()({ component });
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -287,7 +287,12 @@ export const componentToSvelte =
       }
       ${refs
         .concat(props)
-        .map((name) => `export let ${name};`)
+        .map((name) => {
+          if (name === 'children') {
+            return '';
+          }
+          return `export let ${name};`;
+        })
         .join('\n')}
 
       ${functionsString.length < 4 ? '' : functionsString}


### PR DESCRIPTION
## Description

Svelte uses `svelte:self` to reference itself recursively. More about it [here](https://svelte.dev/tutorial/svelte-self).

This PR passes the parent component information to all the child components so that if any of children name match the parents, we introduce Svelte's self tag in place of the component name.


