### PR TITLE
feat(angular): outputs via metadata

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -24,12 +24,12 @@ exports[`Angular BasicFor 1`] = `
   \`,
 })
 export default class MyBasicForComponent {
+  name = \\"PatrickJS\\";
+  names = [\\"Steve\\", \\"PatrickJS\\"];
+
   ngOnInit() {
     console.log(\\"onMount code\\");
   }
-
-  name = \\"PatrickJS\\";
-  names = [\\"Steve\\", \\"PatrickJS\\"];
 }
 "
 `;
@@ -48,6 +48,31 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   \`,
 })
 export default class SlotCode {}
+"
+`;
+
+exports[`Angular basic outputs 1`] = `
+"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-basic-outputs-component\\",
+  template: \`
+    <div></div>
+  \`,
+})
+export default class MyBasicOutputsComponent {
+  @Output() onMessage = new EventEmitter<any>();
+  @Output() onEvent = new EventEmitter<any>();
+
+  @Input() message: any;
+
+  name = \\"PatrickJS\\";
+
+  ngOnInit() {
+    this.onMessage.emit(this.name);
+    this.onEvent.emit(this.message);
+  }
+}
 "
 `;
 

--- a/packages/core/src/__tests__/angular.test.ts
+++ b/packages/core/src/__tests__/angular.test.ts
@@ -7,12 +7,18 @@ const onMount = require('./data/blocks/onMount.raw');
 const onInitonMount = require('./data/blocks/onInit-onMount.raw');
 const onInit = require('./data/blocks/onInit.raw');
 const basicFor = require('./data/basic-for.raw');
+const basicOutputs = require('./data/basic-outputs.raw');
 const contentSlotHtml = require('./data/blocks/content-slot-html.raw');
 const contentSlotJsx = require('./data/blocks/content-slot-jsx.raw');
 const slotJsx = require('./data/blocks/slot-jsx.raw');
 // const slotHtml = require('./data/blocks/slot-html.raw');
 
 describe('Angular', () => {
+  test('basic outputs', () => {
+    const component = parseJsx(basicOutputs);
+    const output = componentToAngular()({ component });
+    expect(output).toMatchSnapshot();
+  });
   test('multiple onUpdate', () => {
     const component = parseJsx(multipleOnUpdate);
     const output = componentToAngular()({ component });

--- a/packages/core/src/__tests__/data/basic-outputs.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-outputs.raw.tsx
@@ -1,0 +1,17 @@
+import { useState, useMetadata, onMount } from '@builder.io/mitosis';
+
+useMetadata({
+  outputs: ['onMessage', 'onEvent'],
+});
+export default function MyBasicOutputsComponent(props: any) {
+  const state = useState({
+    name: 'PatrickJS',
+  });
+
+  onMount(() => {
+    props.onMessage(state.name);
+    props.onEvent(props.message);
+  });
+
+  return <div></div>;
+}


### PR DESCRIPTION
## Description

outputs via metadata for now and I'll update the detector later so we won't need useMetadata

```
import { useState, useMetadata, onMount } from '@builder.io/mitosis';

useMetadata({
  outputs: ['onMessage', 'onEvent'],
});
export default function MyBasicOutputsComponent(props: any) {
  const state = useState({
    name: 'PatrickJS',
  });

  onMount(() => {
    props.onMessage(state.name);
    props.onEvent(props.message);
  });

  return <div></div>;
}
```