### PR TITLE
fix(svelte): only use use:mitosis_styling for tags, not components

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/mitosis-cli",
-  "version": "0.0.17-77",
+  "version": "0.0.17-78",
   "description": "mitosis CLI",
   "types": "build/types/types.d.ts",
   "bin": {
@@ -66,5 +66,5 @@
     "ts-node": "^8.4.1",
     "typescript": "^4.5.4"
   },
-  "stableVersion": "0.0.17-76"
+  "stableVersion": "0.0.17-77"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/mitosis-cli",
-  "version": "0.0.17-76",
+  "version": "0.0.17-77",
   "description": "mitosis CLI",
   "types": "build/types/types.d.ts",
   "bin": {
@@ -66,5 +66,5 @@
     "ts-node": "^8.4.1",
     "typescript": "^4.5.4"
   },
-  "stableVersion": "0.0.17-75"
+  "stableVersion": "0.0.17-76"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "npm": "99999999.9.9"
   },
-  "version": "0.0.56-85",
+  "version": "0.0.56-86",
   "homepage": "https://github.com/BuilderIO/mitosis",
   "main": "./dist/src/index.js",
   "exports": {
@@ -117,5 +117,5 @@
     "typescript": "^4",
     "universalify": "^2.0.0"
   },
-  "stableVersion": "0.0.56-84"
+  "stableVersion": "0.0.56-85"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "npm": "99999999.9.9"
   },
-  "version": "0.0.56-84",
+  "version": "0.0.56-85",
   "homepage": "https://github.com/BuilderIO/mitosis",
   "main": "./dist/src/index.js",
   "exports": {
@@ -117,5 +117,5 @@
     "typescript": "^4",
     "universalify": "^2.0.0"
   },
-  "stableVersion": "0.0.56-83"
+  "stableVersion": "0.0.56-84"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "npm": "99999999.9.9"
   },
-  "version": "0.0.56-82",
+  "version": "0.0.56-84",
   "homepage": "https://github.com/BuilderIO/mitosis",
   "main": "./dist/src/index.js",
   "exports": {
@@ -117,5 +117,5 @@
     "typescript": "^4",
     "universalify": "^2.0.0"
   },
-  "stableVersion": "0.0.56-81"
+  "stableVersion": "0.0.56-83"
 }

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -36,6 +36,7 @@ import { uniq } from 'lodash';
 import { functionLiteralPrefix } from '../constants/function-literal-prefix';
 import { methodLiteralPrefix } from '../constants/method-literal-prefix';
 import { GETTER } from '../helpers/patterns';
+import { isUpperCase } from '../helpers/is-upper-case';
 
 export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';
@@ -191,7 +192,8 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
     str += `{...${stripStateAndProps(json.bindings._spread.code, options)}}`;
   }
 
-  if (json.bindings.style?.code || json.properties.style) {
+  const isComponent = Boolean(tagName[0] && isUpperCase(tagName[0]));
+  if ((json.bindings.style?.code || json.properties.style) && !isComponent) {
     const useValue = stripStateAndProps(
       json.bindings.style?.code || json.properties.style,
       options,


### PR DESCRIPTION
components with a style prop should just be passed through, otherwise svelte has compile errors saying this is disallowed