### PR TITLE
better support both forms of state and functions in Mitosis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Mitosis uses a static subset of JSX, inspired by [Solid](https://www.solidjs.com
 
 ```tsx
 export function MyComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -18,10 +18,10 @@ Mitosis is inspired by many modern frameworks. You'll see components look like R
 An example Mitosis component showing several features:
 
 ```javascript
-import { For, Show, useState } from '@builder.io/mitosis';
+import { For, Show, useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     newItemName: 'New item',
     list: ['hello', 'world'],
     addItem() {
@@ -97,7 +97,7 @@ State is provided by the `useState` hook. Currently, the name of this value must
 
 ```jsx
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 
@@ -119,7 +119,7 @@ If the initial state value is a computed value (whether based on `props` or the 
 import { kebabCase } from 'lodash';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
     get transformedName() {
       return kebabCase('Steve');
@@ -149,7 +149,7 @@ The state object can also take methods.
 
 ```jsx
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
     updateName(newName) {
       state.name = newName;
@@ -188,7 +188,7 @@ Use `<For>` for repeating items, for instance mapping over an array. It takes a 
 
 ```jsx
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     myArray: [1, 2, 3],
   });
   return (

--- a/docs/customizability.md
+++ b/docs/customizability.md
@@ -53,7 +53,7 @@ What happens if you want a plugin to only apply to a specific set of components?
 This is where our `useMetadata` hook comes in handy. All you need to do is import and use the hook (you can use it anywhere in your mitosis component file, even at the top root level!):
 
 ```tsx
-import { useMetadata, useState, onMount, For, Show } from '@builder.io/mitosis';
+import { useMetadata, useStore, onMount, For, Show } from '@builder.io/mitosis';
 
 useMetadata({ mySpecialComponentType: 'ABC' });
 

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -26,7 +26,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     foo: 'bar',
 
     doSomething() {
@@ -59,7 +59,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     foo: 'bar',
 
     doSomething() {
@@ -90,7 +90,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     async doSomethingAsync(event) {
       //  ^^^^^^^^^^^^^^^^^^^^^^^^^
       //  Fails to parse this line
@@ -111,7 +111,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     doSomethingAsync(event) {
       void (async function () {
         const response = await fetch(); /* ... */
@@ -143,7 +143,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     myCallback(event) {
       // do something
     },
@@ -183,7 +183,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     myCallback(event) {
       // do something
     },
@@ -223,7 +223,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent(props) {
-  const state = useState({ text: props.text });
+  const state = useStore({ text: props.text });
   //                             ^^^^^^^^^^
   //                             Could not JSON5 parse object
 }
@@ -237,7 +237,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent(props) {
-  const state = useState({ text: null });
+  const state = useStore({ text: null });
 
   onMount(() => {
     state.text = props.text;
@@ -273,7 +273,7 @@ _Mitosis input_
 import { kebabCase } from 'lodash';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     name: kebabCase('Steve'),
     //    ^^^^^^^^^
     //    Could not JSON5 parse object
@@ -297,7 +297,7 @@ _Mitosis input_
 import { kebabCase } from 'lodash';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     get name() {
       return kebabCase('Steve');
     },
@@ -341,7 +341,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({ foo: '1' });
+  const state = useStore({ foo: '1' });
 
   onMount(() => {
     const { foo } = state;
@@ -373,7 +373,7 @@ _Mitosis input_
 
 ```typescript
 export default function MyComponent() {
-  const state = useState({ foo: '1' });
+  const state = useStore({ foo: '1' });
 
   onMount(() => {
     const foo = state.foo;

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,12 +12,12 @@
 Use the `useRef` hook to hold a reference to a rendered DOM element.
 
 ```typescript
-import { useState, useRef, Show } from '@builder.io/mitosis';
+import { useStore, useRef, Show } from '@builder.io/mitosis';
 
 export default function MyComponent() {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
     onBlur() {
       // Maintain focus
@@ -108,7 +108,7 @@ The onUpdate hook is the best place to put custom code that will either:
 
 ```jsx
 export default function OnUpdateWithDeps() {
-  const state = useState({
+  const state = useStore({
     a: 'a',
     b: 'b',
   });

--- a/examples/todo/src/components/todo.lite.tsx
+++ b/examples/todo/src/components/todo.lite.tsx
@@ -1,6 +1,6 @@
 import '@builder.io/mitosis/dist/src/jsx-types';
 import todosState from '../shared/todos-state.lite';
-import { Show, useState } from '@builder.io/mitosis';
+import { Show, useStore } from '@builder.io/mitosis';
 import { Todo as TodoType } from '../shared/todos-state.lite';
 
 export type TodoProps = {
@@ -8,7 +8,7 @@ export type TodoProps = {
 };
 
 export default function Todo(props: TodoProps) {
-  const state = useState({
+  const state = useStore({
     editing: false,
     toggle() {
       props.todo.completed = !props.todo.completed;

--- a/packages/cli/build/templates/component.lite.tsx.ejs
+++ b/packages/cli/build/templates/component.lite.tsx.ejs
@@ -1,12 +1,12 @@
 import '@jsx-lite/core/dist/jsx'
-import { useState, Show } from '@jsx-lite/core';
+import { useStore, Show } from '@jsx-lite/core';
 
 interface Props {
   showInput?: boolean
 }
 
 export default function MyComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve'
   });
 

--- a/packages/cli/build/templates/library-simple/src/components/my-component.lite.jsx
+++ b/packages/cli/build/templates/library-simple/src/components/my-component.lite.jsx
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 require('@jsx-lite/core/dist/src/jsx-types');
 var core_1 = require('@jsx-lite/core');
 function MyComponent(props) {
-  var state = core_1.useState({
+  var state = core_1.useStore({
     name: 'Steve',
   });
   return (

--- a/packages/cli/build/templates/library-simple/src/components/my-component.lite.tsx
+++ b/packages/cli/build/templates/library-simple/src/components/my-component.lite.tsx
@@ -1,13 +1,13 @@
 // TODO: get the exports alias working here so this is just `import '@jsx-lite/core/jsx'
 import '@jsx-lite/core/dist/src/jsx-types';
-import { useState, Show } from '@jsx-lite/core';
+import { useStore, Show } from '@jsx-lite/core';
 
 type MyProps = {
   showInput?: boolean;
 };
 
 export default function MyComponent(props: MyProps) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/packages/cli/src/templates/component.lite.tsx.ejs
+++ b/packages/cli/src/templates/component.lite.tsx.ejs
@@ -1,12 +1,12 @@
 import '@builder.io/mitosis/dist/jsx'
-import { useState, Show } from '@builder.io/mitosis';
+import { useStore, Show } from '@builder.io/mitosis';
 
 interface Props {
   showInput?: boolean
 }
 
 export default function MyComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve'
   });
 

--- a/packages/cli/src/templates/library-simple/src/components/my-component.lite.tsx
+++ b/packages/cli/src/templates/library-simple/src/components/my-component.lite.tsx
@@ -1,13 +1,13 @@
 // TODO: get the exports alias working here so this is just `import '@builder.io/mitosis/jsx'
 import '@builder.io/mitosis/dist/src/jsx-types';
-import { useState, Show } from '@builder.io/mitosis';
+import { useStore, Show } from '@builder.io/mitosis';
 
 type MyProps = {
   showInput?: boolean;
 };
 
 export default function MyComponent(props: MyProps) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -131,7 +131,7 @@ Mitosis uses a static subset of JSX, inspired by [Solid](https://github.com/ryan
 
 ```tsx
 export function MyComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/packages/core/integration/jsx-lite/home.lite.tsx
+++ b/packages/core/integration/jsx-lite/home.lite.tsx
@@ -1,7 +1,7 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({ name: 'Steve' });
+  const state = useStore({ name: 'Steve' });
 
   return (
     <div

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -132,10 +132,10 @@ useState({
 `;
 
 exports[`Builder Columns 2`] = `
-"import { useState, For } from \\"@builder.io/mitosis\\";
+"import { useStore, For } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     getColumns() {
       return props.columns || [];
     },
@@ -325,10 +325,10 @@ onMount(() => {
 `;
 
 exports[`Builder CustomCode 2`] = `
-"import { useState, useRef } from \\"@builder.io/mitosis\\";
+"import { useStore, useRef } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     scriptsInserted: [],
     scriptsRun: [],
     findAndRunScripts() {
@@ -526,10 +526,10 @@ onMount(() => {
 `;
 
 exports[`Builder Embed 2`] = `
-"import { useState, useRef } from \\"@builder.io/mitosis\\";
+"import { useStore, useRef } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     scriptsInserted: [],
     scriptsRun: [],
     findAndRunScripts() {
@@ -709,19 +709,19 @@ Object {
 Object.assign(state, {
   scrollListener: null,
   imageLoaded: false,
-  load: false,
   setLoaded() {
     state.imageLoaded = true;
   },
-  isBrowser() {
+  useLazyLoading() {
+    // TODO: Add more checks here, like testing for real web browsers
+    return !!props.lazy && isBrowser();
+  },
+  isBrowser: function isBrowser() {
     return (
       typeof window !== \\"undefined\\" && window.navigator.product != \\"ReactNative\\"
     );
   },
-  useLazyLoading() {
-    // TODO: Add more checks here, like testing for real web browsers
-    return !!props.lazy && state.isBrowser();
-  },
+  load: false,
 });
 
 if (state.useLazyLoading()) {
@@ -732,7 +732,7 @@ if (state.useLazyLoading()) {
       const buffer = window.innerHeight / 2;
 
       if (rect.top < window.innerHeight + buffer) {
-        state.load = true;
+        setLoad(true);
         state.scrollListener = null;
         window.removeEventListener(\\"scroll\\", listener);
       }
@@ -752,19 +752,19 @@ if (state.useLazyLoading()) {
 useState({
   scrollListener: null,
   imageLoaded: false,
-  load: false,
   setLoaded() {
     state.imageLoaded = true;
   },
-  isBrowser() {
+  useLazyLoading() {
+    // TODO: Add more checks here, like testing for real web browsers
+    return !!props.lazy && isBrowser();
+  },
+  isBrowser: function isBrowser() {
     return (
       typeof window !== \\"undefined\\" && window.navigator.product != \\"ReactNative\\"
     );
   },
-  useLazyLoading() {
-    // TODO: Add more checks here, like testing for real web browsers
-    return !!props.lazy && state.isBrowser();
-  },
+  load: false,
 });
 
 onMount(() => {
@@ -776,7 +776,7 @@ onMount(() => {
         const buffer = window.innerHeight / 2;
 
         if (rect.top < window.innerHeight + buffer) {
-          state.load = true;
+          setLoad(true);
           state.scrollListener = null;
           window.removeEventListener(\\"scroll\\", listener);
         }
@@ -797,27 +797,27 @@ onMount(() => {
 `;
 
 exports[`Builder Image 2`] = `
-"import { useState, useRef, Show } from \\"@builder.io/mitosis\\";
+"import { useStore, useRef, Show } from \\"@builder.io/mitosis\\";
 import { Fragment } from \\"@components\\";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     scrollListener: null,
     imageLoaded: false,
-    load: false,
     setLoaded() {
       state.imageLoaded = true;
     },
-    isBrowser() {
+    useLazyLoading() {
+      // TODO: Add more checks here, like testing for real web browsers
+      return !!props.lazy && isBrowser();
+    },
+    isBrowser: function isBrowser() {
       return (
         typeof window !== \\"undefined\\" &&
         window.navigator.product != \\"ReactNative\\"
       );
     },
-    useLazyLoading() {
-      // TODO: Add more checks here, like testing for real web browsers
-      return !!props.lazy && state.isBrowser();
-    },
+    load: false,
   });
 
   const pictureRef = useRef();
@@ -831,7 +831,7 @@ export default function MyComponent(props) {
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            state.load = true;
+            setLoad(true);
             state.scrollListener = null;
             window.removeEventListener(\\"scroll\\", listener);
           }
@@ -1233,7 +1233,7 @@ Object {
     ],
     "jsCode": "Object.assign(state, {});
 ",
-    "tsCode": "useState({});
+    "tsCode": "useStore({});
 ",
   },
 }
@@ -1446,7 +1446,7 @@ Object {
     ],
     "jsCode": "Object.assign(state, {});
 ",
-    "tsCode": "useState({});
+    "tsCode": "useStore({});
 ",
   },
 }
@@ -1961,10 +1961,10 @@ onMount(() => {
 `;
 
 exports[`Builder Stamped 2`] = `
-"import { useState, Show, For } from \\"@builder.io/mitosis\\";
+"import { useStore, Show, For } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     reviews: [],
     name: \\"test\\",
     showReviewPrompt: false,

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -502,21 +502,21 @@ exports[`Html Image 1`] = `
     const state = {
       scrollListener: null,
       imageLoaded: false,
-      load: false,
       setLoaded() {
         state.imageLoaded = true;
         update();
       },
-      isBrowser() {
+      useLazyLoading() {
+        // TODO: Add more checks here, like testing for real web browsers
+        return !!props.lazy && isBrowser();
+      },
+      isBrowser: function isBrowser() {
         return (
           typeof window !== \\"undefined\\" &&
           window.navigator.product != \\"ReactNative\\"
         );
       },
-      useLazyLoading() {
-        // TODO: Add more checks here, like testing for real web browsers
-        return !!props.lazy && state.isBrowser();
-      },
+      load: false,
     };
     let props = {};
     let context = null;
@@ -591,8 +591,7 @@ exports[`Html Image 1`] = `
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            state.load = true;
-            update();
+            setLoad(true);
             state.scrollListener = null;
             update();
             window.removeEventListener(\\"scroll\\", listener);

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -220,7 +220,7 @@ Object {
         const buffer = window.innerHeight / 2;
 
         if (rect.top < window.innerHeight + buffer) {
-          state.load = true;
+          setLoad(true);
           state.scrollListener = null;
           window.removeEventListener('scroll', listener);
         }
@@ -277,7 +277,7 @@ export interface ImageProps {
   },
   "state": Object {
     "imageLoaded": false,
-    "isBrowser": "@builder.io/mitosis/method:isBrowser() {
+    "isBrowser": "@builder.io/mitosis/function:function isBrowser() {
   return typeof window !== 'undefined' && window.navigator.product != 'ReactNative';
 }",
     "load": false,
@@ -287,7 +287,7 @@ export interface ImageProps {
 }",
     "useLazyLoading": "@builder.io/mitosis/method:useLazyLoading() {
   // TODO: Add more checks here, like testing for real web browsers
-  return !!props.lazy && state.isBrowser();
+  return !!props.lazy && isBrowser();
 }",
   },
   "subComponents": Array [],

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -580,10 +580,13 @@ export default function Image(props: ImageProps) {
 
   const [imageLoaded, setImageLoaded] = useState(() => false);
 
-  const [load, setLoad] = useState(() => false);
-
   function setLoaded() {
     setImageLoaded(true);
+  }
+
+  function useLazyLoading() {
+    // TODO: Add more checks here, like testing for real web browsers
+    return !!props.lazy && isBrowser();
   }
 
   function isBrowser() {
@@ -592,10 +595,7 @@ export default function Image(props: ImageProps) {
     );
   }
 
-  function useLazyLoading() {
-    // TODO: Add more checks here, like testing for real web browsers
-    return !!props.lazy && isBrowser();
-  }
+  const [load, setLoad] = useState(() => false);
 
   useEffect(() => {
     if (useLazyLoading()) {

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -865,10 +865,13 @@ export default function Image(props: ImageProps) {
 
   const [imageLoaded, setImageLoaded] = useState(() => false);
 
-  const [load, setLoad] = useState(() => false);
-
   function setLoaded() {
     setImageLoaded(true);
+  }
+
+  function useLazyLoading() {
+    // TODO: Add more checks here, like testing for real web browsers
+    return !!props.lazy && isBrowser();
   }
 
   function isBrowser() {
@@ -877,10 +880,7 @@ export default function Image(props: ImageProps) {
     );
   }
 
-  function useLazyLoading() {
-    // TODO: Add more checks here, like testing for real web browsers
-    return !!props.lazy && isBrowser();
-  }
+  const [load, setLoad] = useState(() => false);
 
   useEffect(() => {
     if (useLazyLoading()) {

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -602,20 +602,20 @@ function Image(props) {
   const state = createMutable({
     scrollListener: null,
     imageLoaded: false,
-    load: false,
     setLoaded() {
       state.imageLoaded = true;
     },
-    isBrowser() {
+    useLazyLoading() {
+      // TODO: Add more checks here, like testing for real web browsers
+      return !!props.lazy && isBrowser();
+    },
+    isBrowser: function isBrowser() {
       return (
         typeof window !== \\"undefined\\" &&
         window.navigator.product != \\"ReactNative\\"
       );
     },
-    useLazyLoading() {
-      // TODO: Add more checks here, like testing for real web browsers
-      return !!props.lazy && state.isBrowser();
-    },
+    load: false,
   });
 
   const pictureRef = useRef();
@@ -629,7 +629,7 @@ function Image(props) {
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            state.load = true;
+            setLoad(true);
             state.scrollListener = null;
             window.removeEventListener(\\"scroll\\", listener);
           }

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -650,15 +650,15 @@ export default class Image {
   setLoaded() {
     this.imageLoaded = true;
   }
-  isBrowser() {
+  useLazyLoading() {
+    // TODO: Add more checks here, like testing for real web browsers
+    return !!this.lazy && isBrowser();
+  }
+  isBrowser = function isBrowser() {
     return (
       typeof window !== \\"undefined\\" && window.navigator.product != \\"ReactNative\\"
     );
-  }
-  useLazyLoading() {
-    // TODO: Add more checks here, like testing for real web browsers
-    return !!this.lazy && this.isBrowser();
-  }
+  };
 
   componentDidLoad() {
     if (this.useLazyLoading()) {
@@ -669,7 +669,7 @@ export default class Image {
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            this.load = true;
+            setLoad(true);
             this.scrollListener = null;
             window.removeEventListener(\\"scroll\\", listener);
           }

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -649,7 +649,7 @@ export default {
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            this.load = true;
+            setLoad(true);
             this.scrollListener = null;
             window.removeEventListener(\\"scroll\\", listener);
           }
@@ -675,15 +675,15 @@ export default {
     setLoaded() {
       this.imageLoaded = true;
     },
-    isBrowser() {
+    useLazyLoading() {
+      // TODO: Add more checks here, like testing for real web browsers
+      return !!this.lazy && isBrowser();
+    },
+    isBrowser: function isBrowser() {
       return (
         typeof window !== \\"undefined\\" &&
         window.navigator.product != \\"ReactNative\\"
       );
-    },
-    useLazyLoading() {
-      // TODO: Add more checks here, like testing for real web browsers
-      return !!this.lazy && this.isBrowser();
     },
     _classStringToObject(str) {
       const obj = {};

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -2453,21 +2453,21 @@ class Image extends HTMLElement {
     this.state = {
       scrollListener: null,
       imageLoaded: false,
-      load: false,
       setLoaded() {
         self.state.imageLoaded = true;
         self.update();
       },
-      isBrowser() {
+      useLazyLoading() {
+        // TODO: Add more checks here, like testing for real web browsers
+        return !!self.props.lazy && isBrowser();
+      },
+      isBrowser: function isBrowser() {
         return (
           typeof window !== \\"undefined\\" &&
           window.navigator.product != \\"ReactNative\\"
         );
       },
-      useLazyLoading() {
-        // TODO: Add more checks here, like testing for real web browsers
-        return !!self.props.lazy && self.state.isBrowser();
-      },
+      load: false,
     };
     if (!this.props) {
       this.props = {};
@@ -2584,8 +2584,7 @@ class Image extends HTMLElement {
           const buffer = window.innerHeight / 2;
 
           if (rect.top < window.innerHeight + buffer) {
-            this.state.load = true;
-            this.update();
+            setLoad(true);
             this.state.scrollListener = null;
             this.update();
             window.removeEventListener(\\"scroll\\", listener);

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -108,11 +108,11 @@ describe('Builder', () => {
 
   test('Regenerate Image', () => {
     const code = dedent`
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
       import { Image } from "@components";
 
       export default function MyComponent(props) {
-        const state = useState({ people: ["Steve", "Sewell"] });
+        const state = useStore({ people: ["Steve", "Sewell"] });
 
         return (
           <div
@@ -149,10 +149,10 @@ describe('Builder', () => {
 
   test('Regenerate Text', () => {
     const code = dedent`
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({ people: ["Steve", "Sewell"] });
+        const state = useStore({ people: ["Steve", "Sewell"] });
 
         return (
           <div
@@ -183,10 +183,10 @@ describe('Builder', () => {
 
   test('Regenerate loop', () => {
     const code = dedent`
-      import { useState, For } from "@builder.io/mitosis";
+      import { useStore, For } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({ people: ["Steve", "Sewell"] });
+        const state = useStore({ people: ["Steve", "Sewell"] });
 
         return (
           <For each={state.people}>

--- a/packages/core/src/__tests__/data/basic-child-component.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-child-component.raw.tsx
@@ -1,9 +1,9 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 import MyBasicComponent from './basic.raw';
 import MyBasicOnMountUpdateComponent from './basic-onMount-update.raw';
 
 export default function MyBasicChildComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
     dev: 'PatrickJS',
   });

--- a/packages/core/src/__tests__/data/basic-context.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-context.raw.tsx
@@ -1,5 +1,5 @@
 import {
-  useState,
+  useStore,
   useContext,
   onInit,
   setContext,
@@ -11,7 +11,7 @@ export default function MyBasicComponent() {
   setContext(Injector, createInjector());
 
   const myService = useContext(MyService);
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-custom-mitosis-package.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-custom-mitosis-package.raw.tsx
@@ -1,7 +1,7 @@
 import { useState } from '@dummy/custom-mitosis';
 
 export default function MyBasicComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-custom-mitosis-package.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-custom-mitosis-package.raw.tsx
@@ -1,4 +1,4 @@
-import { useState } from '@dummy/custom-mitosis';
+import { useStore } from '@dummy/custom-mitosis';
 
 export default function MyBasicComponent() {
   const state = useStore({

--- a/packages/core/src/__tests__/data/basic-for-show.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-for-show.raw.tsx
@@ -1,7 +1,7 @@
-import { useState, For, Show } from '@builder.io/mitosis';
+import { useStore, For, Show } from '@builder.io/mitosis';
 
 export default function MyBasicForShowComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
     names: ['Steve', 'PatrickJS'],
   });

--- a/packages/core/src/__tests__/data/basic-for.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-for.raw.tsx
@@ -1,7 +1,7 @@
-import { useState, For, onMount } from '@builder.io/mitosis';
+import { useStore, For, onMount } from '@builder.io/mitosis';
 
 export default function MyBasicForComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
     names: ['Steve', 'PatrickJS'],
   });

--- a/packages/core/src/__tests__/data/basic-forwardRef-metadata.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-forwardRef-metadata.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMetadata } from '@builder.io/mitosis';
+import { useStore, useRef, useMetadata } from '@builder.io/mitosis';
 
 export interface Props {
   showInput: boolean;
@@ -9,7 +9,7 @@ useMetadata({
   forwardRef: 'inputRef',
 });
 export default function MyBasicForwardRefComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-forwardRef.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-forwardRef.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMetadata } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export interface Props {
   showInput: boolean;
@@ -6,7 +6,7 @@ export interface Props {
 }
 
 export default function MyBasicForwardRefComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-onChange.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-onChange.raw.tsx
@@ -1,7 +1,7 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyBasicComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/packages/core/src/__tests__/data/basic-onMount-update.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-onMount-update.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, onInit, onMount } from '@builder.io/mitosis';
+import { useStore, onInit, onMount } from '@builder.io/mitosis';
 
 export interface Props {
   hi: string;
@@ -6,7 +6,7 @@ export interface Props {
 }
 
 export default function MyBasicOnMountUpdateComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
     names: ['Steve', 'PatrickJS'],
   });

--- a/packages/core/src/__tests__/data/basic-onUpdate-deps.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-onUpdate-deps.raw.tsx
@@ -1,11 +1,11 @@
-import { useState, onUpdate } from '@builder.io/mitosis';
+import { useStore, onUpdate } from '@builder.io/mitosis';
 
 export interface Props {
   name: string;
 }
 
 export default function MyBasicComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
   });
 

--- a/packages/core/src/__tests__/data/basic-onUpdate-return.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-onUpdate-return.raw.tsx
@@ -1,7 +1,7 @@
-import { useState, onUpdate } from '@builder.io/mitosis';
+import { useStore, onUpdate } from '@builder.io/mitosis';
 
 export default function MyBasicOnUpdateReturnComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-outputs-meta.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-outputs-meta.raw.tsx
@@ -1,10 +1,10 @@
-import { useState, useMetadata, onMount } from '@builder.io/mitosis';
+import { useStore, useMetadata, onMount } from '@builder.io/mitosis';
 
 useMetadata({
   outputs: ['onMessage', 'onEvent'],
 });
 export default function MyBasicOutputsComponent(props: any) {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-outputs.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-outputs.raw.tsx
@@ -1,7 +1,7 @@
-import { useState, useMetadata, onMount } from '@builder.io/mitosis';
+import { useStore, useMetadata, onMount } from '@builder.io/mitosis';
 
 export default function MyBasicOutputsComponent(props: any) {
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic-props-destructure.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-props-destructure.raw.tsx
@@ -1,8 +1,8 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 // @ts-ignore
 export default function MyBasicComponent({ children: c, type }) {
-  const state = useState({
+  const state = useStore({
     name: 'Decadef20',
   });
 

--- a/packages/core/src/__tests__/data/basic-props.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-props.raw.tsx
@@ -1,8 +1,8 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 // @ts-ignore
 export default function MyBasicComponent(props) {
-  const state = useState({
+  const state = useStore({
     name: 'Decadef20',
   });
 

--- a/packages/core/src/__tests__/data/basic-ref-assignment.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-ref-assignment.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from '@builder.io/mitosis';
+import { useRef } from '@builder.io/mitosis';
 
 export interface Props {
   showInput: boolean;

--- a/packages/core/src/__tests__/data/basic-ref-usePrevious.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-ref-usePrevious.raw.tsx
@@ -1,4 +1,4 @@
-import { onUpdate, useState, useRef } from '@builder.io/mitosis';
+import { onUpdate, useStore, useRef } from '@builder.io/mitosis';
 
 export interface Props {
   showInput: boolean;
@@ -17,7 +17,7 @@ export function usePrevious<T>(value: T) {
 }
 
 export default function MyPreviousComponent(props: Props) {
-  const state = useState({
+  const state = useStore({
     count: 0,
   });
 

--- a/packages/core/src/__tests__/data/basic-ref.raw.tsx
+++ b/packages/core/src/__tests__/data/basic-ref.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from '@builder.io/mitosis';
+import { useStore, useRef } from '@builder.io/mitosis';
 
 export interface Props {
   showInput: boolean;
@@ -8,7 +8,7 @@ export default function MyBasicRefComponent(props: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const inputNoArgRef = useRef<HTMLLabelElement>(null);
 
-  const state = useState({
+  const state = useStore({
     name: 'PatrickJS',
   });
 

--- a/packages/core/src/__tests__/data/basic.raw.tsx
+++ b/packages/core/src/__tests__/data/basic.raw.tsx
@@ -1,11 +1,11 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export const DEFAULT_VALUES = {
   name: 'Steve',
 };
 
 export default function MyBasicComponent() {
-  const state = useState({
+  const state = useStore({
     name: 'Steve',
     underscore_fn_name() {
       return 'bar';

--- a/packages/core/src/__tests__/data/blocks/builder-render-block.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-block.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, Show, useContext, For } from '@builder.io/mitosis';
+import { useStore, Show, useContext, For } from '@builder.io/mitosis';
 import { getBlockComponentOptions } from '../functions/get-block-component-options';
 import { getBlockProperties } from '../functions/get-block-properties';
 import { getBlockStyles } from '../functions/get-block-styles';
@@ -18,7 +18,7 @@ export type RenderBlockProps = {
 export default function RenderBlock(props: RenderBlockProps) {
   const builderContext = useContext(BuilderContext);
 
-  const state = useState({
+  const state = useStore({
     get component() {
       const componentName = state.useBlock.component?.name;
       if (!componentName) {

--- a/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
@@ -1,7 +1,7 @@
 import {
   Show,
   onMount,
-  useState,
+  useStore,
   For,
   afterUnmount,
 } from '@builder.io/mitosis';
@@ -21,7 +21,7 @@ type RenderContentProps = {
 export function RenderContent(props: RenderContentProps) {
   const content: BuilderContent | undefined =
     props.content || useBuilderData(props.model, props.options);
-  const state = useState({
+  const state = useStore({
     get css() {
       return '';
     },

--- a/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/classname-jsx.raw.tsx
@@ -1,4 +1,4 @@
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -6,7 +6,7 @@ type Props = {
 };
 
 export default function ClassNameCode(props: Props) {
-  const state = useState({
+  const state = useStore({
     bindings: 'a binding',
   });
 

--- a/packages/core/src/__tests__/data/blocks/columns.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/columns.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, For } from '@builder.io/mitosis';
+import { useStore, For } from '@builder.io/mitosis';
 
 type Column = {
   content: any;
@@ -18,7 +18,7 @@ export interface ColumnProps {
 }
 
 export default function Column(props: ColumnProps) {
-  const state = useState({
+  const state = useStore({
     getColumns(): Column[] {
       return props.columns || [];
     },

--- a/packages/core/src/__tests__/data/blocks/custom-code.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/custom-code.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, onMount } from '@builder.io/mitosis';
+import { useStore, useRef, onMount } from '@builder.io/mitosis';
 
 export interface CustomCodeProps {
   code: string;
@@ -8,7 +8,7 @@ export interface CustomCodeProps {
 export default function CustomCode(props: CustomCodeProps) {
   const elem = useRef<HTMLDivElement>(null);
 
-  const state = useState({
+  const state = useStore({
     scriptsInserted: [] as string[],
     scriptsRun: [] as string[],
 

--- a/packages/core/src/__tests__/data/blocks/embed.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/embed.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, onMount } from '@builder.io/mitosis';
+import { useStore, useRef, onMount } from '@builder.io/mitosis';
 
 export interface EmbedProps {
   content: string;
@@ -7,7 +7,7 @@ export interface EmbedProps {
 export default function Embed(props: EmbedProps) {
   const elem = useRef<HTMLDivElement>(null);
 
-  const state = useState({
+  const state = useStore({
     scriptsInserted: [] as string[],
     scriptsRun: [] as string[],
 

--- a/packages/core/src/__tests__/data/blocks/form.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/form.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, Show, For } from '@builder.io/mitosis';
+import { useStore, useRef, Show, For } from '@builder.io/mitosis';
 import { BuilderBlock as BuilderBlockComponent } from '@fake';
 import { BuilderElement, Builder, builder } from '@builder.io/sdk';
 import { BuilderBlocks } from '@fake';
@@ -29,7 +29,7 @@ export interface FormProps {
 export type FormState = 'unsubmitted' | 'sending' | 'success' | 'error';
 
 export default function FormComponent(props: FormProps) {
-  const state = useState({
+  const state = useStore({
     state: 'unsubmitted' as FormState,
     // TODO: separate response and error?
     responseData: null as any,

--- a/packages/core/src/__tests__/data/blocks/img-state.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/img-state.raw.tsx
@@ -1,8 +1,8 @@
-import { useState, For, Show } from '@builder.io/mitosis';
+import { useStore, For, Show } from '@builder.io/mitosis';
 import { Builder } from '@builder.io/sdk';
 
 export default function ImgStateComponent() {
-  const state = useState({
+  const state = useStore({
     canShow: true,
     images: ['http://example.com/qwik.png'],
   });

--- a/packages/core/src/__tests__/data/blocks/multiple-onUpdateWithDeps.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/multiple-onUpdateWithDeps.raw.tsx
@@ -1,7 +1,7 @@
-import { onUpdate, useState } from '@builder.io/mitosis';
+import { onUpdate, useStore } from '@builder.io/mitosis';
 
 export default function MultipleOnUpdateWithDeps() {
-  const state = useState({
+  const state = useStore({
     a: 'a',
     b: 'b',
     c: 'c',

--- a/packages/core/src/__tests__/data/blocks/onInit.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/onInit.raw.tsx
@@ -1,4 +1,4 @@
-import { onInit, useState } from '@builder.io/mitosis';
+import { onInit, useStore } from '@builder.io/mitosis';
 
 type Props = {
   name: string;
@@ -9,7 +9,7 @@ export const defaultValues = {
 };
 
 export default function OnInit(props: Props) {
-  const state = useState({
+  const state = useStore({
     // name: props.name
     // name: defaultValues.name || props.name,
     name: '',

--- a/packages/core/src/__tests__/data/blocks/onUpdateWithDeps.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/onUpdateWithDeps.raw.tsx
@@ -1,7 +1,7 @@
-import { onUpdate, useState } from '@builder.io/mitosis';
+import { onUpdate, useStore } from '@builder.io/mitosis';
 
 export default function OnUpdateWithDeps() {
-  const state = useState({
+  const state = useStore({
     a: 'a',
     b: 'b',
   });

--- a/packages/core/src/__tests__/data/blocks/section-state.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/section-state.raw.tsx
@@ -1,5 +1,4 @@
-import { useState, Show, For } from '@builder.io/mitosis';
-import { number } from 'fp-ts';
+import { useStore, Show, For } from '@builder.io/mitosis';
 
 export interface SectionProps {
   maxWidth?: number;
@@ -8,7 +7,7 @@ export interface SectionProps {
 }
 
 export default function SectionStateComponent(props: SectionProps) {
-  const state = useState({
+  const state = useStore({
     max: 42,
     items: [42],
   });

--- a/packages/core/src/__tests__/data/blocks/shadow-dom.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/shadow-dom.raw.tsx
@@ -1,4 +1,4 @@
-import { useMetadata, useState, onMount, For, Show } from '@builder.io/mitosis';
+import { useMetadata, useStore, onMount, For, Show } from '@builder.io/mitosis';
 
 useMetadata({ isAttachedToShadowDom: true });
 
@@ -8,7 +8,7 @@ type SmileReviewsProps = {
 };
 
 export default function SmileReviews(props: SmileReviewsProps) {
-  const state = useState({
+  const state = useStore({
     reviews: [] as any[],
     name: 'test',
     showReviewPrompt: false,

--- a/packages/core/src/__tests__/data/blocks/stamped-io.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/stamped-io.raw.tsx
@@ -1,4 +1,4 @@
-import { useState, onMount, For, Show } from '@builder.io/mitosis';
+import { useStore, onMount, For, Show } from '@builder.io/mitosis';
 import { kebabCase } from 'lodash';
 import { snakeCase } from 'lodash';
 import { reduce } from 'lodash';
@@ -9,7 +9,7 @@ type SmileReviewsProps = {
 };
 
 export default function SmileReviews(props: SmileReviewsProps) {
-  const state = useState({
+  const state = useStore({
     reviews: [] as any[],
     name: 'test',
     showReviewPrompt: false,

--- a/packages/core/src/__tests__/data/blocks/text.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/text.raw.tsx
@@ -1,5 +1,5 @@
 import { Builder } from '@builder.io/sdk';
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export interface TextProps {
   attributes?: any;
@@ -19,7 +19,7 @@ export default function Text(props: TextProps) {
       props.builderBlock?.bindings?.['options.text'] ||
       props.builderBlock?.bindings?.['text']
     );
-  const state = useState({ name: 'Decadef20' });
+  const state = useStore({ name: 'Decadef20' });
 
   // TODO: Add back dynamic `direction` CSS prop when we add support for some
   //       sort of dynamic CSS

--- a/packages/core/src/constants/hooks.ts
+++ b/packages/core/src/constants/hooks.ts
@@ -1,0 +1,6 @@
+export const HOOKS = {
+  STORE: 'useStore',
+  STATE: 'useState',
+  CONTEXT: 'useContext',
+  REF: 'useRef',
+} as const;

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -190,7 +190,7 @@ export const componentToMitosis =
     ${
       !needsMitosisCoreImport
         ? ''
-        : `import { ${!hasState ? '' : 'useState, '} ${
+        : `import { ${!hasState ? '' : 'useStore, '} ${
             !refs.length ? '' : 'useRef, '
           } ${mitosisComponents.join(', ')} } from '@builder.io/mitosis';`
     }
@@ -214,7 +214,7 @@ export const componentToMitosis =
       ${
         !hasState
           ? ''
-          : `const state = useState(${getStateObjectStringFromComponent(
+          : `const state = useStore(${getStateObjectStringFromComponent(
               json,
             )});`
       }

--- a/packages/core/src/helpers/getters-to-functions.ts
+++ b/packages/core/src/helpers/getters-to-functions.ts
@@ -3,7 +3,7 @@ import { MitosisComponent } from '../types/mitosis-component';
 import traverse from 'traverse';
 
 /**
- * Map getters like `useState({ get foo() { ... }})` from `state.foo` to `foo()`
+ * Map getters like `useStore({ get foo() { ... }})` from `state.foo` to `foo()`
  */
 export const gettersToFunctions = (json: MitosisComponent) => {
   const getterKeys = Object.keys(json.state).filter((item) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,8 @@ export * from './flow';
 export type Context<T> = {};
 
 // These compile away
-export const useState = <T>(obj: T) => obj;
+export const useState: <T>(value: T) => [T, (value: T) => void] = null as any;
+export const useStore = <T>(obj: T) => obj;
 export const useRef = <T>(obj?: null | void | T) => obj as unknown as T;
 export const useContext = <T = { [key: string]: any }>(key: Context<T>): T =>
   null as unknown as T;

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -339,12 +339,12 @@ const componentFunctionToJson = (
           }
         }
         // Legacy format, like:
-        // const state = useState({...})
+        // const state = useStore({...})
         else if (types.isIdentifier(init.callee)) {
-          if (init.callee.name === 'useState') {
+          if (init.callee.name === 'useState' || init.callee.name === 'useStore') {
             const firstArg = init.arguments[0];
             if (types.isObjectExpression(firstArg)) {
-              state = parseStateObject(firstArg);
+              Object.assign(state, parseStateObject(firstArg));
             }
           } else if (init.callee.name === 'useContext') {
             const firstArg = init.arguments[0];

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -20,6 +20,7 @@ import {
 } from '../types/mitosis-component';
 import { MitosisNode } from '../types/mitosis-node';
 import { tryParseJson } from '../helpers/json';
+import { HOOKS } from '../constants/hooks';
 
 const jsxPlugin = require('@babel/plugin-syntax-jsx');
 const tsPreset = require('@babel/preset-typescript');
@@ -342,14 +343,14 @@ const componentFunctionToJson = (
         // const state = useStore({...})
         else if (types.isIdentifier(init.callee)) {
           if (
-            init.callee.name === 'useState' ||
-            init.callee.name === 'useStore'
+            init.callee.name === HOOKS.STATE ||
+            init.callee.name === HOOKS.STORE
           ) {
             const firstArg = init.arguments[0];
             if (types.isObjectExpression(firstArg)) {
               Object.assign(state, parseStateObject(firstArg));
             }
-          } else if (init.callee.name === 'useContext') {
+          } else if (init.callee.name === HOOKS.CONTEXT) {
             const firstArg = init.arguments[0];
             if (
               types.isVariableDeclarator(declaration) &&
@@ -374,7 +375,7 @@ const componentFunctionToJson = (
                 };
               }
             }
-          } else if (init.callee.name === 'useRef') {
+          } else if (init.callee.name === HOOKS.REF) {
             if (types.isIdentifier(declaration.id)) {
               const firstArg = init.arguments[0];
               const varName = declaration.id.name;

--- a/packages/core/src/parsers/jsx.ts
+++ b/packages/core/src/parsers/jsx.ts
@@ -341,7 +341,10 @@ const componentFunctionToJson = (
         // Legacy format, like:
         // const state = useStore({...})
         else if (types.isIdentifier(init.callee)) {
-          if (init.callee.name === 'useState' || init.callee.name === 'useStore') {
+          if (
+            init.callee.name === 'useState' ||
+            init.callee.name === 'useStore'
+          ) {
             const firstArg = init.arguments[0];
             if (types.isObjectExpression(firstArg)) {
               Object.assign(state, parseStateObject(firstArg));

--- a/packages/e2e-app/src/components/my-component.lite.tsx
+++ b/packages/e2e-app/src/components/my-component.lite.tsx
@@ -1,5 +1,5 @@
 import '@builder.io/mitosis/dist/src/jsx-types';
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export interface State {
   list: string[];
@@ -7,7 +7,7 @@ export interface State {
 }
 
 export default function MyComponent(props: any) {
-  const state = useState<State>({
+  const state = useStore<State>({
     list: ['hello', 'world'],
     newItemName: 'New item',
   });

--- a/packages/eslint-plugin/docs/rules/no-assign-props-to-state.md
+++ b/packages/eslint-plugin/docs/rules/no-assign-props-to-state.md
@@ -9,20 +9,20 @@ This rule aims to warn you if you declare a variable with the same name as a sta
 Examples of **incorrect** code for this rule:
 
 ```js
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({ text: props.text });
+  const state = useStore({ text: props.text });
 }
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({ text: null });
+  const state = useStore({ text: null });
 
   onMount(() => {
     state.text = props.text;
@@ -30,7 +30,7 @@ export default function MyComponent(props) {
 }
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     text: null,
     fn1() {
       return foo(props.text);

--- a/packages/eslint-plugin/docs/rules/no-async-methods-on-state.md
+++ b/packages/eslint-plugin/docs/rules/no-async-methods-on-state.md
@@ -10,7 +10,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     async doSomethingAsync(event) {
       return;
     },
@@ -22,7 +22,7 @@ Examples of **correct** code for this rule:
 
 ```js
 export default function MyComponent() {
-  const state = useState({
+  const state = useStore({
     doSomethingAsync(event) {
       void (async function () {
         const response = await fetch();

--- a/packages/eslint-plugin/docs/rules/no-state-destructuring.md
+++ b/packages/eslint-plugin/docs/rules/no-state-destructuring.md
@@ -10,7 +10,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 export default function MyComponent() {
-  const state = useState({ foo: '1' });
+  const state = useStore({ foo: '1' });
 
   onMount(() => {
     const { foo } = state;
@@ -22,7 +22,7 @@ Examples of **correct** code for this rule:
 
 ```js
 export default function MyComponent() {
-  const state = useState({ foo: '1' });
+  const state = useStore({ foo: '1' });
 
   onMount(() => {
     const foo = state.foo;

--- a/packages/eslint-plugin/docs/rules/no-var-declaration-or-assignment-in-component.md
+++ b/packages/eslint-plugin/docs/rules/no-var-declaration-or-assignment-in-component.md
@@ -48,7 +48,7 @@ export default function MyComponent(props) {
 export default function MyComponent(props) {
   const context = useContext(x)
 
-  const state = useState({ name: null })
+  const state = useStore({ name: null })
 
   return (
       <div />

--- a/packages/eslint-plugin/docs/rules/no-var-name-same-as-prop-name.md
+++ b/packages/eslint-plugin/docs/rules/no-var-name-same-as-prop-name.md
@@ -12,7 +12,7 @@ Examples of **incorrect** code for this rule:
 import { useState } from "@builder.io/mitosis";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     getName() {
       const name = props.name
       return name + ' world'
@@ -30,7 +30,7 @@ export default function MyComponent(props) {
 import { useState } from "@builder.io/mitosis";
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     getName() {
       const name = props.name || 'hello'
       return name + ' world'
@@ -48,10 +48,10 @@ export default function MyComponent(props) {
 Examples of **correct** code for this rule:
 
 ```js
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     getName() {
       const name = props.name_;
       return name + ' world';

--- a/packages/eslint-plugin/docs/rules/no-var-name-same-as-prop-name.md
+++ b/packages/eslint-plugin/docs/rules/no-var-name-same-as-prop-name.md
@@ -9,7 +9,7 @@ This rule aims to warn you if you declare a variable with the same name as a pro
 Examples of **incorrect** code for this rule:
 
 ```js
-import { useState } from "@builder.io/mitosis";
+import { useStore } from "@builder.io/mitosis";
 
 export default function MyComponent(props) {
   const state = useStore({
@@ -27,7 +27,7 @@ export default function MyComponent(props) {
 }
 
 
-import { useState } from "@builder.io/mitosis";
+import { useStore } from "@builder.io/mitosis";
 
 export default function MyComponent(props) {
   const state = useStore({

--- a/packages/eslint-plugin/docs/rules/no-var-name-same-as-state-property.md
+++ b/packages/eslint-plugin/docs/rules/no-var-name-same-as-state-property.md
@@ -9,10 +9,10 @@ This rule aims to warn you if you declare a variable with the same name as a sta
 Examples of **incorrect** code for this rule:
 
 ```js
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     foo: 'bar',
   });
 
@@ -25,10 +25,10 @@ export default function MyComponent(props) {
 Examples of **correct** code for this rule:
 
 ```js
-import { useState } from '@builder.io/mitosis';
+import { useStore } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-  const state = useState({
+  const state = useStore({
     foo: 'bar',
   });
 

--- a/packages/eslint-plugin/docs/rules/use-state-var-declarator.md
+++ b/packages/eslint-plugin/docs/rules/use-state-var-declarator.md
@@ -4,13 +4,13 @@ This rule warns about a Mitosis limitation.
 
 ## Rule Details
 
-This rule aims to warn you if you assign useState() to a variable named anything other than state.
+This rule aims to warn you if you assign useStore() to a variable named anything other than state.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 export default function MyComponent(props) {
-  const a = useState();
+  const a = useStore();
 
   return <div />;
 }
@@ -20,7 +20,7 @@ Examples of **correct** code for this rule:
 
 ```js
 export default function MyComponent(props) {
-  const state = useState();
+  const state = useStore();
   return <div />;
 }
 

--- a/packages/eslint-plugin/src/constants/hooks.ts
+++ b/packages/eslint-plugin/src/constants/hooks.ts
@@ -1,0 +1,5 @@
+export const HOOKS = {
+  STORE: 'useStore',
+  STATE: 'useState',
+  CONTEXT: 'useContext',
+} as const;

--- a/packages/eslint-plugin/src/rules/__tests__/no-assign-props-to-state.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-assign-props-to-state.ts
@@ -19,9 +19,9 @@ ruleTester.run('no-assign-props-to-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       export default function MyComponent(props) {
-        const state = useState({ text: null });
+        const state = useStore({ text: null });
 
         onMount(() => {
           state.text = props.text;
@@ -32,11 +32,11 @@ ruleTester.run('no-assign-props-to-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       import { foo } from '../helpers';
 
       export default function MyComponent(props) {
-        const state = useState({ 
+        const state = useStore({ 
           text: null,
           fn1() {
             return foo(props.text);
@@ -56,10 +56,10 @@ ruleTester.run('no-assign-props-to-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
 
       export default function MyComponent(props) {
-        const state = useState({ text: props.text });
+        const state = useStore({ text: props.text });
       }
       `,
       filename: 'file.jsx',
@@ -69,9 +69,9 @@ ruleTester.run('no-assign-props-to-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useuseStoreState } from '@builder.io/mitosis';
       export default function MyComponent(props) {
-        const state = useState({ text: props.text });
+        const state = useStore({ text: props.text });
       }
       `,
       errors: ['"props" can\'t be assign to  to "state" directly'],

--- a/packages/eslint-plugin/src/rules/__tests__/no-assign-props-to-state.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-assign-props-to-state.ts
@@ -69,7 +69,7 @@ ruleTester.run('no-assign-props-to-state', rule, {
     {
       ...opts,
       code: `
-      import { useuseStoreState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       export default function MyComponent(props) {
         const state = useStore({ text: props.text });
       }

--- a/packages/eslint-plugin/src/rules/__tests__/no-async-methods-on-state.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-async-methods-on-state.ts
@@ -19,9 +19,9 @@ ruleTester.run('no-async-methods-on-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       export default function MyComponent() {
-        const state = useState({
+        const state = useStore({
           doSomethingAsync(event) {
             void (async function() {
               const response = await fetch(); /* ... */
@@ -35,9 +35,9 @@ ruleTester.run('no-async-methods-on-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       export default function MyComponent() {
-        const state = useState({
+        const state = useStore({
           async doSomethingAsync(event) {
             const response = await fetch(); /* ... */
           },
@@ -52,10 +52,10 @@ ruleTester.run('no-async-methods-on-state', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
 
       export default function MyComponent() {
-        const state = useState({
+        const state = useStore({
           async doSomethingAsync(event) {
       
             const response = await fetch(); /* ... */

--- a/packages/eslint-plugin/src/rules/__tests__/no-state-destructuring.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-state-destructuring.ts
@@ -20,7 +20,7 @@ ruleTester.run('no-state-destructuring', rule, {
       ...opts,
       code: `
       export default function MyComponent() {
-        const state = useState({ foo: '1' });
+        const state = useStore({ foo: '1' });
       
         onMount(() => {
           const foo = state.foo;
@@ -33,7 +33,7 @@ ruleTester.run('no-state-destructuring', rule, {
       ...opts,
       code: `
       export default function MyComponent() {
-        const state = useState({ foo: '1' });
+        const state = useStore({ foo: '1' });
       
         onMount(() => {
           const { foo } = state;
@@ -48,7 +48,7 @@ ruleTester.run('no-state-destructuring', rule, {
       ...opts,
       code: `
       export default function MyComponent() {
-        const state = useState({ foo: '1' });
+        const state = useStore({ foo: '1' });
       
         onMount(() => {
           const { foo } = state;

--- a/packages/eslint-plugin/src/rules/__tests__/no-var-declaration-or-assignment-in-component.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-var-declaration-or-assignment-in-component.ts
@@ -50,7 +50,7 @@ ruleTester.run('no-var-declaration-or-assignment-in-component', rule, {
       export default function MyComponent(props) {
         const context = useContext(x)
 
-        const state = useState({ name: null })
+        const state = useStore({ name: null })
 
         return (
             <div />

--- a/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-prop-name.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-prop-name.ts
@@ -22,7 +22,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
       import { useState } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
           getName() {
             const name = props.name_ || 'hello'
             return name + ' world'
@@ -44,7 +44,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
       import { useState } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
           getName() {
             const name = props.name || 'hello'
             return name + ' world'
@@ -68,7 +68,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
       import { useState } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
           getName() {
             const name = props.name
             return name + ' world'
@@ -90,7 +90,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
       import { useState } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
           getName() {
             const name = props.name || 'hello'
             return name + ' world'

--- a/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-prop-name.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-prop-name.ts
@@ -19,7 +19,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
     {
       ...opts,
       code: `
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
         const state = useStore({
@@ -41,7 +41,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
     {
       ...opts,
       code: `
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
         const state = useStore({
@@ -65,7 +65,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
     {
       ...opts,
       code: `
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
         const state = useStore({
@@ -87,7 +87,7 @@ ruleTester.run('no-var-name-same-as-prop-name', rule, {
     {
       ...opts,
       code: `
-      import { useState } from "@builder.io/mitosis";
+      import { useStore } from "@builder.io/mitosis";
 
       export default function MyComponent(props) {
         const state = useStore({

--- a/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-state-property.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-var-name-same-as-state-property.ts
@@ -19,10 +19,10 @@ ruleTester.run('no-var-name-same-as-state-property', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
             foo: "bar"
           })
           
@@ -38,10 +38,10 @@ ruleTester.run('no-var-name-same-as-state-property', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
             foo: "bar"
           })
           
@@ -59,10 +59,10 @@ ruleTester.run('no-var-name-same-as-state-property', rule, {
     {
       ...opts,
       code: `
-      import { useState } from '@builder.io/mitosis';
+      import { useStore } from '@builder.io/mitosis';
       
       export default function MyComponent(props) {
-        const state = useState({
+        const state = useStore({
             foo: "bar"
           })
           

--- a/packages/eslint-plugin/src/rules/__tests__/use-state-var-declarator.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/use-state-var-declarator.ts
@@ -30,7 +30,7 @@ ruleTester.run('use-state-var-declarator', rule, {
       ...opts,
       code: `
       export default function MyComponent(props) {
-        const state = useState();
+        const state = useStore();
         return (
             <div />
         );
@@ -53,7 +53,7 @@ ruleTester.run('use-state-var-declarator', rule, {
       ...opts,
       code: `
       export default function MyComponent(props) {
-        const foo = useState();
+        const foo = useStore();
         return (
             <div />
         );
@@ -67,7 +67,7 @@ ruleTester.run('use-state-var-declarator', rule, {
       ...opts,
       code: `
       export default function MyComponent(props) {
-        const a = useState();
+        const a = useStore();
         
         return (
             <div />
@@ -75,7 +75,7 @@ ruleTester.run('use-state-var-declarator', rule, {
       }
     `,
       errors: [
-        'useState should be exclusively assigned to a variable called state',
+        'useStore should be exclusively assigned to a variable called state',
       ],
     },
   ],

--- a/packages/eslint-plugin/src/rules/no-assign-props-to-state.ts
+++ b/packages/eslint-plugin/src/rules/no-assign-props-to-state.ts
@@ -45,7 +45,10 @@ const rule: Rule.RuleModule = {
         if (!types.isImportDeclaration(importSpecifiers)) return;
 
         const useState = importSpecifiers.specifiers.find((n) => {
-          if (types.isImportSpecifier(n) && n.imported.name === 'useState') {
+          if (
+            types.isImportSpecifier(n) &&
+            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+          ) {
             return true;
           }
         });

--- a/packages/eslint-plugin/src/rules/no-assign-props-to-state.ts
+++ b/packages/eslint-plugin/src/rules/no-assign-props-to-state.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types';
 import { Rule } from 'eslint';
+import { HOOKS } from '../constants/hooks';
 import isMitosisPath from '../helpers/isMitosisPath';
 
 // ------------------------------------------------------------------------------
@@ -47,7 +48,7 @@ const rule: Rule.RuleModule = {
         const useState = importSpecifiers.specifiers.find((n) => {
           if (
             types.isImportSpecifier(n) &&
-            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+            (n.imported.name === HOOKS.STATE || n.imported.name === HOOKS.STORE)
           ) {
             return true;
           }

--- a/packages/eslint-plugin/src/rules/no-async-methods-on-state.ts
+++ b/packages/eslint-plugin/src/rules/no-async-methods-on-state.ts
@@ -45,7 +45,10 @@ const rule: Rule.RuleModule = {
         if (!types.isImportDeclaration(importSpecifiers)) return;
 
         const useState = importSpecifiers.specifiers.find((n) => {
-          if (types.isImportSpecifier(n) && n.imported.name === 'useState') {
+          if (
+            types.isImportSpecifier(n) &&
+            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+          ) {
             return true;
           }
         });

--- a/packages/eslint-plugin/src/rules/no-async-methods-on-state.ts
+++ b/packages/eslint-plugin/src/rules/no-async-methods-on-state.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types';
 import { Rule } from 'eslint';
+import { HOOKS } from '../constants/hooks';
 import isMitosisPath from '../helpers/isMitosisPath';
 
 // ------------------------------------------------------------------------------
@@ -47,7 +48,7 @@ const rule: Rule.RuleModule = {
         const useState = importSpecifiers.specifiers.find((n) => {
           if (
             types.isImportSpecifier(n) &&
-            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+            (n.imported.name === HOOKS.STATE || n.imported.name === HOOKS.STORE)
           ) {
             return true;
           }

--- a/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
+++ b/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
@@ -43,7 +43,12 @@ const rule: Rule.RuleModule = {
                     type: 'CallExpression',
                     callee: {
                       type: 'Identifier',
-                      name: when((v) => v === 'useState' || v === 'useContext' || v === 'useStore'),
+                      name: when(
+                        (v) =>
+                          v === 'useState' ||
+                          v === 'useContext' ||
+                          v === 'useStore',
+                      ),
                     },
                   },
                 }),

--- a/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
+++ b/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
@@ -1,4 +1,5 @@
 import { Rule } from 'eslint';
+import { HOOKS } from '../constants/hooks';
 import { match, not, when } from 'ts-pattern';
 import isMitosisPath from '../helpers/isMitosisPath';
 import noOp from '../helpers/noOp';
@@ -45,9 +46,9 @@ const rule: Rule.RuleModule = {
                       type: 'Identifier',
                       name: when(
                         (v) =>
-                          v === 'useState' ||
-                          v === 'useContext' ||
-                          v === 'useStore',
+                          v === HOOKS.STATE ||
+                          v === HOOKS.CONTEXT ||
+                          v === HOOKS.STORE,
                       ),
                     },
                   },

--- a/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
+++ b/packages/eslint-plugin/src/rules/no-var-declaration-or-assignment-in-component.ts
@@ -43,7 +43,7 @@ const rule: Rule.RuleModule = {
                     type: 'CallExpression',
                     callee: {
                       type: 'Identifier',
-                      name: when((v) => v === 'useState' || v === 'useContext'),
+                      name: when((v) => v === 'useState' || v === 'useContext' || v === 'useStore'),
                     },
                   },
                 }),

--- a/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
+++ b/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
@@ -46,7 +46,10 @@ const rule: Rule.RuleModule = {
         if (!types.isImportDeclaration(importSpecifiers)) return;
 
         const useState = importSpecifiers.specifiers.find((n) => {
-          if (types.isImportSpecifier(n) && n.imported.name === 'useState') {
+          if (
+            types.isImportSpecifier(n) &&
+            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+          ) {
             return true;
           }
         });

--- a/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
+++ b/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
@@ -1,6 +1,6 @@
 import * as types from '@babel/types';
 import { Rule } from 'eslint';
-import { HOOKS } from 'src/constants/hooks';
+import { HOOKS } from '../constants/hooks';
 import isMitosisPath from '../helpers/isMitosisPath';
 
 // ------------------------------------------------------------------------------

--- a/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
+++ b/packages/eslint-plugin/src/rules/no-var-name-same-as-state-property.ts
@@ -1,5 +1,6 @@
 import * as types from '@babel/types';
 import { Rule } from 'eslint';
+import { HOOKS } from 'src/constants/hooks';
 import isMitosisPath from '../helpers/isMitosisPath';
 
 // ------------------------------------------------------------------------------
@@ -48,7 +49,7 @@ const rule: Rule.RuleModule = {
         const useState = importSpecifiers.specifiers.find((n) => {
           if (
             types.isImportSpecifier(n) &&
-            (n.imported.name === 'useState' || n.imported.name === 'useStore')
+            (n.imported.name === HOOKS.STATE || n.imported.name === HOOKS.STORE)
           ) {
             return true;
           }

--- a/packages/eslint-plugin/src/rules/use-state-var-declarator.ts
+++ b/packages/eslint-plugin/src/rules/use-state-var-declarator.ts
@@ -1,4 +1,5 @@
 import { Rule } from 'eslint';
+import { HOOKS } from '../constants/hooks';
 import { match, not } from 'ts-pattern';
 import isMitosisPath from '../helpers/isMitosisPath';
 import noOp from '../helpers/noOp';
@@ -39,7 +40,7 @@ const rule: Rule.RuleModule = {
           .with(
             {
               callee: {
-                name: 'useStore',
+                name: HOOKS.STORE,
               },
               parent: {
                 type: 'VariableDeclarator',
@@ -51,8 +52,7 @@ const rule: Rule.RuleModule = {
             (node) => {
               context.report({
                 node: node.parent.id as any,
-                message:
-                  'useStore should be exclusively assigned to a variable called state',
+                message: `${HOOKS.STORE} should be exclusively assigned to a variable called state`,
               });
             },
           )

--- a/packages/eslint-plugin/src/rules/use-state-var-declarator.ts
+++ b/packages/eslint-plugin/src/rules/use-state-var-declarator.ts
@@ -12,7 +12,7 @@ const rule: Rule.RuleModule = {
     type: 'problem',
     docs: {
       description:
-        'disallow assigning useState() to a variable with name other than state.',
+        'disallow assigning useStore() to a variable with name other than state.',
       recommended: true,
     },
   },
@@ -39,7 +39,7 @@ const rule: Rule.RuleModule = {
           .with(
             {
               callee: {
-                name: 'useState',
+                name: 'useStore',
               },
               parent: {
                 type: 'VariableDeclarator',
@@ -52,7 +52,7 @@ const rule: Rule.RuleModule = {
               context.report({
                 node: node.parent.id as any,
                 message:
-                  'useState should be exclusively assigned to a variable called state',
+                  'useStore should be exclusively assigned to a variable called state',
               });
             },
           )

--- a/packages/fiddle/src/constants/templates.ts
+++ b/packages/fiddle/src/constants/templates.ts
@@ -26,7 +26,7 @@ export const templates: { [key: string]: string } = {
     import { useState } from "@builder.io/mitosis";
     
     export default function MyComponent(props) {
-      const state = useState({
+      const state = useStore({
         name: "Steve"
       });
       
@@ -50,7 +50,7 @@ export const templates: { [key: string]: string } = {
     import { useState } from "@builder.io/mitosis";
 
     export default function MyComponent(props) {
-      const state = useState({
+      const state = useStore({
         name: "Steve"
       });
 
@@ -88,12 +88,12 @@ export const templates: { [key: string]: string } = {
   `,
 
   'methods and refs': dedent`
-    import { useState, useRef } from "@builder.io/mitosis";
+    import { useStore, useRef } from "@builder.io/mitosis";
     
     export default function MyComponent(props) {
       const inputRef = useRef();
 
-      const state = useState({
+      const state = useStore({
         name: "Steve",
         onBlur() {
           inputRef.focus()
@@ -128,7 +128,7 @@ export const templates: { [key: string]: string } = {
     import { useState } from "@builder.io/mitosis";
     
     export default function MyComponent(props) {
-      const state = useState({
+      const state = useStore({
         list: ["hello", "world"],
         newItemName: "New item",
         addItem() {


### PR DESCRIPTION
currently, we have a "useState" hook that supports two different formats, based on how it is used. the logic is funky - unlike most code, the behavior actually changes based on how it's written, which is weird and has needed to change

this changes the default name for the object format to useStore({}) and keeps useState() to be used just for the react format. this also fixes types accordingly and allows you to intermix both types of hooks and functions as you please

so now you can do:

```ts
export default function MyCompnent(props) {
  const state = useStore({
    myProperty: 'foo',
    myMethod() { /* ... */ },
    get myGetter() { /* ... */ },
 })
 function myFunction() { /* ... */ }
 const [foo, setFoo] = useState('foobar')

 return <>/*...*/</>
}
```

pros:
 - one name does one thing
 - avoid confusing of react's useState semantics and (part of) ours
 - this is backwards compatible, you can still use useState({...}) for now so you don't have to refactor old code
 - fixes/improves TS types

 cons:
  - `const state = useStore(...)` may cause confusion. state object vs state hooks