### PR TITLE
Fix: Transpiler

### DIFF
--- a/packages/cli/src/build/helpers/transpile.ts
+++ b/packages/cli/src/build/helpers/transpile.ts
@@ -41,7 +41,7 @@ export const transpile = async ({
        * Collisions occur between TSX and TS Generic syntax. We want to only provide this loader config if the file is
        * a mitosis `.lite.tsx` file.
        */
-      ...(path.endsWith('.tsx') ? { loader: 'tsx' } : {}),
+      loader: path.endsWith('.tsx') ? 'tsx' : 'ts',
       target: 'es6',
     });
 

--- a/packages/cli/src/build/helpers/transpile.ts
+++ b/packages/cli/src/build/helpers/transpile.ts
@@ -37,7 +37,11 @@ export const transpile = async ({
     useContent = useContent.replace(/getTarget\(\)/g, `"${target}"`);
     const output = await esbuild.transform(useContent, {
       format: format,
-      loader: 'tsx',
+      /**
+       * Collisions occur between TSX and TS Generic syntax. We want to only provide this loader config if the file is
+       * a mitosis `.lite.tsx` file.
+       */
+      ...(path.endsWith('.tsx') ? { loader: 'tsx' } : {}),
       target: 'es6',
     });
 

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -55,12 +55,12 @@ export interface ToReactOptions extends BaseTranspilerOptions {
 }
 
 /**
- * If the root Mitosis component only has 1 child, and it is a `Show` node, then we need to wrap it in a fragment.
+ * If the root Mitosis component only has 1 child, and it is a `Show`/`For` node, then we need to wrap it in a fragment.
  * Otherwise, we end up with invalid React render code.
  *
  */
-const isRootShowNode = (json: MitosisComponent) =>
-  json.children.length === 1 && ['Show'].includes(json.children[0].name);
+const isRootSpecialNode = (json: MitosisComponent) =>
+  json.children.length === 1 && ['Show', 'For'].includes(json.children[0].name);
 
 const wrapInFragment = (json: MitosisComponent | MitosisNode) => json.children.length !== 1;
 
@@ -557,7 +557,7 @@ const _componentToReact = (
   const wrap =
     wrapInFragment(json) ||
     (componentHasStyles && stylesType === 'styled-jsx') ||
-    isRootShowNode(json);
+    isRootSpecialNode(json);
 
   const [hasStateArgument, refsString] = getRefsString(json, allRefs, options);
   const nativeStyles =


### PR DESCRIPTION
## Description

- Add Fragments in React for root `For` node
- Only use esbuild `.tsx` loader for `.tsx` files, to avoid collisions in TS/TSX syntax.