### PR TITLE
fix embedded Builder preview URL

### DIFF
--- a/packages/fiddle/src/components/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle.tsx
@@ -147,7 +147,6 @@ const AlphaPreviewMessage = () => (
 const builderOptions = {
   useDefaultStyles: false,
   hideAnimateTab: true,
-  previewUrl: 'https://jsx-lite.builder.io/preview.html',
 };
 
 const BuilderEditor = adapt('builder-editor');


### PR DESCRIPTION
when we took down the firebase project it broke the
URL the preview was loading

note that the Builder preview still isn't getting content updates, so that's a separate issue