### PR TITLE
Adding back angular component compile

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -17,6 +17,7 @@ import {
   Target,
   Transpiler,
   componentToSvelte,
+  componentToAngular,
 } from '@builder.io/mitosis';
 import debug from 'debug';
 import dedent from 'dedent';
@@ -153,6 +154,8 @@ const getTranspilerForTarget = ({
       return componentToReactNative({ stateType: 'useState' });
     case 'vue':
       return componentToVue(options.options.vue);
+    case 'angular':
+      return componentToAngular(options.options.angular);
     case 'react':
       return componentToReact(options.options.react);
     case 'swift':


### PR DESCRIPTION
## Description
When trying to follow the example I found that no components were compiling for Angular. For some reason the switch statement for Angular was missing. This PR adds it back.

