### PR TITLE
fix(core): side effect imports

### DIFF
--- a/packages/core/src/helpers/render-imports.test.ts
+++ b/packages/core/src/helpers/render-imports.test.ts
@@ -15,4 +15,19 @@ describe('renderImport', () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  test('Adds correctly a side-effect import', () => {
+    const data = [
+      {
+        imports: {},
+        path: '../render-blocks.scss',
+      },
+    ];
+    const output = renderImport({
+      theImport: data[0],
+      target: 'react',
+      asyncComponentImports: false,
+    });
+    expect(output).toEqual("import '../render-blocks.scss';");
+  });
 });

--- a/packages/core/src/helpers/render-imports.ts
+++ b/packages/core/src/helpers/render-imports.ts
@@ -119,7 +119,7 @@ export const renderImport = ({
     }
   }
 
-  return `import ${importValue} from '${path}';`;
+  return importValue ? `import ${importValue} from '${path}';` : `import '${path}';`;
 };
 
 export const renderImports = ({


### PR DESCRIPTION
## Description

Changed the template literal of the renderImport function to allow side-effect imports (e.g. `import 'styles.scss'`).
Made this changes to fix #580 .


