### PR TITLE
chore: fix save artifacts workflow; deduplicate workflow;

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,14 +1,14 @@
+# This workflow runs when new change is pushed to repo OR when a new PR is created
+# It performs all of the tests to make sure everything is good.
+
 ---
 name: PR Runner
 
 on:
   push:
-    branches:
-      - main
 
+on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   checks:

--- a/.github/workflows/save-build-artifacts.yml
+++ b/.github/workflows/save-build-artifacts.yml
@@ -1,10 +1,13 @@
+# This workflow runs when new change is pushed to the main repo.
+# It should only save artifacts and nothing else so that it is fast.
+
 name: Save artifact on branch push
 
 on:
   push:
 
 jobs:
-  build:
+  save-build-artifacts:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,21 +24,6 @@ jobs:
 
       - name: Build
         run: yarn ci:build
-
-      - name: Run tests
-        run: yarn ci:test
-
-      - name: Run prettier
-        run: yarn ci:lint
-
-      - name: Install browsers for Playwright
-        run: yarn ci:e2e-prep
-
-      - name: Build E2E tests
-        run: yarn ci:e2e-build
-
-      - name: Run E2E tests
-        run: yarn ci:e2e
 
       - name: save artifact
         env:

--- a/scripts/mitosis-save-artifacts.ts
+++ b/scripts/mitosis-save-artifacts.ts
@@ -6,7 +6,7 @@ const srcRepoRef = 'https://github.com/BuilderIO/mitosis/commit/';
 const root = __dirname + '/..';
 const packages_core = root + '/packages/core';
 const mitosis_build_artifacts = packages_core + '/mitosis-build';
-const buildFiles = ['CHANGELOG.md', 'package.json', 'README.md', 'dist'];
+const buildFiles = ['CHANGELOG.md', 'package.json', 'dist'];
 
 (async () => {
   await $('rm', '-rf', mitosis_build_artifacts);
@@ -43,9 +43,7 @@ const buildFiles = ['CHANGELOG.md', 'package.json', 'README.md', 'dist'];
   const dstSHA = await $('git', 'rev-parse', 'HEAD');
   console.log('##############################################################');
   console.log('##############################################################');
-  console.log(
-    `### https://github.com/BuilderIO/mitosis-build/commit/${dstSHA}`,
-  );
+  console.log(`### https://github.com/BuilderIO/mitosis-build/commit/${dstSHA}`);
   console.log('##############################################################');
   console.log('##############################################################');
   await $('git', 'push', repo, `HEAD:${branch}`);


### PR DESCRIPTION
- Fix the save artifacts workflow by removing `README.md` file which is no longer present.
- Rename save artifacts workflow to `save-build-artifacts` to make it more clear its purpose.
- Rename `pr-runner` to `checks` to make it more clear its purpose. It runs on both PRs and merge to main repo

## Description

Add a short description of:
- what changes you made, 
- why you made them, and 
- any other context that you think might be helpful for someone to better understand what is contained in this pull request. 

This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

