### PR TITLE
fix(vue): use named slots

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -245,6 +245,18 @@ export default function Layout(props) {
 }
 ```
 
+For vue component `slot` prop will be compiled into named slot
+
+```html
+<div class="layout">
+  <div class="top"><slot name="top" /></div>
+  <div class="left"><slot name="left" /></div>
+  <div class="center"><slot name="center" /></div>
+  <slot />
+</div>
+}
+```
+
 Mitosis compiles one component at a time and is only concerned with outputting the correct method for each framework. For the two examples above, here are the angular and html outputs.
 
 ```html

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -509,11 +509,11 @@ export default {
 exports[`Vue ContentSlotJSX 1`] = `
 "<template>
   <div>
-    {{ slotTesting }}
+    <slot name=\\"testing\\" />
     <div>
       <hr />
     </div>
-    <div><slot></slot></div>
+    <div><slot /></div>
   </div>
 </template>
 <script>
@@ -1033,7 +1033,7 @@ exports[`Vue Image 1`] = `
     <source :srcset=\\"srcset\\" />
   </picture>
 
-  <slot></slot>
+  <slot />
 </template>
 <script>
 export default {
@@ -1250,7 +1250,7 @@ exports[`Vue Section 1`] = `
         : undefined
     \\"
   >
-    <slot></slot>
+    <slot />
   </section>
 </template>
 <script>
@@ -1274,7 +1274,7 @@ exports[`Vue Section 2`] = `
     }\\"
     :key=\\"index\\"
   >
-    <slot></slot>
+    <slot />
   </section>
 </template>
 <script>
@@ -1985,7 +1985,7 @@ export default {
 exports[`Vue propsDestructure 1`] = `
 "<template>
   <div>
-    <slot></slot> {{ type }}
+    <slot /> {{ type }}
     Hello! I can run in React, Vue, Solid, or Liquid!
   </div>
 </template>
@@ -2066,7 +2066,7 @@ exports[`Vue self-referencing component with children 1`] = `
 "<template>
   <div>
     {{ name }}
-    <slot></slot>
+    <slot />
 
     <my-component name=\\"Bruce\\" v-if=\\"name === 'Batman'\\">
       <div>Wayne</div>

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -36,6 +36,7 @@ import { methodLiteralPrefix } from '../constants/method-literal-prefix';
 import { OmitObj } from '../helpers/typescript';
 import { pipe } from 'fp-ts/lib/function';
 import { getCustomImports } from '../helpers/get-custom-imports';
+import { isSlotProperty, stripSlotPrefix } from '../helpers/slots';
 
 function encodeQuotes(string: string) {
   return string.replace(/"/g, '&quot;');
@@ -157,7 +158,7 @@ const NODE_MAPPERS: {
         ${
           isMitosisNode(json.meta.else)
             ? `
-            <template ${SPECIAL_PROPERTIES.V_ELSE}> 
+            <template ${SPECIAL_PROPERTIES.V_ELSE}>
               ${blockToVue(json.meta.else, options)}
             </template>`
             : ''
@@ -230,13 +231,13 @@ const NODE_MAPPERS: {
             : '';
 
           return `
-            
+
             ${ifString}
-            
+
             ${elseIfString}
-            
+
             ${elseString}
-            
+
           `;
         } else {
           const ifString = firstChild
@@ -348,7 +349,7 @@ export const blockToVue: BlockRenderer = (node, options, scope) => {
   }
 
   if (isChildren(node)) {
-    return `<slot></slot>`;
+    return `<slot/>`;
   }
 
   if (node.name === 'style') {
@@ -362,8 +363,13 @@ export const blockToVue: BlockRenderer = (node, options, scope) => {
     return `${node.properties._text}`;
   }
 
-  if (node.bindings._text?.code) {
-    return `{{${stripStateAndPropsRefs(node.bindings._text.code as string)}}}`;
+  const textCode = node.bindings._text?.code;
+  if (textCode) {
+    const strippedTextCode = stripStateAndPropsRefs(textCode);
+    if (isSlotProperty(strippedTextCode)) {
+      return `<slot name="${stripSlotPrefix(strippedTextCode).toLowerCase()}"/>`;
+    }
+    return `{{${strippedTextCode}}}`;
   }
 
   let str = '';
@@ -597,10 +603,10 @@ const componentToVue =
         `_classStringToObject(str) {
         const obj = {};
         if (typeof str !== 'string') { return obj }
-        const classNames = str.trim().split(/\\s+/); 
+        const classNames = str.trim().split(/\\s+/);
         for (const name of classNames) {
           obj[name] = true;
-        } 
+        }
         return obj;
       }  }`,
       );

--- a/packages/core/src/helpers/slots.ts
+++ b/packages/core/src/helpers/slots.ts
@@ -1,3 +1,5 @@
 const SLOT_PREFIX = 'slot';
 
 export const isSlotProperty = (key: string): boolean => key.startsWith(SLOT_PREFIX);
+
+export const stripSlotPrefix = (key: string): string => key.substring(SLOT_PREFIX.length);


### PR DESCRIPTION
## Description
**Why change is needed?**
`slotIcon={<svg></svg>}` is compiled into `{{slotIcon}}` which isn’t slot, this result in not being able to pass HTML element into slot, it will be displayed as `&lt;svg&gt;...&lt;/svg&gt;`. Named slots should work same as default slot (`props.children`) which is compiled to `<slot></slot>` , therefore named slot should be transpiled into `<slot name="icon"></slot>`. 

**What have been changed?**
I changed parsing prefixed `slotIcon` prop so it will be rendered as `<slot name="icon"/>`
Minor change, self closing `<slot/>` tag instead of `<slot></slot>`

Thank you :)
