### PR TITLE
Add return outside of function.

### DIFF
--- a/packages/core/src/helpers/babel-transform.ts
+++ b/packages/core/src/helpers/babel-transform.ts
@@ -14,6 +14,7 @@ export const babelTransform = <VisitorContextType = any>(
     configFile: false,
     babelrc: false,
     presets: [[tsPreset, { isTSX: true, allExtensions: true }]],
+    parserOpts: { allowReturnOutsideFunction: true },
     plugins: [[decorators, { legacy: true }], jsxPlugin, ...(visitor ? [() => ({ visitor })] : [])],
   });
 };


### PR DESCRIPTION


  onUpdate(() => {
    console.log("dddhi");
    return () => {
      console.log("hello");
    };
  }, [rootRef, otherRef]);

Causes an error  SyntaxError: unknown: 'return' outside of function. (3:2) 

This "fixes" it. Angular will need to be updated.