### PR TITLE
fix: support old query params on fiddle

### DIFF
--- a/packages/fiddle/src/functions/get-query-param.ts
+++ b/packages/fiddle/src/functions/get-query-param.ts
@@ -2,7 +2,8 @@ import { decompressFromBase64 } from 'lz-string';
 
 export const getQueryParam = (name: string): string | null => {
   const urlParams = new URLSearchParams(window.location.search);
-  const compressedValue = urlParams.get(name);
+  const rawValue = urlParams.get(name);
+  const decompressedValue = decompressFromBase64(rawValue);
 
-  return decompressFromBase64(compressedValue);
+  return decompressedValue ?? rawValue;
 };


### PR DESCRIPTION
Fixes:

_Would be nice to get an update so old links work too - we have those sitting around in github issues to reproduce issues so would be nice to not lose that_

_Originally posted by @steve8708 in https://github.com/BuilderIO/mitosis/pull/578#issuecomment-1190728179_