### PR TITLE
className now gets pruned to class.

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -76,6 +76,25 @@ export default class MyBasicOutputsComponent {
 "
 `;
 
+exports[`Angular className to class 1`] = `
+"import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"class-name-code\\",
+  template: \`
+    <div>
+      <div class=\\"no binding\\">Without Binding</div>
+
+      <div [class]=\\"bindings\\">With binding</div>
+    </div>
+  \`,
+})
+export default class ClassNameCode {
+  bindings = \\"a binding\\";
+}
+"
+`;
+
 exports[`Angular multiple onUpdate 1`] = `
 "import { Component } from \\"@angular/core\\";
 

--- a/packages/core/src/__tests__/angular.test.ts
+++ b/packages/core/src/__tests__/angular.test.ts
@@ -11,6 +11,7 @@ const basicOutputs = require('./data/basic-outputs.raw');
 const contentSlotHtml = require('./data/blocks/content-slot-html.raw');
 const contentSlotJsx = require('./data/blocks/content-slot-jsx.raw');
 const slotJsx = require('./data/blocks/slot-jsx.raw');
+const classNameJsx = require('./data/blocks/classname-jsx.raw');
 // const slotHtml = require('./data/blocks/slot-html.raw');
 
 describe('Angular', () => {
@@ -77,4 +78,10 @@ describe('Angular', () => {
   //   const output = componentToAngular()({ component });
   //   expect(output).toMatchSnapshot();
   // });
+
+  test('className to class', () => {
+    const component = parseJsx(classNameJsx);
+    const output = componentToAngular()({ component });
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
@@ -12,7 +12,9 @@ export default function ClassNameCode(props: Props) {
 
   return (
     <div>
+      {/*// @ts-ignore */}
       <div className="no binding">Without Binding</div>
+      {/*// @ts-ignore */}
       <div className={state.bindings}>With binding</div>
     </div>
   );

--- a/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
@@ -1,0 +1,19 @@
+import { useState } from '@builder.io/mitosis';
+
+type Props = {
+  [key: string]: string | JSX.Element;
+  slotTesting: JSX.Element;
+};
+
+export default function ClassNameCode(props: Props) {
+  const state = useState({
+    bindings: 'a binding',
+  });
+
+  return (
+    <div>
+      <div className="no binding">Without Binding</div>
+      <div className={state.bindings}>With binding</div>
+    </div>
+  );
+}

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -127,7 +127,11 @@ export const blockToAngular = (
         continue;
       }
       const value = json.properties[key];
-      str += ` ${key}="${value}" `;
+      if (key === 'className') {
+        str += ` class="${value}" `;
+      } else {
+        str += ` ${key}="${value}" `;
+      }
     }
     for (const key in json.bindings) {
       if (key === '_spread') {
@@ -156,6 +160,8 @@ export const blockToAngular = (
           useValue.replace(/event\./g, '$event.'),
         );
         str += ` (${event})="${finalValue}" `;
+      } else if (key === 'className') {
+        str += ` [class]="${useValue}" `;
       } else if (key === 'ref') {
         str += ` #${useValue} `;
       } else if (key.startsWith('slot')) {


### PR DESCRIPTION
#353 

Due to the way JSX typings work, we have to account for React Developers who have toolsets that issue warnings for not using className, this then turns into a silent error when compiling to Angular. So to account for this issue we will have the Angular generator account for it. :) :) :) 