### PR TITLE
fix(svelte): no line-breaks between children

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -46,15 +46,11 @@ exports[`Svelte AdvancedRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   {/if}
-
   Hello
-
-  {lowerCaseName()}
-  ! I can run in React, Qwik, Vue, Solid, or Web Component!
+  {lowerCaseName()}! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
 
 <style>
@@ -91,7 +87,6 @@ exports[`Svelte Basic 1`] = `
       name = myEvent.target.value;
     }}
   />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 
@@ -154,9 +149,7 @@ exports[`Svelte Basic Context 1`] = `
 
 <div>
   {myService.method(\\"hello\\") + name}
-
   Hello! I can run in React, Vue, Solid, or Liquid!
-
   <input
     on:change={(event) => {
       onChange;
@@ -188,10 +181,7 @@ exports[`Svelte Basic OnMount Update 1`] = `
   });
 </script>
 
-<div>
-  Hello
-  {name}
-</div>
+<div>Hello {name}</div>
 "
 `;
 
@@ -246,7 +236,6 @@ exports[`Svelte BasicChildComponent 1`] = `
 
 <div>
   <MyBasicComponent id={dev} />
-
   <div>
     <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
   </div>
@@ -322,15 +311,11 @@ exports[`Svelte BasicRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   {/if}
-
   Hello
-
-  {lowerCaseName()}
-  ! I can run in React, Qwik, Vue, Solid, or Web Component!
+  {lowerCaseName()}! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
 
 <style>
@@ -399,12 +384,8 @@ exports[`Svelte BasicRefPrevious 1`] = `
 
 <div>
   <h1>
-    Now:
-    {count}
-    , before:
-    {prevCount}
+    Now: {count}, before: {prevCount}
   </h1>
-
   <button
     on:click={(event) => {
       count += 1;
@@ -497,7 +478,6 @@ exports[`Svelte Columns 1`] = `
   {#each columns as column, index}
     <div class=\\"builder-column div-2\\">
       {column.content}
-
       {index}
     </div>
   {/each}
@@ -979,9 +959,7 @@ exports[`Svelte Form 1`] = `
 
   {#if submissionState() === \\"error\\" && responseData}
     <pre class=\\"builder-form-error-text pre\\">
-        
-{JSON.stringify(responseData, null, 2)}
-
+        {JSON.stringify(responseData, null, 2)}
       </pre>
   {/if}
 
@@ -1100,7 +1078,6 @@ exports[`Svelte Image 1`] = `
       {sizes}
     />
   {/if}
-
   <source {srcset} />
 </picture>
 
@@ -1242,11 +1219,7 @@ exports[`Svelte Remove Internal mitosis package 1`] = `
   let name = \\"PatrickJS\\";
 </script>
 
-<div>
-  Hello
-  {name}
-  ! I can run in React, Qwik, Vue, Solid, or Liquid!
-</div>
+<div>Hello {name}! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
 "
 `;
 
@@ -1430,15 +1403,9 @@ exports[`Svelte Stamped.io 1`] = `
   {#each reviews as review, index (review.id)}
     <div class=\\"review\\">
       <img class=\\"img\\" src={review.avatar} />
-
       <div class={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-        <div>
-          N:
-          {index}
-        </div>
-
+        <div>N: {index}</div>
         <div>{review.author}</div>
-
         <div>{review.reviewMessage}</div>
       </div>
     </div>
@@ -1692,10 +1659,7 @@ exports[`Svelte basicOnUpdateReturn 1`] = `
   $: onUpdateFn_0(...[name]);
 </script>
 
-<div>
-  Hello!
-  {name}
-</div>
+<div>Hello! {name}</div>
 "
 `;
 
@@ -1813,10 +1777,7 @@ exports[`Svelte defaultValsWithTypes 1`] = `
   export let name: Props[\\"name\\"];
 </script>
 
-<div>
-  Hello
-  {name || DEFAULT_VALUES.name}
-</div>
+<div>Hello {name || DEFAULT_VALUES.name}</div>
 "
 `;
 
@@ -1948,10 +1909,7 @@ exports[`Svelte onInit 1`] = `
   let name = \\"\\";
 </script>
 
-<div>
-  Default name defined by parent
-  {name}
-</div>
+<div>Default name defined by parent {name}</div>
 "
 `;
 
@@ -2055,10 +2013,7 @@ exports[`Svelte preserveTyping 1`] = `
   export let name: MyBasicComponentProps[\\"name\\"];
 </script>
 
-<div>
-  Hello! I can run in React, Vue, Solid, or Liquid!
-  {name}
-</div>
+<div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
 "
 `;
 
@@ -2078,9 +2033,7 @@ exports[`Svelte propsDestructure 1`] = `
 
 <div>
   <slot />
-
   {type}
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 "
@@ -2098,10 +2051,7 @@ exports[`Svelte propsInterface 1`] = `
   export let name: Person[\\"name\\"];
 </script>
 
-<div>
-  Hello! I can run in React, Vue, Solid, or Liquid!
-  {name}
-</div>
+<div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
 "
 `;
 
@@ -2117,10 +2067,7 @@ exports[`Svelte propsType 1`] = `
   export let name: Person[\\"name\\"];
 </script>
 
-<div>
-  Hello! I can run in React, Vue, Solid, or Liquid!
-  {name}
-</div>
+<div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
 "
 `;
 
@@ -2165,7 +2112,6 @@ exports[`Svelte self-referencing component with children 1`] = `
 
 <div>
   {name}
-
   <slot />
 
   {#if name === \\"Batman\\"}

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -246,7 +246,7 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
   if (json.children) {
     str += json.children
       .map((item) => blockToSvelte({ json: item, options, parentComponent }))
-      .join('\n');
+      .join('');
   }
 
   str += `</${tagName}>`;


### PR DESCRIPTION
## Description

Add a short description of:
The line-breaks causes the browser to render spaces that were not intended to be there. Other generators (like React) also don't add these.

fixes #310