### PR TITLE
feat(vue): convert prop slots to Vue template slot syntax

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -1241,7 +1241,9 @@ type Props = {
   selector: \\"content-slot-jsx-code\\",
   template: \`
     <div>
-      <ng-content select=\\"[testing]\\"></ng-content>
+      <ng-container *ngIf=\\"slotTesting\\">
+        <div><ng-content select=\\"[testing]\\"></ng-content></div>
+      </ng-container>
 
       <div>
         <hr />
@@ -1270,7 +1272,9 @@ type Props = {
   selector: \\"content-slot-jsx-code\\",
   template: \`
     <div>
-      <ng-content select=\\"[testing]\\"></ng-content>
+      <ng-container *ngIf=\\"slotTesting\\">
+        <div><ng-content select=\\"[testing]\\"></ng-content></div>
+      </ng-container>
 
       <div>
         <hr />

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -1377,7 +1377,11 @@ exports[`Html ContentSlotHtml 1`] = `
 
 exports[`Html ContentSlotJSX 1`] = `
 "<div>
-  <template data-el=\\"div-1\\"><!-- props.slotTesting --></template>
+  <template data-el=\\"show\\">
+    <div>
+      <template data-el=\\"div-1\\"><!-- props.slotTesting --></template>
+    </div>
+  </template>
 
   <div>
     <hr />
@@ -1408,6 +1412,13 @@ exports[`Html ContentSlotJSX 1`] = `
       }
       pendingUpdate = true;
 
+      document.querySelectorAll(\\"[data-el='show']\\").forEach((el) => {
+        const whenCondition = props.slotTesting;
+        if (whenCondition) {
+          showContent(el);
+        }
+      });
+
       document.querySelectorAll(\\"[data-el='div-1']\\").forEach((el) => {
         renderTextNode(el, props.slotTesting);
       });
@@ -1419,6 +1430,26 @@ exports[`Html ContentSlotJSX 1`] = `
 
     // Update with initial state on first load
     update();
+
+    function showContent(el) {
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement/content
+      // grabs the content of a node that is between <template> tags
+      // iterates through child nodes to register all content including text elements
+      // attaches the content after the template
+
+      const elementFragment = el.content.cloneNode(true);
+      const children = Array.from(elementFragment.childNodes);
+      children.forEach((child) => {
+        if (el?.scope) {
+          child.scope = el.scope;
+        }
+        if (el?.context) {
+          child.context = el.context;
+        }
+        nodesToDestroy.push(child);
+      });
+      el.after(elementFragment);
+    }
 
     // Helper text DOM nodes
     function renderTextNode(el, text) {

--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -188,7 +188,11 @@ exports[`Liquid ContentSlotHtml 1`] = `
 
 exports[`Liquid ContentSlotJSX 1`] = `
 "<div>
-  {{slotTesting}}
+  {% if slotTesting %}
+
+  <div>{{slotTesting}}</div>
+
+  {% endif %}
 
   <div>
     <hr />

--- a/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
@@ -721,7 +721,13 @@ export default class ContentSlotJsxCode extends LitElement {
     return html\`
         
         <div>
-        \${this.slotTesting}
+        \${
+          this.slotTesting
+            ? html\`
+        <div>\${this.slotTesting}</div>
+        \`
+            : null
+        }
 
         <div>
           <hr />

--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -466,7 +466,7 @@ exports[`Marko ContentSlotJSX 1`] = `
 "class {}
 
 <div>
-  \${input.slotTesting}
+  <if(input.slotTesting)> <div>\${input.slotTesting}</div></if>
 
   <div>
     <hr />

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -2614,13 +2614,61 @@ Object {
         Object {
           "@type": "@builder.io/mitosis/node",
           "bindings": Object {
-            "_text": Object {
+            "when": Object {
               "code": "props.slotTesting",
             },
           },
-          "children": Array [],
+          "children": Array [
+            Object {
+              "@type": "@builder.io/mitosis/node",
+              "bindings": Object {},
+              "children": Array [],
+              "meta": Object {},
+              "name": "div",
+              "properties": Object {
+                "_text": "
+        ",
+              },
+              "scope": Object {},
+            },
+            Object {
+              "@type": "@builder.io/mitosis/node",
+              "bindings": Object {},
+              "children": Array [
+                Object {
+                  "@type": "@builder.io/mitosis/node",
+                  "bindings": Object {
+                    "_text": Object {
+                      "code": "props.slotTesting",
+                    },
+                  },
+                  "children": Array [],
+                  "meta": Object {},
+                  "name": "div",
+                  "properties": Object {},
+                  "scope": Object {},
+                },
+              ],
+              "meta": Object {},
+              "name": "div",
+              "properties": Object {},
+              "scope": Object {},
+            },
+            Object {
+              "@type": "@builder.io/mitosis/node",
+              "bindings": Object {},
+              "children": Array [],
+              "meta": Object {},
+              "name": "div",
+              "properties": Object {
+                "_text": "
+      ",
+              },
+              "scope": Object {},
+            },
+          ],
           "meta": Object {},
-          "name": "div",
+          "name": "Show",
           "properties": Object {},
           "scope": Object {},
         },

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -559,7 +559,11 @@ type Props = {
 export default function ContentSlotJsxCode(props: Props) {
   return (
     <div>
-      {props.slotTesting}
+      {props.slotTesting ? (
+        <Fragment>
+          <div>{props.slotTesting}</div>
+        </Fragment>
+      ) : null}
 
       <div>
         <hr />

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -704,7 +704,7 @@ import { Fragment, Slot, component$, h } from \\"@builder.io/qwik\\";
 export const ContentSlotJsxCode = component$((props) => {
   return (
     <div>
-      {props.slotTesting}
+      {props.slotTesting ? <div>{props.slotTesting}</div> : null}
       <div>
         <hr></hr>
       </div>

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -541,7 +541,13 @@ type Props = {
 export default function ContentSlotJsxCode(props: Props) {
   return (
     <View>
-      <Text>{props.slotTesting}</Text>
+      {props.slotTesting ? (
+        <>
+          <View>
+            <Text>{props.slotTesting}</Text>
+          </View>
+        </>
+      ) : null}
 
       <View>
         <View />

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -544,7 +544,11 @@ type Props = {
 export default function ContentSlotJsxCode(props: Props) {
   return (
     <div>
-      {props.slotTesting}
+      {props.slotTesting ? (
+        <>
+          <div>{props.slotTesting}</div>
+        </>
+      ) : null}
 
       <div>
         <hr />

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -1111,10 +1111,14 @@ export default ContentSlotCode;
 `;
 
 exports[`Solid ContentSlotJSX 1`] = `
-"function ContentSlotJsxCode(props) {
+"import { Show } from \\"solid-js\\";
+
+function ContentSlotJsxCode(props) {
   return (
     <div>
-      {props.slotTesting}
+      <Show when={props.slotTesting}>
+        <div>{props.slotTesting}</div>
+      </Show>
       <div>
         <hr />
       </div>
@@ -1128,13 +1132,17 @@ export default ContentSlotJsxCode;
 `;
 
 exports[`Solid ContentSlotJSX 2`] = `
-"import { css } from \\"solid-styled-components\\";
+"import { Show } from \\"solid-js\\";
+
+import { css } from \\"solid-styled-components\\";
 
 function ContentSlotJsxCode(props) {
   return (
     <>
       <div>
-        {props.slotTesting}
+        <Show when={props.slotTesting}>
+          <div>{props.slotTesting}</div>
+        </Show>
         <div>
           <hr />
         </div>

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -550,7 +550,11 @@ export default class ContentSlotJsxCode {
   render() {
     return (
       <div>
-        {this.slotTesting}
+        {this.slotTesting ? (
+          <>
+            <div>{this.slotTesting}</div>
+          </>
+        ) : null}
 
         <div>
           <hr />

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -823,7 +823,8 @@ slotTesting: JSX.Element;
 exports[`Vue ContentSlotJSX 1`] = `
 "<template>
   <div>
-    <slot name=\\"testing\\" />
+    <div v-if=\\"$slots.testing\\"><slot name=\\"testing\\" /></div>
+
     <div>
       <hr />
     </div>

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -2740,8 +2740,12 @@ class ContentSlotJsxCode extends HTMLElement {
 
     this._root.innerHTML = \`
       <div>
-        <template data-el=\\"div-content-slot-jsx-code-1\\">
-          <!-- props.slotTesting -->
+        <template data-el=\\"show-content-slot-jsx-code\\">
+          <div>
+            <template data-el=\\"div-content-slot-jsx-code-1\\">
+              <!-- props.slotTesting -->
+            </template>
+          </div>
         </template>
       
         <div>
@@ -2756,6 +2760,26 @@ class ContentSlotJsxCode extends HTMLElement {
     this.onMount();
     this.pendingUpdate = false;
     this.update();
+  }
+
+  showContent(el) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement/content
+    // grabs the content of a node that is between <template> tags
+    // iterates through child nodes to register all content including text elements
+    // attaches the content after the template
+
+    const elementFragment = el.content.cloneNode(true);
+    const children = Array.from(elementFragment.childNodes);
+    children.forEach((child) => {
+      if (el?.scope) {
+        child.scope = el.scope;
+      }
+      if (el?.context) {
+        child.context = el.context;
+      }
+      this.nodesToDestroy.push(child);
+    });
+    el.after(elementFragment);
   }
 
   onMount() {}
@@ -2779,6 +2803,15 @@ class ContentSlotJsxCode extends HTMLElement {
   }
 
   updateBindings() {
+    this._root
+      .querySelectorAll(\\"[data-el='show-content-slot-jsx-code']\\")
+      .forEach((el) => {
+        const whenCondition = this.props.slotTesting;
+        if (whenCondition) {
+          this.showContent(el);
+        }
+      });
+
     this._root
       .querySelectorAll(\\"[data-el='div-content-slot-jsx-code-1']\\")
       .forEach((el) => {

--- a/packages/core/src/__tests__/data/blocks/content-slot-jsx.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/content-slot-jsx.raw.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from '../../../../jsx-runtime';
+import { Show } from '@builder.io/mitosis';
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -7,7 +8,9 @@ type Props = {
 export default function ContentSlotJsxCode(props: Props) {
   return (
     <div>
-      {props.slotTesting}
+      <Show when={props.slotTesting}>
+        <div>{props.slotTesting}</div>
+      </Show>
       <div>
         <hr />
       </div>

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -35,7 +35,7 @@ import { GETTER } from '../helpers/patterns';
 import { OmitObj } from '../helpers/typescript';
 import { pipe } from 'fp-ts/lib/function';
 import { getCustomImports } from '../helpers/get-custom-imports';
-import { isSlotProperty, stripSlotPrefix, propSlotsToTemplateSlots } from '../helpers/slots';
+import { isSlotProperty, stripSlotPrefix, replaceSlotsInString } from '../helpers/slots';
 import { PropsDefinition, DefaultProps } from 'vue/types/options';
 
 function encodeQuotes(string: string) {
@@ -147,7 +147,10 @@ const NODE_MAPPERS: {
       : '';
   },
   Show(json, options, scope) {
-    const ifValue = propSlotsToTemplateSlots(stripStateAndPropsRefs(json.bindings.when?.code));
+    const ifValue = replaceSlotsInString(
+      stripStateAndPropsRefs(json.bindings.when?.code),
+      (slotName) => `$slots.${slotName}`,
+    );
 
     switch (options.vueVersion) {
       case 3:

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -35,7 +35,7 @@ import { GETTER } from '../helpers/patterns';
 import { OmitObj } from '../helpers/typescript';
 import { pipe } from 'fp-ts/lib/function';
 import { getCustomImports } from '../helpers/get-custom-imports';
-import { isSlotProperty, stripSlotPrefix } from '../helpers/slots';
+import { isSlotProperty, stripSlotPrefix, propSlotsToTemplateSlots } from '../helpers/slots';
 import { PropsDefinition, DefaultProps } from 'vue/types/options';
 
 function encodeQuotes(string: string) {
@@ -147,7 +147,7 @@ const NODE_MAPPERS: {
       : '';
   },
   Show(json, options, scope) {
-    const ifValue = stripStateAndPropsRefs(json.bindings.when?.code);
+    const ifValue = propSlotsToTemplateSlots(stripStateAndPropsRefs(json.bindings.when?.code));
 
     switch (options.vueVersion) {
       case 3:

--- a/packages/core/src/helpers/slots.ts
+++ b/packages/core/src/helpers/slots.ts
@@ -3,3 +3,6 @@ const SLOT_PREFIX = 'slot';
 export const isSlotProperty = (key: string): boolean => key.startsWith(SLOT_PREFIX);
 
 export const stripSlotPrefix = (key: string): string => key.substring(SLOT_PREFIX.length);
+
+export const propSlotsToTemplateSlots = (string: string) =>
+  string.replace(/(slot)(\w+)/g, (_match, _g1, g2) => '$slots.' + g2.toLowerCase());

--- a/packages/core/src/helpers/slots.ts
+++ b/packages/core/src/helpers/slots.ts
@@ -1,8 +1,21 @@
+import { types } from '@babel/core';
+import { babelTransformExpression } from './babel-transform';
+
 const SLOT_PREFIX = 'slot';
+export type SlotMapper = (slotName: string) => string;
 
 export const isSlotProperty = (key: string): boolean => key.startsWith(SLOT_PREFIX);
 
 export const stripSlotPrefix = (key: string): string => key.substring(SLOT_PREFIX.length);
 
-export const propSlotsToTemplateSlots = (string: string) =>
-  string.replace(/(slot)(\w+)/g, (_match, _g1, g2) => '$slots.' + g2.toLowerCase());
+export function replaceSlotsInString(code: string, mapper: SlotMapper) {
+  return babelTransformExpression(code, {
+    Identifier(path: babel.NodePath<babel.types.Identifier>) {
+      const name = path.node.name;
+      const isSlot = isSlotProperty(name);
+      if (isSlot) {
+        path.replaceWith(types.identifier(mapper(stripSlotPrefix(name).toLowerCase())));
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Description

PR updates prop slots syntax in Vue components used with `<Show>` component.

jsx component

```js
<Show when={props.slotName}>
```

current result
```js
<template v-if="props.slotName">
```

desired output
```js
<template v-if="$slots.name">
```

