### PR TITLE
#279 feat: add ESlint recommended config

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,0 +1,24 @@
+export default {
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['@builder.io/mitosis'],
+  rules: {
+    '@builder.io/mitosis/css-no-vars': 'error',
+    '@builder.io/mitosis/jsx-callback-arg-name': 'error',
+    '@builder.io/mitosis/jsx-callback-arrow-function': 'error',
+    '@builder.io/mitosis/no-assign-props-to-state': 'error',
+    '@builder.io/mitosis/no-async-methods-on-state': 'error',
+    '@builder.io/mitosis/no-conditional-logic-in-component-render': 'error',
+    '@builder.io/mitosis/no-state-destructuring': 'error',
+    '@builder.io/mitosis/no-var-declaration-in-jsx': 'error',
+    '@builder.io/mitosis/no-var-declaration-or-assignment-in-component':
+      'error',
+    '@builder.io/mitosis/no-var-name-same-as-state-property': 'error',
+    '@builder.io/mitosis/only-default-function-and-imports': 'error',
+    '@builder.io/mitosis/ref-no-current': 'error',
+    '@builder.io/mitosis/use-state-var-declarator': 'error',
+  },
+};

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -14,7 +14,7 @@ import noVarNameSameAsStateProperty from './rules/no-var-name-same-as-state-prop
 import onlyDefaultFunctionAndImports from './rules/only-default-function-and-imports';
 import noConditionalLogicInComponentRender from './rules/no-conditional-logic-in-component-render';
 import noVarDeclarationOrAssignmentInComponent from './rules/no-var-declaration-or-assignment-in-component';
-
+import recommended from './configs/recommended';
 export const staticControlFlow: Rule.RuleModule = {
   create(context) {
     if (!isMitosisPath(context.getFilename())) return {};
@@ -98,4 +98,8 @@ export const rules = {
     noConditionalLogicInComponentRender,
   'no-var-declaration-or-assignment-in-component':
     noVarDeclarationOrAssignmentInComponent,
+};
+
+export const configs = {
+  recommended,
 };


### PR DESCRIPTION
## Description

Address #279 
Include basic ESlint configuration in README.md & all eslint-plugin rules.

Currently all rules are included set to prompt an error. Looking forward to know the authors option about the "severity" of each rule, as not hinder developer experience.

The recommended config is currently hand-coded. While doing some research on other open source library I noticed they use a script to auto generate config files. In my opinion we may need to consider this in the future 

Please note: This change is not fully tested yet, and would appreciate some help.


