### PR TITLE
fix: added import of react for react generated components

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -877,7 +877,8 @@ export default function MyComponent(props) {
 `;
 
 exports[`Builder Regenerate Image 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 import { Image } from \\"@components\\";
 
 export default function MyComponent(props) {

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -431,7 +431,8 @@ Object {
 `;
 
 exports[`Context Use and set context in complex components 2`] = `
-"import { useContext } from \\"react\\";
+"import * as React from \\"react\\";
+import { useContext } from \\"react\\";
 
 export type RenderBlockProps = {
   block: BuilderBlock;
@@ -656,7 +657,8 @@ Object {
 `;
 
 exports[`Context Use and set context in components 2`] = `
-"import { useContext } from \\"react\\";
+"import * as React from \\"react\\";
+import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
 

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`React AdvancedRef 1`] = `
-"import { useState, useRef, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -65,7 +66,8 @@ export default function MyBasicRefComponent(props: Props) {
 `;
 
 exports[`React Basic 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 export const DEFAULT_VALUES = {
   name: \\"Steve\\",
@@ -99,7 +101,8 @@ export default function MyBasicComponent(props: { id: string }) {
 `;
 
 exports[`React Basic Context 1`] = `
-"import { useState, useContext, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useContext, useEffect } from \\"react\\";
 import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
 
 export default function MyBasicComponent(props) {
@@ -134,7 +137,8 @@ export default function MyBasicComponent(props) {
 `;
 
 exports[`React Basic OnMount Update 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export interface Props {
   hi: string;
@@ -165,7 +169,8 @@ export default function MyBasicOnMountUpdateComponent(props: Props) {
 `;
 
 exports[`React Basic Outputs 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicOutputsComponent(props: any) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
@@ -181,7 +186,8 @@ export default function MyBasicOutputsComponent(props: any) {
 `;
 
 exports[`React Basic Outputs Meta 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicOutputsComponent(props: any) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
@@ -197,7 +203,8 @@ export default function MyBasicOutputsComponent(props: any) {
 `;
 
 exports[`React BasicChildComponent 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 import MyBasicComponent from \\"./basic.raw\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
 
@@ -220,7 +227,8 @@ export default function MyBasicChildComponent(props) {
 `;
 
 exports[`React BasicFor 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicForComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
@@ -253,7 +261,8 @@ export default function MyBasicForComponent(props) {
 `;
 
 exports[`React BasicRef 1`] = `
-"import { useState, useRef } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -313,7 +322,8 @@ export default function MyBasicRefComponent(props: Props) {
 `;
 
 exports[`React BasicRefAssignment 1`] = `
-"import { useRef } from \\"react\\";
+"import * as React from \\"react\\";
+import { useRef } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -337,7 +347,8 @@ export default function MyBasicRefAssignmentComponent(props: Props) {
 `;
 
 exports[`React BasicRefPrevious 1`] = `
-"import { useState, useRef, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -381,7 +392,9 @@ export default function MyPreviousComponent(props: Props) {
 `;
 
 exports[`React Button 1`] = `
-"export interface ButtonProps {
+"import * as React from \\"react\\";
+
+export interface ButtonProps {
   attributes?: any;
   text?: string;
   link?: string;
@@ -417,7 +430,9 @@ export default function Button(props: ButtonProps) {
 `;
 
 exports[`React Columns 1`] = `
-"type Column = {
+"import * as React from \\"react\\";
+
+type Column = {
   content: any; // TODO: Implement this when support for dynamic CSS lands
 
   width?: number;
@@ -492,7 +507,9 @@ export default function Column(props: ColumnProps) {
 `;
 
 exports[`React ContentSlotHtml 1`] = `
-"type Props = {
+"import * as React from \\"react\\";
+
+type Props = {
   [key: string]: string | JSX.Element;
   slotTesting: JSX.Element;
 };
@@ -514,7 +531,9 @@ export default function ContentSlotCode(props: Props) {
 `;
 
 exports[`React ContentSlotJSX 1`] = `
-"type Props = {
+"import * as React from \\"react\\";
+
+type Props = {
   [key: string]: string | JSX.Element;
 };
 
@@ -535,7 +554,8 @@ export default function ContentSlotJsxCode(props: Props) {
 `;
 
 exports[`React CustomCode 1`] = `
-"import { useState, useRef, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -608,7 +628,8 @@ export default function CustomCode(props: CustomCodeProps) {
 `;
 
 exports[`React Embed 1`] = `
-"import { useState, useRef, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -681,7 +702,8 @@ export default function CustomCode(props: CustomCodeProps) {
 `;
 
 exports[`React Form 1`] = `
-"import { useState, useRef } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef } from \\"react\\";
 
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
 export interface FormProps {
@@ -979,7 +1001,8 @@ export default function FormComponent(props: FormProps) {
 `;
 
 exports[`React Image 1`] = `
-"import { useState, useRef, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useRef, useEffect } from \\"react\\";
 
 // TODO: AMP Support?
 export interface ImageProps {
@@ -1098,7 +1121,8 @@ export default function Image(props: ImageProps) {
 `;
 
 exports[`React Image State 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 export default function ImgStateComponent(props) {
   const [canShow, setCanShow] = useState(() => true);
@@ -1119,7 +1143,9 @@ export default function ImgStateComponent(props) {
 `;
 
 exports[`React Img 1`] = `
-"export interface ImgProps {
+"import * as React from \\"react\\";
+
+export interface ImgProps {
   attributes?: any;
   imgSrc?: string;
   altText?: string;
@@ -1156,7 +1182,9 @@ export default function ImgComponent(props: ImgProps) {
 `;
 
 exports[`React Input 1`] = `
-"export interface FormInputProps {
+"import * as React from \\"react\\";
+
+export interface FormInputProps {
   type?: string;
   attributes?: any;
   name?: string;
@@ -1190,7 +1218,9 @@ export default function FormInputComponent(props: FormInputProps) {
 `;
 
 exports[`React RawText 1`] = `
-"export interface RawTextProps {
+"import * as React from \\"react\\";
+
+export interface RawTextProps {
   attributes?: any;
   text?: string; // builderBlock?: any;
 }
@@ -1207,7 +1237,8 @@ export default function RawText(props: RawTextProps) {
 `;
 
 exports[`React Remove Internal mitosis package 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 export default function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
@@ -1223,7 +1254,9 @@ export default function MyBasicComponent(props) {
 `;
 
 exports[`React Section 1`] = `
-"export interface SectionProps {
+"import * as React from \\"react\\";
+
+export interface SectionProps {
   maxWidth?: number;
   attributes?: any;
   children?: any;
@@ -1249,7 +1282,9 @@ export default function SectionComponent(props: SectionProps) {
 `;
 
 exports[`React Select 1`] = `
-"export interface FormSelectProps {
+"import * as React from \\"react\\";
+
+export interface FormSelectProps {
   options?: {
     name?: string;
     value: string;
@@ -1287,7 +1322,9 @@ export default function SelectComponent(props: FormSelectProps) {
 `;
 
 exports[`React SlotHtml 1`] = `
-"type Props = {
+"import * as React from \\"react\\";
+
+type Props = {
   [key: string]: string;
 };
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
@@ -1303,7 +1340,9 @@ export default function SlotCode(props: Props) {
 `;
 
 exports[`React SlotJsx 1`] = `
-"type Props = {
+"import * as React from \\"react\\";
+
+type Props = {
   [key: string]: string;
 };
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
@@ -1319,7 +1358,8 @@ export default function SlotCode(props: Props) {
 `;
 
 exports[`React Stamped.io 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 type SmileReviewsProps = {
   productId: string;
@@ -1429,7 +1469,9 @@ export default function SmileReviews(props: SmileReviewsProps) {
 `;
 
 exports[`React Submit 1`] = `
-"export interface ButtonProps {
+"import * as React from \\"react\\";
+
+export interface ButtonProps {
   attributes?: any;
   text?: string;
 }
@@ -1445,7 +1487,8 @@ export default function SubmitButton(props: ButtonProps) {
 `;
 
 exports[`React Text 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 export interface TextProps {
   attributes?: any;
@@ -1480,7 +1523,9 @@ export default function Text(props: TextProps) {
 `;
 
 exports[`React Textarea 1`] = `
-"export interface TextareaProps {
+"import * as React from \\"react\\";
+
+export interface TextareaProps {
   attributes?: any;
   name?: string;
   value?: string;
@@ -1503,7 +1548,9 @@ export default function Textarea(props: TextareaProps) {
 `;
 
 exports[`React Video 1`] = `
-"export interface VideoProps {
+"import * as React from \\"react\\";
+
+export interface VideoProps {
   attributes?: any;
   video?: string;
   autoPlay?: boolean;
@@ -1557,7 +1604,8 @@ export default function Video(props: VideoProps) {
 `;
 
 exports[`React basicForwardRef 1`] = `
-"import { useState, forwardRef } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, forwardRef } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -1591,7 +1639,8 @@ export default forwardRef<Props[\\"inputRef\\"]>(
 `;
 
 exports[`React basicForwardRefMetadata 1`] = `
-"import { useState, forwardRef } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, forwardRef } from \\"react\\";
 
 export interface Props {
   showInput: boolean;
@@ -1625,7 +1674,8 @@ export default forwardRef<Props[\\"inputRef\\"]>(
 `;
 
 exports[`React basicOnUpdateReturn 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MyBasicOnUpdateReturnComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
@@ -1658,7 +1708,9 @@ export default function MyBasicOnUpdateReturnComponent(props) {
 `;
 
 exports[`React class + ClassName + css 1`] = `
-"export default function MyBasicComponent(props) {
+"import * as React from \\"react\\";
+
+export default function MyBasicComponent(props) {
   return (
     <>
       <div className=\\"test2 test div\\">
@@ -1676,7 +1728,9 @@ exports[`React class + ClassName + css 1`] = `
 `;
 
 exports[`React class + css 1`] = `
-"export default function MyBasicComponent(props) {
+"import * as React from \\"react\\";
+
+export default function MyBasicComponent(props) {
   return (
     <>
       <div className=\\"test div\\">
@@ -1694,7 +1748,9 @@ exports[`React class + css 1`] = `
 `;
 
 exports[`React className + css 1`] = `
-"export default function MyBasicComponent(props) {
+"import * as React from \\"react\\";
+
+export default function MyBasicComponent(props) {
   return (
     <>
       <div className=\\"test div\\">
@@ -1712,7 +1768,8 @@ exports[`React className + css 1`] = `
 `;
 
 exports[`React className 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -1734,7 +1791,8 @@ export default function ClassNameCode(props: Props) {
 `;
 
 exports[`React classState 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 export default function MyBasicComponent(props) {
   const [classState, setClassState] = useState(() => \\"testClassName\\");
@@ -1760,7 +1818,8 @@ export default function MyBasicComponent(props) {
 `;
 
 exports[`React multipleOnUpdate 1`] = `
-"import { useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useEffect } from \\"react\\";
 
 export default function MultipleOnUpdate(props) {
   useEffect(() => {
@@ -1776,7 +1835,8 @@ export default function MultipleOnUpdate(props) {
 `;
 
 exports[`React multipleOnUpdateWithDeps 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function MultipleOnUpdateWithDeps(props) {
   const [a, setA] = useState(() => \\"a\\");
@@ -1808,7 +1868,9 @@ export default function MultipleOnUpdateWithDeps(props) {
 `;
 
 exports[`React nestedShow 1`] = `
-"interface Props {
+"import * as React from \\"react\\";
+
+interface Props {
   conditionA: boolean;
   conditionB: boolean;
 }
@@ -1836,7 +1898,8 @@ export default function NestedShow(props: Props) {
 `;
 
 exports[`React onInit & onMount 1`] = `
-"import { useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useEffect } from \\"react\\";
 
 export default function OnInit(props) {
   useEffect(() => {
@@ -1853,7 +1916,8 @@ export default function OnInit(props) {
 `;
 
 exports[`React onInit 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 type Props = {
   name: string;
@@ -1882,7 +1946,8 @@ export default function OnInit(props: Props) {
 `;
 
 exports[`React onMount 1`] = `
-"import { useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useEffect } from \\"react\\";
 
 export default function Comp(props) {
   useEffect(() => {
@@ -1901,7 +1966,8 @@ export default function Comp(props) {
 `;
 
 exports[`React onUpdate 1`] = `
-"import { useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useEffect } from \\"react\\";
 
 export default function OnUpdate(props) {
   useEffect(() => {
@@ -1914,7 +1980,8 @@ export default function OnUpdate(props) {
 `;
 
 exports[`React onUpdateWithDeps 1`] = `
-"import { useState, useEffect } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState, useEffect } from \\"react\\";
 
 export default function OnUpdateWithDeps(props) {
   const [a, setA] = useState(() => \\"a\\");
@@ -1931,7 +1998,9 @@ export default function OnUpdateWithDeps(props) {
 `;
 
 exports[`React preserveExportOrLocalStatement 1`] = `
-"type Types = {
+"import * as React from \\"react\\";
+
+type Types = {
   s: any[];
 };
 interface IPost {
@@ -1951,7 +2020,9 @@ export default function MyBasicComponent(props: { id: string }) {
 `;
 
 exports[`React preserveTyping 1`] = `
-"export type A = \\"test\\";
+"import * as React from \\"react\\";
+
+export type A = \\"test\\";
 type B = \\"test2\\";
 export interface C {
   n: \\"test\\";
@@ -1975,7 +2046,8 @@ export default function MyBasicComponent(props: {
 `;
 
 exports[`React propsDestructure 1`] = `
-"import { useState } from \\"react\\";
+"import * as React from \\"react\\";
+import { useState } from \\"react\\";
 
 type Props = {
   children: any;
@@ -1997,7 +2069,9 @@ export default function MyBasicComponent(props: Props) {
 `;
 
 exports[`React propsInterface 1`] = `
-"interface Person {
+"import * as React from \\"react\\";
+
+interface Person {
   name: string;
   age?: number;
 }
@@ -2014,7 +2088,9 @@ export default function MyBasicComponent(props: Person | never) {
 `;
 
 exports[`React propsType 1`] = `
-"type Person = {
+"import * as React from \\"react\\";
+
+type Person = {
   name: string;
   age?: number;
 };
@@ -2031,7 +2107,9 @@ export default function MyBasicComponent(props: Person) {
 `;
 
 exports[`React rootShow 1`] = `
-"export default function RenderStyles(props: { foo: string }) {
+"import * as React from \\"react\\";
+
+export default function RenderStyles(props: { foo: string }) {
   return (
     <>
       {props.foo === \\"bar\\" ? (
@@ -2048,7 +2126,9 @@ exports[`React rootShow 1`] = `
 `;
 
 exports[`React self-referencing component 1`] = `
-"export default function MyComponent(props: any) {
+"import * as React from \\"react\\";
+
+export default function MyComponent(props: any) {
   return (
     <div>
       {props.name}
@@ -2065,7 +2145,9 @@ exports[`React self-referencing component 1`] = `
 `;
 
 exports[`React self-referencing component with children 1`] = `
-"export default function MyComponent(props: any) {
+"import * as React from \\"react\\";
+
+export default function MyComponent(props: any) {
   return (
     <div>
       {props.name}
@@ -2086,7 +2168,9 @@ exports[`React self-referencing component with children 1`] = `
 `;
 
 exports[`React showWithFor 1`] = `
-"interface Props {
+"import * as React from \\"react\\";
+
+interface Props {
   conditionA: boolean;
   items: string[];
 }
@@ -2110,7 +2194,8 @@ export default function NestedShow(props: Props) {
 `;
 
 exports[`React stamped 1`] = `
-"import styled from \\"styled-components\\";
+"import * as React from \\"react\\";
+import styled from \\"styled-components\\";
 import { useState, useEffect } from \\"react\\";
 
 type SmileReviewsProps = {

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -571,7 +571,7 @@ const _componentToReact = (
   let str = dedent`
   ${
     options.type !== 'native'
-      ? 'import * as React from \'react\';'
+      ? "import * as React from 'react';"
       : `
   import * as React from 'react';
   import { View, StyleSheet, Image, Text } from 'react-native';

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -571,7 +571,7 @@ const _componentToReact = (
   let str = dedent`
   ${
     options.type !== 'native'
-      ? ''
+      ? 'import * as React from \'react\';'
       : `
   import * as React from 'react';
   import { View, StyleSheet, Image, Text } from 'react-native';


### PR DESCRIPTION
## Description

Closing issue [609](https://github.com/BuilderIO/mitosis/issues/609)

Added import of React lib to generated components for react.
Without it, generated components after importing them from package are not working due to 
```
ReferenceError: React is not defined
```

More info in linked issue.


