### PR TITLE
Fix/angular this

### DIFF
--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -246,7 +246,7 @@ export declare namespace JSX {
     | 'video'
     | 'worker';
 
-  interface HTMLAttributes<T> extends DOMAttributes<T> {
+  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     // Special attributes
     key?: string | boolean | number;
 
@@ -304,6 +304,9 @@ export declare namespace JSX {
     itemRef?: string;
     exportParts?: string;
     inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
+
+    // WAI-ARIA
+    role?: AriaRole | undefined;
   }
 
   // HTML Elements
@@ -821,11 +824,14 @@ export declare namespace JSX {
 
   type SVGUnits = 'userSpaceOnUse' | 'objectBoundingBox';
 
-  interface CoreSVGAttributes<T> extends DOMAttributes<T> {
+  interface CoreSVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     id?: string;
     lang?: string;
     tabIndex?: number | string;
     tabindex?: number | string;
+
+    // Other HTML properties supported by SVG elements in browsers
+    role?: AriaRole | undefined;
   }
 
   interface StylableSVGAttributes {
@@ -1831,6 +1837,296 @@ export declare namespace JSX {
     tspan: TSpanSVGAttributes<SVGTSpanElement>;
     use: UseSVGAttributes<SVGUseElement>;
     view: ViewSVGAttributes<SVGViewElement>;
+  }
+
+  type AriaRole =
+    | 'alert'
+    | 'alertdialog'
+    | 'application'
+    | 'article'
+    | 'banner'
+    | 'button'
+    | 'cell'
+    | 'checkbox'
+    | 'columnheader'
+    | 'combobox'
+    | 'complementary'
+    | 'contentinfo'
+    | 'definition'
+    | 'dialog'
+    | 'directory'
+    | 'document'
+    | 'feed'
+    | 'figure'
+    | 'form'
+    | 'grid'
+    | 'gridcell'
+    | 'group'
+    | 'heading'
+    | 'img'
+    | 'link'
+    | 'list'
+    | 'listbox'
+    | 'listitem'
+    | 'log'
+    | 'main'
+    | 'marquee'
+    | 'math'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'menuitemcheckbox'
+    | 'menuitemradio'
+    | 'navigation'
+    | 'none'
+    | 'note'
+    | 'option'
+    | 'presentation'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'region'
+    | 'row'
+    | 'rowgroup'
+    | 'rowheader'
+    | 'scrollbar'
+    | 'search'
+    | 'searchbox'
+    | 'separator'
+    | 'slider'
+    | 'spinbutton'
+    | 'status'
+    | 'switch'
+    | 'tab'
+    | 'table'
+    | 'tablist'
+    | 'tabpanel'
+    | 'term'
+    | 'textbox'
+    | 'timer'
+    | 'toolbar'
+    | 'tooltip'
+    | 'tree'
+    | 'treegrid'
+    | 'treeitem'
+    | (string & {});
+
+  type Booleanish = boolean | 'true' | 'false';
+
+  interface AriaAttributes {
+    /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+    'aria-activedescendant'?: string | undefined;
+    /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+    'aria-atomic'?: Booleanish | undefined;
+    /**
+     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+     * presented if they are made.
+     */
+    'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined;
+    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+    'aria-busy'?: Booleanish | undefined;
+    /**
+     * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+     * @see aria-pressed @see aria-selected.
+     */
+    'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+    /**
+     * Defines the total number of columns in a table, grid, or treegrid.
+     * @see aria-colindex.
+     */
+    'aria-colcount'?: number | undefined;
+    /**
+     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+     * @see aria-colcount @see aria-colspan.
+     */
+    'aria-colindex'?: number | undefined;
+    /**
+     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+     * @see aria-colindex @see aria-rowspan.
+     */
+    'aria-colspan'?: number | undefined;
+    /**
+     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+     * @see aria-owns.
+     */
+    'aria-controls'?: string | undefined;
+    /** Indicates the element that represents the current item within a container or set of related elements. */
+    'aria-current'?:
+      | boolean
+      | 'false'
+      | 'true'
+      | 'page'
+      | 'step'
+      | 'location'
+      | 'date'
+      | 'time'
+      | undefined;
+    /**
+     * Identifies the element (or elements) that describes the object.
+     * @see aria-labelledby
+     */
+    'aria-describedby'?: string | undefined;
+    /**
+     * Identifies the element that provides a detailed, extended description for the object.
+     * @see aria-describedby.
+     */
+    'aria-details'?: string | undefined;
+    /**
+     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+     * @see aria-hidden @see aria-readonly.
+     */
+    'aria-disabled'?: Booleanish | undefined;
+    /**
+     * Indicates what functions can be performed when a dragged object is released on the drop target.
+     * @deprecated in ARIA 1.1
+     */
+    'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined;
+    /**
+     * Identifies the element that provides an error message for the object.
+     * @see aria-invalid @see aria-describedby.
+     */
+    'aria-errormessage'?: string | undefined;
+    /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+    'aria-expanded'?: Booleanish | undefined;
+    /**
+     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+     * allows assistive technology to override the general default of reading in document source order.
+     */
+    'aria-flowto'?: string | undefined;
+    /**
+     * Indicates an element's "grabbed" state in a drag-and-drop operation.
+     * @deprecated in ARIA 1.1
+     */
+    'aria-grabbed'?: Booleanish | undefined;
+    /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+    'aria-haspopup'?:
+      | boolean
+      | 'false'
+      | 'true'
+      | 'menu'
+      | 'listbox'
+      | 'tree'
+      | 'grid'
+      | 'dialog'
+      | undefined;
+    /**
+     * Indicates whether the element is exposed to an accessibility API.
+     * @see aria-disabled.
+     */
+    'aria-hidden'?: Booleanish | undefined;
+    /**
+     * Indicates the entered value does not conform to the format expected by the application.
+     * @see aria-errormessage.
+     */
+    'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined;
+    /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+    'aria-keyshortcuts'?: string | undefined;
+    /**
+     * Defines a string value that labels the current element.
+     * @see aria-labelledby.
+     */
+    'aria-label'?: string | undefined;
+    /**
+     * Identifies the element (or elements) that labels the current element.
+     * @see aria-describedby.
+     */
+    'aria-labelledby'?: string | undefined;
+    /** Defines the hierarchical level of an element within a structure. */
+    'aria-level'?: number | undefined;
+    /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+    'aria-live'?: 'off' | 'assertive' | 'polite' | undefined;
+    /** Indicates whether an element is modal when displayed. */
+    'aria-modal'?: Booleanish | undefined;
+    /** Indicates whether a text box accepts multiple lines of input or only a single line. */
+    'aria-multiline'?: Booleanish | undefined;
+    /** Indicates that the user may select more than one item from the current selectable descendants. */
+    'aria-multiselectable'?: Booleanish | undefined;
+    /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
+    'aria-orientation'?: 'horizontal' | 'vertical' | undefined;
+    /**
+     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+     * @see aria-controls.
+     */
+    'aria-owns'?: string | undefined;
+    /**
+     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+     * A hint could be a sample value or a brief description of the expected format.
+     */
+    'aria-placeholder'?: string | undefined;
+    /**
+     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * @see aria-setsize.
+     */
+    'aria-posinset'?: number | undefined;
+    /**
+     * Indicates the current "pressed" state of toggle buttons.
+     * @see aria-checked @see aria-selected.
+     */
+    'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+    /**
+     * Indicates that the element is not editable, but is otherwise operable.
+     * @see aria-disabled.
+     */
+    'aria-readonly'?: Booleanish | undefined;
+    /**
+     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+     * @see aria-atomic.
+     */
+    'aria-relevant'?:
+      | 'additions'
+      | 'additions removals'
+      | 'additions text'
+      | 'all'
+      | 'removals'
+      | 'removals additions'
+      | 'removals text'
+      | 'text'
+      | 'text additions'
+      | 'text removals'
+      | undefined;
+    /** Indicates that user input is required on the element before a form may be submitted. */
+    'aria-required'?: Booleanish | undefined;
+    /** Defines a human-readable, author-localized description for the role of an element. */
+    'aria-roledescription'?: string | undefined;
+    /**
+     * Defines the total number of rows in a table, grid, or treegrid.
+     * @see aria-rowindex.
+     */
+    'aria-rowcount'?: number | undefined;
+    /**
+     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+     * @see aria-rowcount @see aria-rowspan.
+     */
+    'aria-rowindex'?: number | undefined;
+    /**
+     * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+     * @see aria-rowindex @see aria-colspan.
+     */
+    'aria-rowspan'?: number | undefined;
+    /**
+     * Indicates the current "selected" state of various widgets.
+     * @see aria-checked @see aria-pressed.
+     */
+    'aria-selected'?: Booleanish | undefined;
+    /**
+     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * @see aria-posinset.
+     */
+    'aria-setsize'?: number | undefined;
+    /** Indicates if items in a table or grid are sorted in ascending or descending order. */
+    'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined;
+    /** Defines the maximum allowed value for a range widget. */
+    'aria-valuemax'?: number | undefined;
+    /** Defines the minimum allowed value for a range widget. */
+    'aria-valuemin'?: number | undefined;
+    /**
+     * Defines the current value for a range widget.
+     * @see aria-valuetext.
+     */
+    'aria-valuenow'?: number | undefined;
+    /** Defines the human readable text alternative of aria-valuenow for a range widget. */
+    'aria-valuetext'?: string | undefined;
   }
 }
 

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -1177,7 +1177,7 @@ export default class Image {
   }
   useLazyLoading() {
     // TODO: Add more checks here, like testing for real web browsers
-    return !!this.lazy && isBrowser();
+    return !!this.lazy && this.isBrowser();
   }
   isBrowser = function isBrowser() {
     return (
@@ -2003,13 +2003,13 @@ export default class MultipleOnUpdateWithDeps {
   d = \\"d\\";
 
   ngAfterContentChecked() {
-    console.log(\\"Runs when a or b changes\\", this.a, this.b);
+    console.log(\\"Runs when this.a or this.b changes\\", this.a, this.b);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
     }
 
-    console.log(\\"Runs when c or d changes\\", this.c, this.d);
+    console.log(\\"Runs when this.c or this.d changes\\", this.c, this.d);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
@@ -2147,7 +2147,7 @@ export default class OnUpdateWithDeps {
   b = \\"b\\";
 
   ngAfterContentChecked() {
-    console.log(\\"Runs when a or b changes\\", this.a, this.b);
+    console.log(\\"Runs when this.a or this.b changes\\", this.a, this.b);
   }
 }
 "

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -271,6 +271,9 @@ export const componentToAngular =
 
     const domRefs = getRefs(json);
     const jsRefs = Object.keys(json.refs).filter((ref) => !domRefs.has(ref));
+
+    const stateVars = Object.keys(json?.state || {});
+
     mapRefs(json, (refName) => {
       const isDomRef = domRefs.has(refName);
       return `this.${isDomRef ? '' : '_'}${refName}${isDomRef ? '.nativeElement' : ''}`;
@@ -308,6 +311,7 @@ export const componentToAngular =
           contextVars,
           outputVars,
           domRefs: Array.from(domRefs),
+          stateVars,
         }),
     });
 
@@ -365,6 +369,7 @@ export const componentToAngular =
                   contextVars,
                   outputVars,
                   domRefs: Array.from(domRefs),
+                  stateVars,
                 })}`
               : ''
           };`;
@@ -403,6 +408,7 @@ export const componentToAngular =
                   contextVars,
                   outputVars,
                   domRefs: Array.from(domRefs),
+                  stateVars,
                 })}
                 `
               }
@@ -419,6 +425,7 @@ export const componentToAngular =
                   contextVars,
                   outputVars,
                   domRefs: Array.from(domRefs),
+                  stateVars,
                 });
                 return code + '\n';
               }, '')}
@@ -434,6 +441,7 @@ export const componentToAngular =
                 contextVars,
                 outputVars,
                 domRefs: Array.from(domRefs),
+                stateVars,
               })}
             }`
       }

--- a/packages/core/src/helpers/strip-state-and-props-refs.ts
+++ b/packages/core/src/helpers/strip-state-and-props-refs.ts
@@ -4,6 +4,7 @@ export type StripStateAndPropsRefsOptions = {
   includeState?: boolean;
   contextVars?: string[];
   outputVars?: string[];
+  stateVars?: string[];
   context?: string;
   domRefs?: string[];
 };
@@ -26,6 +27,7 @@ export const stripStateAndPropsRefs = (
   const outputVars = options?.outputVars || [];
   const context = options?.context || 'this.';
   const domRefs = options?.domRefs || [];
+  const stateVars = options?.stateVars || [];
 
   if (contextVars.length) {
     contextVars.forEach((_var) => {
@@ -69,6 +71,24 @@ export const stripStateAndPropsRefs = (
         new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
         '$1' + 'this.' + _var + '$2',
       );
+    });
+  }
+  if (stateVars.length) {
+    stateVars.forEach((_var) => {
+      newCode = newCode
+        .replace(
+          // roughly gets rid of state vars, like stuff = function this.stuff() {} turning it into stuff = function () {}
+          new RegExp(
+            '(^(?:function))(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)',
+            'g',
+          ),
+          '$1',
+        )
+        .replace(
+          // determine expression edge cases - https://regex101.com/r/iNcTSM/1
+          new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
+          '$1' + 'this.' + _var + '$2',
+        );
     });
   }
   return newCode;

--- a/packages/core/src/helpers/strip-state-and-props-refs.ts
+++ b/packages/core/src/helpers/strip-state-and-props-refs.ts
@@ -68,25 +68,26 @@ export const stripStateAndPropsRefs = (
     domRefs.forEach((_var) => {
       newCode = newCode.replace(
         // determine expression edge cases - https://regex101.com/r/iNcTSM/1
-        new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
+        new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(\\?\\.|,|\\.|\\(| |;|\\)|\\]|$)', 'g'),
         '$1' + 'this.' + _var + '$2',
       );
     });
   }
   if (stateVars.length) {
     stateVars.forEach((_var) => {
+      console.log('LOL', 'VAR ', _var, newCode);
       newCode = newCode
         .replace(
           // roughly gets rid of state vars, like stuff = function this.stuff() {} turning it into stuff = function () {}
-          new RegExp(
-            '(^(?:function))(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)',
-            'g',
-          ),
+          new RegExp('(^(?:function))(^| |)' + _var, 'g'),
           '$1',
         )
         .replace(
           // determine expression edge cases - https://regex101.com/r/iNcTSM/1
-          new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
+          new RegExp(
+            '(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(\\?\\.|,|\\.|\\(| |;|\\)|\\]|$)',
+            'g',
+          ),
           '$1' + 'this.' + _var + '$2',
         );
     });

--- a/packages/core/src/helpers/strip-state-and-props-refs.ts
+++ b/packages/core/src/helpers/strip-state-and-props-refs.ts
@@ -75,21 +75,14 @@ export const stripStateAndPropsRefs = (
   }
   if (stateVars.length) {
     stateVars.forEach((_var) => {
-      console.log('LOL', 'VAR ', _var, newCode);
-      newCode = newCode
-        .replace(
-          // roughly gets rid of state vars, like stuff = function this.stuff() {} turning it into stuff = function () {}
-          new RegExp('(^(?:function))(^| |)' + _var, 'g'),
-          '$1',
-        )
-        .replace(
-          // determine expression edge cases - https://regex101.com/r/iNcTSM/1
-          new RegExp(
-            '(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(\\?\\.|,|\\.|\\(| |;|\\)|\\]|$)',
-            'g',
-          ),
-          '$1' + 'this.' + _var + '$2',
-        );
+      newCode = newCode.replace(
+        // determine expression edge cases - https://regex101.com/r/iNcTSM/1
+        new RegExp(
+          `(?!^${_var}|^ ${_var})(?<!function|get)(^|\\n|\\r| |;|\\(|\\[|!|,)${_var}(\\?\\.|,|\\.|\\(| |;|\\)|\\]|$)`,
+          'g',
+        ),
+        '$1' + 'this.' + _var + '$2',
+      );
     });
   }
   return newCode;

--- a/packages/core/src/helpers/strip-state-and-props-refs.ts
+++ b/packages/core/src/helpers/strip-state-and-props-refs.ts
@@ -66,7 +66,7 @@ export const stripStateAndPropsRefs = (
     domRefs.forEach((_var) => {
       newCode = newCode.replace(
         // determine expression edge cases - https://regex101.com/r/iNcTSM/1
-        new RegExp('(^|\\n|\\r| |;|\\(|\\[|!)' + _var + '(\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
+        new RegExp('(^|\\n|\\r| |;|\\(|\\[|!|,)' + _var + '(|\\?\\.|\\.|\\(| |;|\\)|$)', 'g'),
         '$1' + 'this.' + _var + '$2',
       );
     });


### PR DESCRIPTION
Updated types for aria purposes ripped directly from the react types.

Updated stripStateAndPropsRefs to properly deal with embedded functions and state functions in Angular so they have the correct 'this.' when being used. 

Also updated the regex to find more instances of state variables being used and prepend 'this'. 
