### PR TITLE
Refactor babel transform to remove lodash.attempt

### DIFF
--- a/packages/core/src/helpers/babel-transform.ts
+++ b/packages/core/src/helpers/babel-transform.ts
@@ -1,9 +1,54 @@
 import * as babel from '@babel/core';
-import { attempt, isError } from 'lodash';
 const jsxPlugin = require('@babel/plugin-syntax-jsx');
 const tsPreset = require('@babel/preset-typescript');
 const decorators = require('@babel/plugin-syntax-decorators');
 import type { Visitor } from '@babel/traverse';
+import { pipe } from 'fp-ts/lib/function';
+
+const handleErrorOrExpression = <VisitorContextType = any>({
+  code,
+  useCode,
+  result,
+  visitor,
+}: {
+  code: string;
+  useCode: string;
+  result: string | null;
+  visitor: Visitor<VisitorContextType>;
+}) => {
+  try {
+    // If it can't, e.g. this is an expression or code fragment, modify the code below and try again
+
+    // Detect method fragments. These get passed sometimes and otherwise
+    // generate compile errors. They are of the form `foo() { ... }`
+    const isMethod = Boolean(
+      !code.startsWith('function') && code.match(/^[a-z0-9_]+\s*\([^\)]*\)\s*[\{:]/i),
+    );
+
+    if (isMethod) {
+      useCode = `function ${useCode}`;
+    }
+    // Parse the code as an expression (instead of the default, a block) by giving it a fake variable assignment
+    // e.g. if the code parsed is { ... } babel will treat that as a block by deafult, unless processed as an expression
+    // that is an object
+    useCode = `let _ = ${useCode}`;
+    result = pipe(babelTransformCode(useCode, visitor), trimSemicolons, (str) =>
+      // Remove our fake variable assignment
+      str.replace(/let _ =\s/, ''),
+    );
+    if (isMethod) {
+      return result.replace('function', '');
+    }
+    return result;
+  } catch (err) {
+    console.error('Error parsing code:\n', code, '\n', result);
+    try {
+      return babelTransformExpression(code, visitor, 'functionBody');
+    } catch (err) {
+      throw err;
+    }
+  }
+};
 
 export const babelTransform = <VisitorContextType = any>(
   code: string,
@@ -21,14 +66,28 @@ export const babelTransform = <VisitorContextType = any>(
 export const babelTransformCode = <VisitorContextType = any>(
   code: string,
   visitor?: Visitor<VisitorContextType>,
-) => {
-  return babelTransform(code, visitor)?.code || '';
+) => babelTransform(code, visitor)?.code || '';
+
+// Babel adds trailing semicolons, but for expressions we need those gone
+// TODO: maybe detect if the original code ended with one, and keep it if so, for the case
+// of appending several fragements
+const trimSemicolons = (code: string) => code.replace(/;$/, '');
+
+const trimExpression = (type: ExpressionType) => (code: string) => {
+  switch (type) {
+    case 'functionBody':
+      return code.replace(/^function\s*\(\)\s*\{/, '').replace(/\};?$/, '');
+    default:
+      return trimSemicolons(code);
+  }
 };
+
+type ExpressionType = 'expression' | 'unknown' | 'block' | 'functionBody';
 
 export const babelTransformExpression = <VisitorContextType = any>(
   code: string,
   visitor: Visitor<VisitorContextType>,
-  type: 'expression' | 'unknown' | 'block' | 'functionBody' = 'unknown',
+  type: ExpressionType = 'unknown',
 ): string => {
   if (!code) {
     return '';
@@ -54,62 +113,13 @@ export const babelTransformExpression = <VisitorContextType = any>(
     useCode = `function(){${useCode}}`;
   }
 
-  let result =
-    type === 'expression'
-      ? null
-      : attempt(() => {
-          let result = babelTransformCode(useCode, visitor);
-          if (type === 'functionBody') {
-            return result.replace(/^function\(\)\{/, '').replace(/\};$/, '');
-          } else {
-            // Babel addes trailing semicolons, but for expressions we need those gone
-            // TODO: maybe detect if the original code ended with one, and keep it if so, for the case
-            // of appending several fragements
-            return result.replace(/;$/, '');
-          }
-        });
-
-  if (isError(result) || type === 'expression') {
+  if (type !== 'expression') {
     try {
-      // If it can't, e.g. this is an expression or code fragment, modify the code below and try again
-
-      // Detect method fragments. These get passed sometimes and otherwise
-      // generate compile errors. They are of the form `foo() { ... }`
-      const isMethod = Boolean(
-        !code.startsWith('function') && code.match(/^[a-z0-9_]+\s*\([^\)]*\)\s*[\{:]/i),
-      );
-
-      if (isMethod) {
-        useCode = `function ${useCode}`;
-      }
-      // Parse the code as an expression (instead of the default, a block) by giving it a fake variable assignment
-      // e.g. if the code parsed is { ... } babel will treat that as a block by deafult, unless processed as an expression
-      // that is an object
-      useCode = `let _ = ${useCode}`;
-      result = babelTransformCode(useCode, visitor)
-        // Babel adds trailing semicolons, but for expressions we need those gone
-        .replace(/;$/, '')
-        // Remove our fake variable assignment
-        .replace(/let _ =\s/, '');
-
-      if (isMethod) {
-        result = result.replace('function', '');
-      }
-    } catch (err) {
-      console.error('Error parsing code:\n', code, '\n', result);
-      try {
-        return babelTransformExpression(code, visitor, 'functionBody');
-      } catch (err) {
-        throw err;
-      }
+      return pipe(babelTransformCode(useCode, visitor), trimExpression(type));
+    } catch (error) {
+      return handleErrorOrExpression({ code, useCode, result: null, visitor });
     }
-  }
-  if (type === 'functionBody') {
-    return result!.replace(/^function\s*\(\)\s*\{/, '').replace(/\};?$/, '');
   } else {
-    // Babel adds trailing semicolons, but for expressions we need those gone
-    // TODO: maybe detect if the original code ended with one, and keep it if so, for the case
-    // of appending several fragements
-    return result!.replace(/;$/, '');
+    return handleErrorOrExpression({ code, useCode, result: null, visitor });
   }
 };


### PR DESCRIPTION
## Description

`lodash.attempt` swallows errors, which cause our snapshot tests to silently freeze when a failure happens.

- remove `lodash.attempt` usage from babel transform code
- cleanup the code logic a bunch
