### PR TITLE
bug fixes for solidjs

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -496,7 +496,7 @@ export default function FormComponent(props) {
       action={!props.sendWithJs && props.action}
       method={props.method}
       name={props.name}
-      onSubmit={(event) => state.state.onSubmit(event)}
+      onSubmit={(event) => state.onSubmit(event)}
     >
       <Show when={props.builderBlock && props.builderBlock.children}>
         <For each={props.builderBlock?.children}>
@@ -509,23 +509,19 @@ export default function FormComponent(props) {
           )}
         </For>
       </Show>
-      <Show when={state.state.submissionState === \\"error\\"}>
+      <Show when={state.submissionState === \\"error\\"}>
         <BuilderBlocks
           dataPath=\\"errorMessage\\"
           blocks={props.errorMessage}
         ></BuilderBlocks>
       </Show>
-      <Show when={state.state.submissionState === \\"sending\\"}>
+      <Show when={state.submissionState === \\"sending\\"}>
         <BuilderBlocks
           dataPath=\\"sendingMessage\\"
           blocks={props.sendingMessage}
         ></BuilderBlocks>
       </Show>
-      <Show
-        when={
-          state.state.submissionState === \\"error\\" && state.state.responseData
-        }
-      >
+      <Show when={state.submissionState === \\"error\\" && state.responseData}>
         <pre
           class={css({
             padding: \\"10px\\",
@@ -533,10 +529,10 @@ export default function FormComponent(props) {
             textAlign: \\"center\\",
           })}
         >
-          {JSON.stringify(state.state.responseData, null, 2)}
+          {JSON.stringify(state.responseData, null, 2)}
         </pre>
       </Show>
-      <Show when={state.state.submissionState === \\"success\\"}>
+      <Show when={state.submissionState === \\"success\\"}>
         <BuilderBlocks
           dataPath=\\"successMessage\\"
           blocks={props.successMessage}
@@ -642,8 +638,8 @@ export default function ImgComponent(props) {
     <img
       {...props.attributes}
       style={{
-        objectFit: props.backgroundSize || \\"cover\\",
-        objectPosition: props.backgroundPosition || \\"center\\",
+        \\"object-fit\\": props.backgroundSize || \\"cover\\",
+        \\"object-position\\": props.backgroundPosition || \\"center\\",
       }}
       key={(Builder.isEditing && props.imgSrc) || \\"default-key\\"}
       alt={props.altText}
@@ -698,7 +694,7 @@ exports[`Solid Section 1`] = `
       style={
         props.maxWidth && typeof props.maxWidth === \\"number\\"
           ? {
-              maxWidth: props.maxWidth,
+              \\"max-width\\": props.maxWidth,
             }
           : undefined
       }
@@ -791,11 +787,11 @@ exports[`Solid Video 1`] = `
         width: \\"100%\\",
         height: \\"100%\\",
         ...props.attributes?.style,
-        objectFit: props.fit,
-        objectPosition: props.position,
+        \\"object-fit\\": props.fit,
+        \\"object-position\\": props.position,
         // Hack to get object fit to work as expected and
         // not have the video overflow
-        borderRadius: 1,
+        \\"border-radius\\": 1,
       }}
       key={props.video || \\"no-src\\"}
       poster={props.posterImage}


### PR DESCRIPTION
- convert style object keys to kebabcase
- HACK: force remove `state.state.`. this needs more looking into but was becoming a rabbit hole and we need to get this delivered
- fix missing `useContext` reference