### PR TITLE
refactor: #650 add useDefaultProps compile away hook

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -4173,7 +4173,7 @@ export interface ButtonProps {
 }
 const defaultProps = {
   text: \\"default text\\",
-  link: false,
+  link: \\"https://builder.io/\\",
   openLinkInNewTab: false,
 };
 
@@ -4215,7 +4215,7 @@ export interface ButtonProps {
 }
 const defaultProps = {
   text: \\"default text\\",
-  link: false,
+  link: \\"https://builder.io/\\",
   openLinkInNewTab: false,
 };
 

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -1810,7 +1810,7 @@ export default function Button(props: ButtonProps) {
 
 Button.defaultProps = {
   text: \\"default text\\",
-  link: false,
+  link: \\"https://builder.io/\\",
   openLinkInNewTab: false,
 };
 "

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -1901,7 +1901,7 @@ export default function Button(props: ButtonProps) {
 
 Button.defaultProps = {
   text: \\"default text\\",
-  link: false,
+  link: \\"https://builder.io/\\",
   openLinkInNewTab: false,
 };
 "
@@ -4225,7 +4225,7 @@ export default function Button(props: ButtonProps) {
 
 Button.defaultProps = {
   text: \\"default text\\",
-  link: false,
+  link: \\"https://builder.io/\\",
   openLinkInNewTab: false,
 };
 "

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1774,7 +1774,7 @@ exports[`Svelte defaultProps 1`] = `
 </script>
 
 <script lang=\\"ts\\">
-  export let link: ButtonProps[\\"link\\"] = false;
+  export let link: ButtonProps[\\"link\\"] = \\"https://builder.io/\\";
   export let attributes: ButtonProps[\\"attributes\\"];
   export let openLinkInNewTab: ButtonProps[\\"openLinkInNewTab\\"] = false;
   export let text: ButtonProps[\\"text\\"] = \\"default text\\";

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1788,7 +1788,7 @@ export default {
   name: \\"button\\",
 
   props: {
-    link: { default: false },
+    link: { default: \\"https://builder.io/\\" },
     attributes: {},
     openLinkInNewTab: { default: false },
     text: { default: \\"default text\\" },

--- a/packages/core/src/__tests__/data/default-props/default-props.raw.tsx
+++ b/packages/core/src/__tests__/data/default-props/default-props.raw.tsx
@@ -1,4 +1,4 @@
-import { Show } from '@builder.io/mitosis';
+import { Show, useDefaultProps } from '@builder.io/mitosis';
 
 export interface ButtonProps {
   attributes?: any;
@@ -8,6 +8,12 @@ export interface ButtonProps {
 }
 
 export default function Button(props: ButtonProps) {
+  useDefaultProps<ButtonProps>({
+    text: 'default text',
+    link: 'https://builder.io/',
+    openLinkInNewTab: false,
+  });
+
   return (
     <>
       <Show when={props.link}>
@@ -27,9 +33,3 @@ export default function Button(props: ButtonProps) {
     </>
   );
 }
-
-Button.defaultProps = {
-  text: 'default text',
-  link: false,
-  openLinkInNewTab: false,
-};

--- a/packages/core/src/constants/hooks.ts
+++ b/packages/core/src/constants/hooks.ts
@@ -3,4 +3,5 @@ export const HOOKS = {
   STATE: 'useState',
   CONTEXT: 'useContext',
   REF: 'useRef',
+  DEFAULT_PROPS: 'useDefaultProps',
 } as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export const useMetadata = (obj: object) => {
   throw new Error('useMetadata: Mitosis hook should have been compiled away');
   return null as any;
 };
+export const useDefaultProps = <T = { [key: string]: any }>(value: T): T => null as unknown as T;
 
 export * from './parsers/jsx';
 export * from './parsers/builder';

--- a/packages/core/src/parsers/jsx/jsx.ts
+++ b/packages/core/src/parsers/jsx/jsx.ts
@@ -133,7 +133,9 @@ const componentFunctionToJson = (
           } else if (expression.callee.name === 'useDefaultProps') {
             const firstArg = expression.arguments[0];
             if (types.isObjectExpression(firstArg)) {
-              const objectProperties = firstArg.properties?.filter(i => types.isObjectProperty(i));
+              const objectProperties = firstArg.properties?.filter((i) =>
+                types.isObjectProperty(i),
+              );
               objectProperties?.forEach((i: any) => {
                 if (i.key?.name) {
                   context.builder.component.defaultProps = {

--- a/packages/core/src/parsers/jsx/jsx.ts
+++ b/packages/core/src/parsers/jsx/jsx.ts
@@ -130,7 +130,7 @@ const componentFunctionToJson = (
                 .replace(/}$/, '');
               hooks.onInit = { code };
             }
-          } else if (expression.callee.name === 'useDefaultProps') {
+          } else if (expression.callee.name === HOOKS.DEFAULT_PROPS) {
             const firstArg = expression.arguments[0];
             if (types.isObjectExpression(firstArg)) {
               const objectProperties = firstArg.properties?.filter((i) =>

--- a/packages/core/src/parsers/jsx/jsx.ts
+++ b/packages/core/src/parsers/jsx/jsx.ts
@@ -18,7 +18,7 @@ import { collectMetadata } from './metadata';
 import { extractContextComponents } from './context';
 import { parseCodeJson } from './helpers';
 import { collectTypes, getPropsTypeRef, isTypeImport, isTypeOrInterface } from './component-types';
-import { collectDefaultProps, undoPropsDestructure } from './props';
+import { undoPropsDestructure } from './props';
 
 const jsxPlugin = require('@babel/plugin-syntax-jsx');
 const tsPreset = require('@babel/preset-typescript');
@@ -129,6 +129,19 @@ const componentFunctionToJson = (
                 .replace(/^{/, '')
                 .replace(/}$/, '');
               hooks.onInit = { code };
+            }
+          } else if (expression.callee.name === 'useDefaultProps') {
+            const firstArg = expression.arguments[0];
+            if (types.isObjectExpression(firstArg)) {
+              const objectProperties = firstArg.properties?.filter(i => types.isObjectProperty(i));
+              objectProperties?.forEach((i: any) => {
+                if (i.key?.name) {
+                  context.builder.component.defaultProps = {
+                    ...(context.builder.component.defaultProps ?? {}),
+                    [i.key?.name]: i.value.value,
+                  };
+                }
+              });
             }
           }
         }
@@ -545,8 +558,6 @@ export function parseJsx(
                 collectTypes(statement, context);
               }
             }
-
-            collectDefaultProps(path, context);
 
             const exportsOrLocalVariables = path.node.body.filter(
               (statement) =>

--- a/packages/core/src/parsers/jsx/props.ts
+++ b/packages/core/src/parsers/jsx/props.ts
@@ -1,5 +1,4 @@
 import * as babel from '@babel/core';
-import { Context } from './types';
 
 const { types } = babel;
 
@@ -41,34 +40,6 @@ export function undoPropsDestructure(path: babel.NodePath<babel.types.FunctionDe
           }
         }
       },
-    });
-  }
-}
-
-export function collectDefaultProps(path: babel.NodePath<babel.types.Program>, context: Context) {
-  const expressionStatements = path.node.body.filter((statement) =>
-    types.isExpressionStatement(statement),
-  );
-
-  const defaultPropsStatement: any =
-    expressionStatements?.filter((i: any) => {
-      const { expression } = i;
-      return (
-        types.isAssignmentExpression(expression) &&
-        types.isMemberExpression(expression.left) &&
-        types.isIdentifier(expression.left.property) &&
-        expression.left.property.name === 'defaultProps'
-      );
-    })[0] ?? null;
-
-  if (defaultPropsStatement) {
-    defaultPropsStatement?.expression.right.properties.forEach((i: any) => {
-      if (i.key?.name) {
-        context.builder.component.defaultProps = {
-          ...(context.builder.component.defaultProps ?? {}),
-          [i.key?.name]: i.value.value,
-        };
-      }
     });
   }
 }


### PR DESCRIPTION
## Description

Refactors the default props feature to use `useDefaultProps` as requested in  https://github.com/BuilderIO/mitosis/issues/650

