### PR TITLE
fix(svelte): output more natural prop defs

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1,18 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Svelte AdvancedRef 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { afterUpdate } from \\"svelte\\";
 
-  export let inputRef: Props[\\"inputRef\\"];
-  export let inputNoArgRef: Props[\\"inputNoArgRef\\"];
-  export let showInput: Props[\\"showInput\\"];
+  export let inputRef: any;
+  export let inputNoArgRef: any;
+  export let showInput: boolean;
 
   const onBlur = function onBlur() {
     // Maintain focus
@@ -62,13 +56,7 @@ exports[`Svelte AdvancedRef 1`] = `
 `;
 
 exports[`Svelte Basic 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface MyBasicComponentProps {
-    id: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   export const DEFAULT_VALUES = {
     name: \\"Steve\\",
   };
@@ -160,18 +148,11 @@ exports[`Svelte Basic Context 1`] = `
 `;
 
 exports[`Svelte Basic OnMount Update 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    hi: string;
-    bye: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
-  export let hi: Props[\\"hi\\"];
-  export let bye: Props[\\"bye\\"];
+  export let hi: string;
+  export let bye: string;
 
   let name = \\"PatrickJS\\";
   let names = [\\"Steve\\", \\"PatrickJS\\"];
@@ -273,16 +254,10 @@ exports[`Svelte BasicFor 1`] = `
 `;
 
 exports[`Svelte BasicRef 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let inputRef: Props[\\"inputRef\\"];
-  export let inputNoArgRef: Props[\\"inputNoArgRef\\"];
-  export let showInput: Props[\\"showInput\\"];
+"<script lang=\\"ts\\">
+  export let inputRef: any;
+  export let inputNoArgRef: any;
+  export let showInput: boolean;
 
   const onBlur = function onBlur() {
     // Maintain focus
@@ -327,13 +302,7 @@ exports[`Svelte BasicRef 1`] = `
 `;
 
 exports[`Svelte BasicRefAssignment 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   const handlerClick = function handlerClick(event) {
     event.preventDefault();
     console.log(\\"current value\\", holdValueRef);
@@ -352,13 +321,7 @@ exports[`Svelte BasicRefAssignment 1`] = `
 `;
 
 exports[`Svelte BasicRefPrevious 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { afterUpdate } from \\"svelte\\";
 
   export function usePrevious<T>(value: T) {
@@ -396,20 +359,11 @@ exports[`Svelte BasicRefPrevious 1`] = `
 `;
 
 exports[`Svelte Button 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface ButtonProps {
-    attributes?: any;
-    text?: string;
-    link?: string;
-    openLinkInNewTab?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let link: ButtonProps[\\"link\\"];
-  export let attributes: ButtonProps[\\"attributes\\"];
-  export let openLinkInNewTab: ButtonProps[\\"openLinkInNewTab\\"];
-  export let text: ButtonProps[\\"text\\"];
+"<script lang=\\"ts\\">
+  export let link: string;
+  export let attributes: any;
+  export let openLinkInNewTab: boolean;
+  export let text: string;
 </script>
 
 {#if link}
@@ -432,12 +386,6 @@ exports[`Svelte Button 1`] = `
 
 exports[`Svelte Columns 1`] = `
 "<script context=\\"module\\" lang=\\"ts\\">
-  type Column = {
-    content: any; // TODO: Implement this when support for dynamic CSS lands
-
-    width?: number;
-  };
-
   export interface ColumnProps {
     columns?: Column[]; // TODO: Implement this when support for dynamic CSS lands
 
@@ -450,8 +398,8 @@ exports[`Svelte Columns 1`] = `
 </script>
 
 <script lang=\\"ts\\">
-  export let columns: ColumnProps[\\"columns\\"];
-  export let space: ColumnProps[\\"space\\"];
+  export let columns;
+  export let space;
 
   const getColumns = function getColumns() {
     return columns || [];
@@ -508,19 +456,12 @@ exports[`Svelte Columns 1`] = `
 `;
 
 exports[`Svelte CustomCode 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface CustomCodeProps {
-    code: string;
-    replaceNodes?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
-  export let elem: CustomCodeProps[\\"elem\\"];
-  export let replaceNodes: CustomCodeProps[\\"replaceNodes\\"];
-  export let code: CustomCodeProps[\\"code\\"];
+  export let elem: any;
+  export let replaceNodes: boolean;
+  export let code: string;
 
   const findAndRunScripts = function findAndRunScripts() {
     // TODO: Move this function to standalone one in '@builder.io/utils'
@@ -582,19 +523,12 @@ exports[`Svelte CustomCode 1`] = `
 `;
 
 exports[`Svelte Embed 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface CustomCodeProps {
-    code: string;
-    replaceNodes?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
-  export let elem: CustomCodeProps[\\"elem\\"];
-  export let replaceNodes: CustomCodeProps[\\"replaceNodes\\"];
-  export let code: CustomCodeProps[\\"code\\"];
+  export let elem: any;
+  export let replaceNodes: boolean;
+  export let code: string;
 
   const findAndRunScripts = function findAndRunScripts() {
     // TODO: Move this function to standalone one in '@builder.io/utils'
@@ -657,29 +591,6 @@ exports[`Svelte Embed 1`] = `
 
 exports[`Svelte Form 1`] = `
 "<script context=\\"module\\" lang=\\"ts\\">
-  export interface FormProps {
-    attributes?: any;
-    name?: string;
-    action?: string;
-    validate?: boolean;
-    method?: string;
-    builderBlock?: BuilderElement;
-    sendSubmissionsTo?: string;
-    sendSubmissionsToEmail?: string;
-    sendWithJs?: boolean;
-    contentType?: string;
-    customHeaders?: {
-      [key: string]: string;
-    };
-    successUrl?: string;
-    previewState?: FormState;
-    successMessage?: BuilderElement[];
-    errorMessage?: BuilderElement[];
-    sendingMessage?: BuilderElement[];
-    resetFormOnSubmit?: boolean;
-    errorMessagePath?: string;
-  }
-
   export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
 </script>
 
@@ -690,25 +601,25 @@ exports[`Svelte Form 1`] = `
   import { set } from \\"@fake\\";
   import { get } from \\"@fake\\";
 
-  export let formRef: FormProps[\\"formRef\\"];
-  export let previewState: FormProps[\\"previewState\\"];
-  export let sendWithJs: FormProps[\\"sendWithJs\\"];
-  export let sendSubmissionsTo: FormProps[\\"sendSubmissionsTo\\"];
-  export let action: FormProps[\\"action\\"];
-  export let customHeaders: FormProps[\\"customHeaders\\"];
-  export let contentType: FormProps[\\"contentType\\"];
-  export let sendSubmissionsToEmail: FormProps[\\"sendSubmissionsToEmail\\"];
-  export let name: FormProps[\\"name\\"];
-  export let method: FormProps[\\"method\\"];
-  export let errorMessagePath: FormProps[\\"errorMessagePath\\"];
-  export let resetFormOnSubmit: FormProps[\\"resetFormOnSubmit\\"];
-  export let successUrl: FormProps[\\"successUrl\\"];
-  export let validate: FormProps[\\"validate\\"];
-  export let attributes: FormProps[\\"attributes\\"];
-  export let builderBlock: FormProps[\\"builderBlock\\"];
-  export let errorMessage: FormProps[\\"errorMessage\\"];
-  export let sendingMessage: FormProps[\\"sendingMessage\\"];
-  export let successMessage: FormProps[\\"successMessage\\"];
+  export let formRef: any;
+  export let previewState: FormState;
+  export let sendWithJs: boolean;
+  export let sendSubmissionsTo: string;
+  export let action: string;
+  export let customHeaders: any;
+  export let contentType: string;
+  export let sendSubmissionsToEmail: string;
+  export let name: string;
+  export let method: string;
+  export let errorMessagePath: string;
+  export let resetFormOnSubmit: boolean;
+  export let successUrl: string;
+  export let validate: boolean;
+  export let attributes: any;
+  export let builderBlock: BuilderElement;
+  export let errorMessage: BuilderElement[];
+  export let sendingMessage: BuilderElement[];
+  export let successMessage: BuilderElement[];
 
   const onSubmit = function onSubmit(event) {
     const sendWithJs = sendWithJs || sendSubmissionsTo === \\"email\\";
@@ -979,39 +890,18 @@ exports[`Svelte Form 1`] = `
 `;
 
 exports[`Svelte Image 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  // TODO: AMP Support?
-  export interface ImageProps {
-    _class?: string;
-    image: string;
-    sizes?: string;
-    lazy?: boolean;
-    height?: number;
-    width?: number;
-    altText?: string;
-    backgroundSize?: string;
-    backgroundPosition?: string; // TODO: Support generating Builder.io and or Shopify \`srcset\`s when needed
-
-    srcset?: string; // TODO: Implement support for custom aspect ratios
-
-    aspectRatio?: number; // TODO: This might not work as expected in terms of positioning
-
-    children?: any;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
   import { onDestroy } from \\"svelte\\";
 
-  export let pictureRef: ImageProps[\\"pictureRef\\"];
-  export let lazy: ImageProps[\\"lazy\\"];
-  export let altText: ImageProps[\\"altText\\"];
-  export let _class: ImageProps[\\"_class\\"];
-  export let image: ImageProps[\\"image\\"];
-  export let srcset: ImageProps[\\"srcset\\"];
-  export let sizes: ImageProps[\\"sizes\\"];
+  export let pictureRef: any;
+  export let lazy: boolean;
+  export let altText: string;
+  export let _class: string;
+  export let image: string;
+  export let srcset: string;
+  export let sizes: string;
 
   const setLoaded = function setLoaded() {
     imageLoaded = true;
@@ -1109,33 +999,23 @@ exports[`Svelte Image State 1`] = `
 `;
 
 exports[`Svelte Img 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface ImgProps {
-    attributes?: any;
-    imgSrc?: string;
-    altText?: string;
-    backgroundSize?: \\"cover\\" | \\"contain\\";
-    backgroundPosition?:
-      | \\"center\\"
-      | \\"top\\"
-      | \\"left\\"
-      | \\"right\\"
-      | \\"bottom\\"
-      | \\"top left\\"
-      | \\"top right\\"
-      | \\"bottom left\\"
-      | \\"bottom right\\";
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { Builder } from \\"@builder.io/sdk\\";
 
-  export let backgroundSize: ImgProps[\\"backgroundSize\\"];
-  export let backgroundPosition: ImgProps[\\"backgroundPosition\\"];
-  export let attributes: ImgProps[\\"attributes\\"];
-  export let imgSrc: ImgProps[\\"imgSrc\\"];
-  export let altText: ImgProps[\\"altText\\"];
+  export let backgroundSize: \\"cover\\" | \\"contain\\";
+  export let backgroundPosition:
+    | \\"center\\"
+    | \\"top\\"
+    | \\"left\\"
+    | \\"right\\"
+    | \\"bottom\\"
+    | \\"top left\\"
+    | \\"top right\\"
+    | \\"bottom left\\"
+    | \\"bottom right\\";
+  export let attributes: any;
+  export let imgSrc: string;
+  export let altText: string;
 
   function mitosis_styling(node, vars) {
     Object.entries(vars).forEach(([p, v]) => {
@@ -1158,28 +1038,16 @@ exports[`Svelte Img 1`] = `
 `;
 
 exports[`Svelte Input 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface FormInputProps {
-    type?: string;
-    attributes?: any;
-    name?: string;
-    value?: string;
-    placeholder?: string;
-    defaultValue?: string;
-    required?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { Builder } from \\"@builder.io/sdk\\";
 
-  export let attributes: FormInputProps[\\"attributes\\"];
-  export let defaultValue: FormInputProps[\\"defaultValue\\"];
-  export let placeholder: FormInputProps[\\"placeholder\\"];
-  export let type: FormInputProps[\\"type\\"];
-  export let name: FormInputProps[\\"name\\"];
-  export let value: FormInputProps[\\"value\\"];
-  export let required: FormInputProps[\\"required\\"];
+  export let attributes: any;
+  export let defaultValue: string;
+  export let placeholder: string;
+  export let type: string;
+  export let name: string;
+  export let value: string;
+  export let required: boolean;
 </script>
 
 <input
@@ -1196,16 +1064,9 @@ exports[`Svelte Input 1`] = `
 `;
 
 exports[`Svelte RawText 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface RawTextProps {
-    attributes?: any;
-    text?: string; // builderBlock?: any;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: RawTextProps[\\"attributes\\"];
-  export let text: RawTextProps[\\"text\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
+  export let text: string;
 </script>
 
 <span class={attributes?.class || attributes?.className}
@@ -1224,17 +1085,9 @@ exports[`Svelte Remove Internal mitosis package 1`] = `
 `;
 
 exports[`Svelte Section 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface SectionProps {
-    maxWidth?: number;
-    attributes?: any;
-    children?: any;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: SectionProps[\\"attributes\\"];
-  export let maxWidth: SectionProps[\\"maxWidth\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
+  export let maxWidth: number;
 
   function mitosis_styling(node, vars) {
     Object.entries(vars).forEach(([p, v]) => {
@@ -1257,16 +1110,8 @@ exports[`Svelte Section 1`] = `
 `;
 
 exports[`Svelte Section 2`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface SectionProps {
-    maxWidth?: number;
-    attributes?: any;
-    children?: any;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: SectionProps[\\"attributes\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
 
   function mitosis_styling(node, vars) {
     Object.entries(vars).forEach(([p, v]) => {
@@ -1294,27 +1139,14 @@ exports[`Svelte Section 2`] = `
 `;
 
 exports[`Svelte Select 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface FormSelectProps {
-    options?: {
-      name?: string;
-      value: string;
-    }[];
-    attributes?: any;
-    name?: string;
-    value?: string;
-    defaultValue?: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { Builder } from \\"@builder.io/sdk\\";
 
-  export let attributes: FormSelectProps[\\"attributes\\"];
-  export let value: FormSelectProps[\\"value\\"];
-  export let defaultValue: FormSelectProps[\\"defaultValue\\"];
-  export let name: FormSelectProps[\\"name\\"];
-  export let options: FormSelectProps[\\"options\\"];
+  export let attributes: any;
+  export let value: string;
+  export let defaultValue: string;
+  export let name: string;
+  export let options: any;
 </script>
 
 <select
@@ -1334,21 +1166,14 @@ exports[`Svelte Select 1`] = `
 `;
 
 exports[`Svelte Stamped.io 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type SmileReviewsProps = {
-    productId: string;
-    apiKey: string;
-  };
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
   import { kebabCase } from \\"lodash\\";
   import { snakeCase } from \\"lodash\\";
 
-  export let apiKey: SmileReviewsProps[\\"apiKey\\"];
-  export let productId: SmileReviewsProps[\\"productId\\"];
+  export let apiKey: string;
+  export let productId: string;
 
   const kebabCaseValue = function kebabCaseValue() {
     return kebabCase(\\"testThat\\");
@@ -1440,16 +1265,9 @@ exports[`Svelte Stamped.io 1`] = `
 `;
 
 exports[`Svelte Submit 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface ButtonProps {
-    attributes?: any;
-    text?: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: ButtonProps[\\"attributes\\"];
-  export let text: ButtonProps[\\"text\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
+  export let text: string;
 </script>
 
 <button {...attributes} type=\\"submit\\">
@@ -1459,21 +1277,11 @@ exports[`Svelte Submit 1`] = `
 `;
 
 exports[`Svelte Text 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface TextProps {
-    attributes?: any;
-    rtlMode: boolean;
-    text?: string;
-    content?: string;
-    builderBlock?: any;
-  }
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   import { Builder } from \\"@builder.io/sdk\\";
 
-  export let text: TextProps[\\"text\\"];
-  export let content: TextProps[\\"content\\"];
+  export let text: string;
+  export let content: string;
 
   let name = \\"Decadef20\\";
 </script>
@@ -1490,22 +1298,12 @@ exports[`Svelte Text 1`] = `
 `;
 
 exports[`Svelte Textarea 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface TextareaProps {
-    attributes?: any;
-    name?: string;
-    value?: string;
-    defaultValue?: string;
-    placeholder?: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: TextareaProps[\\"attributes\\"];
-  export let placeholder: TextareaProps[\\"placeholder\\"];
-  export let name: TextareaProps[\\"name\\"];
-  export let value: TextareaProps[\\"value\\"];
-  export let defaultValue: TextareaProps[\\"defaultValue\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
+  export let placeholder: string;
+  export let name: string;
+  export let value: string;
+  export let defaultValue: string;
 </script>
 
 <textarea {...attributes} {placeholder} {name} {value} {defaultValue} />
@@ -1513,44 +1311,25 @@ exports[`Svelte Textarea 1`] = `
 `;
 
 exports[`Svelte Video 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface VideoProps {
-    attributes?: any;
-    video?: string;
-    autoPlay?: boolean;
-    controls?: boolean;
-    muted?: boolean;
-    loop?: boolean;
-    playsInline?: boolean;
-    aspectRatio?: number;
-    width?: number;
-    height?: number;
-    fit?: \\"contain\\" | \\"cover\\" | \\"fill\\";
-    position?:
-      | \\"center\\"
-      | \\"top\\"
-      | \\"left\\"
-      | \\"right\\"
-      | \\"bottom\\"
-      | \\"top left\\"
-      | \\"top right\\"
-      | \\"bottom left\\"
-      | \\"bottom right\\";
-    posterImage?: string;
-    lazyLoad?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let attributes: VideoProps[\\"attributes\\"];
-  export let fit: VideoProps[\\"fit\\"];
-  export let position: VideoProps[\\"position\\"];
-  export let video: VideoProps[\\"video\\"];
-  export let posterImage: VideoProps[\\"posterImage\\"];
-  export let autoPlay: VideoProps[\\"autoPlay\\"];
-  export let muted: VideoProps[\\"muted\\"];
-  export let controls: VideoProps[\\"controls\\"];
-  export let loop: VideoProps[\\"loop\\"];
+"<script lang=\\"ts\\">
+  export let attributes: any;
+  export let fit: \\"contain\\" | \\"cover\\" | \\"fill\\";
+  export let position:
+    | \\"center\\"
+    | \\"top\\"
+    | \\"left\\"
+    | \\"right\\"
+    | \\"bottom\\"
+    | \\"top left\\"
+    | \\"top right\\"
+    | \\"bottom left\\"
+    | \\"bottom right\\";
+  export let video: string;
+  export let posterImage: string;
+  export let autoPlay: boolean;
+  export let muted: boolean;
+  export let controls: boolean;
+  export let loop: boolean;
 
   function mitosis_styling(node, vars) {
     Object.entries(vars).forEach(([p, v]) => {
@@ -1583,15 +1362,8 @@ exports[`Svelte Video 1`] = `
 `;
 
 exports[`Svelte basicForwardRef 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-    inputRef: HTMLInputElement;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let inputRef: Props[\\"inputRef\\"];
+"<script lang=\\"ts\\">
+  export let inputRef: HTMLInputElement;
 
   let name = \\"PatrickJS\\";
 </script>
@@ -1609,15 +1381,8 @@ exports[`Svelte basicForwardRef 1`] = `
 `;
 
 exports[`Svelte basicForwardRefMetadata 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface Props {
-    showInput: boolean;
-    inputRef: HTMLInputElement;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let inputRef: Props[\\"inputRef\\"];
+"<script lang=\\"ts\\">
+  export let inputRef: HTMLInputElement;
 
   let name = \\"PatrickJS\\";
 </script>
@@ -1708,14 +1473,7 @@ exports[`Svelte className + css 1`] = `
 `;
 
 exports[`Svelte className 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type Props = {
-    [key: string]: string | JSX.Element;
-    slotTesting: JSX.Element;
-  };
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   let bindings = \\"a binding\\";
 </script>
 
@@ -1728,20 +1486,11 @@ exports[`Svelte className 1`] = `
 `;
 
 exports[`Svelte defaultProps 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface ButtonProps {
-    attributes?: any;
-    text?: string;
-    link?: string;
-    openLinkInNewTab?: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let link: ButtonProps[\\"link\\"] = \\"https://builder.io/\\";
-  export let attributes: ButtonProps[\\"attributes\\"];
-  export let openLinkInNewTab: ButtonProps[\\"openLinkInNewTab\\"] = false;
-  export let text: ButtonProps[\\"text\\"] = \\"default text\\";
+"<script lang=\\"ts\\">
+  export let link: string = \\"https://builder.io/\\";
+  export let attributes: any;
+  export let openLinkInNewTab: boolean = false;
+  export let text: string = \\"default text\\";
 </script>
 
 {#if link}
@@ -1763,18 +1512,12 @@ exports[`Svelte defaultProps 1`] = `
 `;
 
 exports[`Svelte defaultValsWithTypes 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type Props = {
-    name: string;
-  };
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   const DEFAULT_VALUES: Props = {
     name: \\"Sami\\",
   };
 
-  export let name: Props[\\"name\\"];
+  export let name: string;
 </script>
 
 <div>Hello {name || DEFAULT_VALUES.name}</div>
@@ -1829,16 +1572,9 @@ exports[`Svelte multipleOnUpdateWithDeps 1`] = `
 `;
 
 exports[`Svelte nestedShow 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  interface Props {
-    conditionA: boolean;
-    conditionB: boolean;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let conditionA: Props[\\"conditionA\\"];
-  export let conditionB: Props[\\"conditionB\\"];
+"<script lang=\\"ts\\">
+  export let conditionA: boolean;
+  export let conditionB: boolean;
 </script>
 
 {#if conditionA}
@@ -1893,18 +1629,12 @@ exports[`Svelte onInit & onMount 1`] = `
 `;
 
 exports[`Svelte onInit 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type Props = {
-    name: string;
-  };
-</script>
-
-<script lang=\\"ts\\">
+"<script lang=\\"ts\\">
   export const defaultValues = {
     name: \\"PatrickJS\\",
   };
 
-  export let name: Props[\\"name\\"];
+  export let name: string;
 
   let name = \\"\\";
 </script>
@@ -1964,10 +1694,6 @@ exports[`Svelte onUpdateWithDeps 1`] = `
 
 exports[`Svelte preserveExportOrLocalStatement 1`] = `
 "<script context=\\"module\\" lang=\\"ts\\">
-  type Types = {
-    s: any[];
-  };
-
   interface IPost {
     len: number;
   }
@@ -1991,8 +1717,6 @@ exports[`Svelte preserveExportOrLocalStatement 1`] = `
 
 exports[`Svelte preserveTyping 1`] = `
 "<script context=\\"module\\" lang=\\"ts\\">
-  export type A = \\"test\\";
-
   export interface C {
     n: \\"test\\";
   }
@@ -2010,7 +1734,7 @@ exports[`Svelte preserveTyping 1`] = `
 </script>
 
 <script lang=\\"ts\\">
-  export let name: MyBasicComponentProps[\\"name\\"];
+  export let name;
 </script>
 
 <div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
@@ -2018,15 +1742,8 @@ exports[`Svelte preserveTyping 1`] = `
 `;
 
 exports[`Svelte propsDestructure 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type Props = {
-    children: any;
-    type: string;
-  };
-</script>
-
-<script lang=\\"ts\\">
-  export let type: Props[\\"type\\"];
+"<script lang=\\"ts\\">
+  export let type: string;
 
   let name = \\"Decadef20\\";
 </script>
@@ -2040,15 +1757,8 @@ exports[`Svelte propsDestructure 1`] = `
 `;
 
 exports[`Svelte propsInterface 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  interface Person {
-    name: string;
-    age?: number;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let name: Person[\\"name\\"];
+"<script lang=\\"ts\\">
+  export let name: string;
 </script>
 
 <div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
@@ -2056,15 +1766,8 @@ exports[`Svelte propsInterface 1`] = `
 `;
 
 exports[`Svelte propsType 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  type Person = {
-    name: string;
-    age?: number;
-  };
-</script>
-
-<script lang=\\"ts\\">
-  export let name: Person[\\"name\\"];
+"<script lang=\\"ts\\">
+  export let name: string;
 </script>
 
 <div>Hello! I can run in React, Vue, Solid, or Liquid! {name}</div>
@@ -2072,14 +1775,8 @@ exports[`Svelte propsType 1`] = `
 `;
 
 exports[`Svelte rootShow 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  export interface RenderStylesProps {
-    foo: string;
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let foo: RenderStylesProps[\\"foo\\"];
+"<script lang=\\"ts\\">
+  export let foo;
 </script>
 
 {#if foo === \\"bar\\"}
@@ -2124,16 +1821,9 @@ exports[`Svelte self-referencing component with children 1`] = `
 `;
 
 exports[`Svelte showWithFor 1`] = `
-"<script context=\\"module\\" lang=\\"ts\\">
-  interface Props {
-    conditionA: boolean;
-    items: string[];
-  }
-</script>
-
-<script lang=\\"ts\\">
-  export let conditionA: Props[\\"conditionA\\"];
-  export let items: Props[\\"items\\"];
+"<script lang=\\"ts\\">
+  export let conditionA: boolean;
+  export let items: string[];
 </script>
 
 {#if conditionA}
@@ -2157,8 +1847,6 @@ exports[`Svelte subComponent 1`] = `
 
 exports[`Svelte typeDependency 1`] = `
 "<script context=\\"module\\" lang=\\"ts\\">
-  import type { Foo } from \\"./foo-type\\";
-
   import type { Foo as Foo2 } from \\"./type-export\\";
 
   export type TypeDependencyProps = {
@@ -2168,7 +1856,7 @@ exports[`Svelte typeDependency 1`] = `
 </script>
 
 <script lang=\\"ts\\">
-  export let foo: TypeDependencyProps[\\"foo\\"];
+  export let foo;
 </script>
 
 <div>{foo}</div>

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -36,7 +36,7 @@ import { uniq } from 'lodash';
 import { isUpperCase } from '../helpers/is-upper-case';
 import json5 from 'json5';
 import { propTypesToJson } from '../helpers/prop-types-to-json';
-import { JSONObject } from 'src/types/json';
+import { JSONObject } from '../types/json';
 
 export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -35,6 +35,8 @@ import { VALID_HTML_TAGS } from '../constants/html_tags';
 import { uniq } from 'lodash';
 import { isUpperCase } from '../helpers/is-upper-case';
 import json5 from 'json5';
+import { propTypesToJson } from '../helpers/prop-types-to-json';
+import { JSONObject } from 'src/types/json';
 
 export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';
@@ -385,10 +387,12 @@ export const componentToSvelte =
 
     let str = '';
 
+    const jsonTypes: JSONObject = propTypesToJson(props, json);
+
     if (json.types?.length) {
       str += dedent`
       <script context='module' lang='ts'>
-        ${json.types ? json.types.join('\n\n') + '\n' : ''}
+        ${json.types?.length ? json.types.join('\n\n') + '\n' : ''}
       </script>
       \n
       \n
@@ -412,8 +416,8 @@ export const componentToSvelte =
 
           let propDeclaration = `export let ${name}`;
 
-          if (json.propsTypeRef && json.propsTypeRef !== 'any') {
-            propDeclaration += `: ${json.propsTypeRef.split(' |')[0]}['${name}']`;
+          if (Object.keys(jsonTypes).length) {
+            propDeclaration += `: ${jsonTypes[name] ?? 'any'}`;
           }
 
           if (json.defaultProps && json.defaultProps.hasOwnProperty(name)) {

--- a/packages/core/src/helpers/prop-types-to-json.ts
+++ b/packages/core/src/helpers/prop-types-to-json.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from 'src/types/json';
+import { JSONObject } from '../types/json';
 import { MitosisComponent } from '..';
 
 export const propTypesToJson = (

--- a/packages/core/src/helpers/prop-types-to-json.ts
+++ b/packages/core/src/helpers/prop-types-to-json.ts
@@ -1,0 +1,28 @@
+import { JSONObject } from 'src/types/json';
+import { MitosisComponent } from '..';
+
+export const propTypesToJson = (
+  props: string[], // collected props
+  json: MitosisComponent,
+  strip = true, // strip the prop types from json.types after collecting them
+): JSONObject => {
+  let obj: JSONObject = {};
+
+  if (json.types?.length && json.propsTypeRef) {
+    let propTypeIndex = json.types.findIndex((t: string) => t.indexOf(`${json.propsTypeRef} =`));
+    if (propTypeIndex >= 0) {
+      let propTypes = strip
+        ? json.types.splice(propTypeIndex, 1)
+        : json.types.slice(propTypeIndex, 1);
+      props.forEach((prop) => {
+        let regexp = new RegExp(`(?<=${prop}[\?]*: )(.*?)(?=\;)`);
+        const matches = propTypes[0].match(regexp);
+        if (matches?.length) {
+          obj[prop] = matches[0];
+        }
+      });
+    }
+  }
+
+  return obj;
+};


### PR DESCRIPTION
## Description

Outputs a more 'natural way' of Svelte code.
As described in https://github.com/BuilderIO/mitosis/pull/632 , you probably won't write the prop declarations in Svelte by
1. Defining the props type in a context module script
2. Then defining the type like this for example: Props['name']

You would more likely write `export let name: string;` instead

Examples:

Before:
<img width="1263" alt="Screenshot 2022-08-28 at 16 18 55" src="https://user-images.githubusercontent.com/3808818/187078829-e56072d9-f07e-4e04-9f6a-513ebe6a8e22.png">

<img width="1643" alt="Screenshot 2022-08-28 at 16 19 25" src="https://user-images.githubusercontent.com/3808818/187078834-b755f80e-4a46-416d-8204-21d67a97d7cd.png">

After:

<img width="1364" alt="Screenshot 2022-08-28 at 16 26 52" src="https://user-images.githubusercontent.com/3808818/187079067-47cbbfbb-5aae-4056-a497-3273277aebd0.png">


<img width="1683" alt="Screenshot 2022-08-28 at 16 27 03" src="https://user-images.githubusercontent.com/3808818/187079086-462a62bd-55ac-42ba-bbf9-18ffe6575ab0.png">





