### PR TITLE
Small marko fix for tag names

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -374,7 +374,7 @@ class {
 }
 
 <div>
-  <h-1> Now: \${state.count} , before: \${this.prevCount} </h-1>
+  <h1>Now: \${state.count} , before: \${this.prevCount}</h1>
 
   <button on-click(event => state.count += 1)>Increment</button>
 </div>"

--- a/packages/core/src/generators/marko/generate.ts
+++ b/packages/core/src/generators/marko/generate.ts
@@ -26,8 +26,21 @@ import { functionLiteralPrefix } from '../../constants/function-literal-prefix';
 import { methodLiteralPrefix } from '../../constants/method-literal-prefix';
 import { GETTER } from '../../helpers/patterns';
 import { getRefs } from '../../helpers/get-refs';
+import { isUpperCase } from '../../helpers/is-upper-case';
+import { kebabCase } from 'lodash';
 
 export interface ToMarkoOptions extends BaseTranspilerOptions {}
+
+/**
+ * Convert a component name to a tagName
+ *
+ * So things like
+ *  'FooBar' -> <foo-bar>
+ *  'h1' -> <h1>
+ */
+const toTagName = (str: string) => {
+  return isUpperCase(str[0]) ? kebabCase(str) : str;
+};
 
 interface InternalToMarkoOptions extends ToMarkoOptions {
   component: MitosisComponent;
@@ -111,7 +124,7 @@ const blockToMarko = (json: MitosisNode, options: InternalToMarkoOptions): strin
 
   let str = '';
 
-  str += `<${dashCase(json.name)} `;
+  str += `<${toTagName(json.name)} `;
 
   const classString = collectClassString(json);
   if (classString) {
@@ -152,7 +165,7 @@ const blockToMarko = (json: MitosisNode, options: InternalToMarkoOptions): strin
     str += json.children.map((item) => blockToMarko(item, options)).join('\n');
   }
 
-  str += `</${dashCase(json.name)}>`;
+  str += `</${toTagName(json.name)}>`;
 
   return str;
 };


### PR DESCRIPTION
Make sure not to convert `<h1>` to `<h-1>` etc