### PR TITLE
fix(cli): build - throw errors instead of swallowing

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -229,7 +229,7 @@ async function outputTsxLiteFiles(
     } catch (error) {
       debugTarget(`Failure: transpiled ${path}.`);
       debugTarget(error);
-      return;
+      throw error;
     }
 
     const original = transpiled;


### PR DESCRIPTION
## Description

We need to make sure to throw errors during `mitosis build`, or else builds will succeed despite certain files not transpiling properly.
