### PR TITLE
Build basic and todo examples in CI

### DIFF
--- a/.github/workflows/on-push-build.yml
+++ b/.github/workflows/on-push-build.yml
@@ -17,12 +17,19 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: build
         run: yarn workspace @builder.io/mitosis run build
 
+      - name: build basic example
+        run: yarn workspace @builder.io/basic-example run build
+
+      - name: build todo example
+        run: yarn workspace @builder.io/todo-example run build
+
       - name: save artifact
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        if: "${{ env.API_TOKEN_GITHUB != '' }}"
         run: yarn workspace @builder.io/mitosis run mitosis-save-artifacts

--- a/.github/workflows/pr-runner.yml
+++ b/.github/workflows/pr-runner.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Run prettier
         run: yarn ci:lint

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@builder.io/basic-example",
   "version": "0.0.1",
   "scripts": {
     "mitosis": "mitosis build",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@builder.io/todo-example",
   "version": "0.0.1",
   "scripts": {
     "build": "mitosis build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,6 +1594,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@builder.io/basic-example@workspace:examples/basic":
+  version: 0.0.0-use.local
+  resolution: "@builder.io/basic-example@workspace:examples/basic"
+  dependencies:
+    "@builder.io/mitosis": "workspace:*"
+    "@builder.io/mitosis-cli": "workspace:*"
+    "@types/jest": ^27.4.0
+    "@types/node-fetch": ^2.5.12
+    eslint: ^7.21.0
+    jest: ^27.5.1
+    jest-fetch-mock: ^3.0.3
+    node-fetch: ^2.6.1
+    prettier: ^2.5.0
+    seedrandom: ^3.0.5
+    ts-jest: ^27.1.3
+    typescript: ^4.5.5
+    watch: ^1.0.2
+  languageName: unknown
+  linkType: soft
+
 "@builder.io/eslint-plugin-mitosis@workspace:packages/eslint-plugin":
   version: 0.0.0-use.local
   resolution: "@builder.io/eslint-plugin-mitosis@workspace:packages/eslint-plugin"
@@ -1862,6 +1882,16 @@ __metadata:
   checksum: 18379d312f17e0b389f18465ca9dcf3a45d4054ecee8d5eb18a2e98af755b4fcc5816bb368a1452ece142b898507f6dce4849e850028341f0afad68e8a0f444d
   languageName: node
   linkType: hard
+
+"@builder.io/todo-example@workspace:examples/todo":
+  version: 0.0.0-use.local
+  resolution: "@builder.io/todo-example@workspace:examples/todo"
+  dependencies:
+    "@builder.io/mitosis": "workspace:*"
+    "@builder.io/mitosis-cli": "workspace:*"
+    eslint: ^7.21.0
+  languageName: unknown
+  linkType: soft
 
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
@@ -6742,26 +6772,6 @@ __metadata:
   checksum: a4a146b912e27eea8f66d09cb0c9eab666f32ce27859a7dfd50f38cd069a2557b39f16dba1bc2aecb3b44bf096738dd207b7970d99b0318423285ab1b1994edd
   languageName: node
   linkType: hard
-
-"basic-3cea2e@workspace:examples/basic":
-  version: 0.0.0-use.local
-  resolution: "basic-3cea2e@workspace:examples/basic"
-  dependencies:
-    "@builder.io/mitosis": "workspace:*"
-    "@builder.io/mitosis-cli": "workspace:*"
-    "@types/jest": ^27.4.0
-    "@types/node-fetch": ^2.5.12
-    eslint: ^7.21.0
-    jest: ^27.5.1
-    jest-fetch-mock: ^3.0.3
-    node-fetch: ^2.6.1
-    prettier: ^2.5.0
-    seedrandom: ^3.0.5
-    ts-jest: ^27.1.3
-    typescript: ^4.5.5
-    watch: ^1.0.2
-  languageName: unknown
-  linkType: soft
 
 "batch@npm:0.6.1":
   version: 0.6.1
@@ -24004,16 +24014,6 @@ __metadata:
   checksum: 4ed4a619059b64e204aad84e4e5f3ea82d97410988bcece7cf6cbfdbf193d11bff48cf53842d88b8bb00b1bfc0d048f61f20f0709e6f393fd8fe0122662d9db4
   languageName: node
   linkType: hard
-
-"todo-a54566@workspace:examples/todo":
-  version: 0.0.0-use.local
-  resolution: "todo-a54566@workspace:examples/todo"
-  dependencies:
-    "@builder.io/mitosis": "workspace:*"
-    "@builder.io/mitosis-cli": "workspace:*"
-    eslint: ^7.21.0
-  languageName: unknown
-  linkType: soft
 
 "toggle-selection@npm:^1.0.6":
   version: 1.0.6


### PR DESCRIPTION
Use yarn --immutable in CI per docs recommendations.

The previous improvement to include the examples in the workspace already ran them as part of PR build; this further runs them on any commit build.

Future PRs can work toward more complete CI, such as verifying the output code compiles under each supported target, verifying the resulting applications work via Playwright, etc.