### PR TITLE
fix(svelte): only export props / define refs without exporting them

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -10,8 +10,6 @@ exports[`Svelte AdvancedRef 1`] = `
 <script lang=\\"ts\\">
   import { afterUpdate } from \\"svelte\\";
 
-  export let inputRef: Props[\\"inputRef\\"];
-  export let inputNoArgRef: Props[\\"inputNoArgRef\\"];
   export let showInput: Props[\\"showInput\\"];
 
   const onBlur = function onBlur() {
@@ -22,6 +20,9 @@ exports[`Svelte AdvancedRef 1`] = `
   const lowerCaseName = function lowerCaseName() {
     return name.toLowerCase();
   };
+
+  let inputRef;
+  let inputNoArgRef;
 
   let name = \\"PatrickJS\\";
 
@@ -280,8 +281,6 @@ exports[`Svelte BasicRef 1`] = `
 </script>
 
 <script lang=\\"ts\\">
-  export let inputRef: Props[\\"inputRef\\"];
-  export let inputNoArgRef: Props[\\"inputNoArgRef\\"];
   export let showInput: Props[\\"showInput\\"];
 
   const onBlur = function onBlur() {
@@ -292,6 +291,9 @@ exports[`Svelte BasicRef 1`] = `
   const lowerCaseName = function lowerCaseName() {
     return name.toLowerCase();
   };
+
+  let inputRef;
+  let inputNoArgRef;
 
   let name = \\"PatrickJS\\";
 </script>
@@ -518,7 +520,6 @@ exports[`Svelte CustomCode 1`] = `
 <script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
-  export let elem: CustomCodeProps[\\"elem\\"];
   export let replaceNodes: CustomCodeProps[\\"replaceNodes\\"];
   export let code: CustomCodeProps[\\"code\\"];
 
@@ -563,6 +564,8 @@ exports[`Svelte CustomCode 1`] = `
       }
     }
   };
+
+  let elem;
 
   let scriptsInserted = [];
   let scriptsRun = [];
@@ -592,7 +595,6 @@ exports[`Svelte Embed 1`] = `
 <script lang=\\"ts\\">
   import { onMount } from \\"svelte\\";
 
-  export let elem: CustomCodeProps[\\"elem\\"];
   export let replaceNodes: CustomCodeProps[\\"replaceNodes\\"];
   export let code: CustomCodeProps[\\"code\\"];
 
@@ -637,6 +639,8 @@ exports[`Svelte Embed 1`] = `
       }
     }
   };
+
+  let elem;
 
   let scriptsInserted = [];
   let scriptsRun = [];
@@ -690,7 +694,6 @@ exports[`Svelte Form 1`] = `
   import { set } from \\"@fake\\";
   import { get } from \\"@fake\\";
 
-  export let formRef: FormProps[\\"formRef\\"];
   export let previewState: FormProps[\\"previewState\\"];
   export let sendWithJs: FormProps[\\"sendWithJs\\"];
   export let sendSubmissionsTo: FormProps[\\"sendSubmissionsTo\\"];
@@ -927,6 +930,8 @@ exports[`Svelte Form 1`] = `
     return (Builder.isEditing && previewState) || formState;
   };
 
+  let formRef;
+
   let formState = \\"unsubmitted\\";
   let responseData = null;
   let formErrorMessage = \\"\\";
@@ -1005,7 +1010,6 @@ exports[`Svelte Image 1`] = `
 
   import { onDestroy } from \\"svelte\\";
 
-  export let pictureRef: ImageProps[\\"pictureRef\\"];
   export let lazy: ImageProps[\\"lazy\\"];
   export let altText: ImageProps[\\"altText\\"];
   export let _class: ImageProps[\\"_class\\"];
@@ -1027,6 +1031,8 @@ exports[`Svelte Image 1`] = `
       typeof window !== \\"undefined\\" && window.navigator.product != \\"ReactNative\\"
     );
   };
+
+  let pictureRef;
 
   let scrollListener = null;
   let imageLoaded = false;
@@ -1593,6 +1599,8 @@ exports[`Svelte basicForwardRef 1`] = `
 <script lang=\\"ts\\">
   export let inputRef: Props[\\"inputRef\\"];
 
+  let inputRef;
+
   let name = \\"PatrickJS\\";
 </script>
 
@@ -1618,6 +1626,8 @@ exports[`Svelte basicForwardRefMetadata 1`] = `
 
 <script lang=\\"ts\\">
   export let inputRef: Props[\\"inputRef\\"];
+
+  let inputRef;
 
   let name = \\"PatrickJS\\";
 </script>

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -32,7 +32,6 @@ import { babelTransformCode } from '../helpers/babel-transform';
 import { pipe } from 'fp-ts/lib/function';
 import { hasContext } from './helpers/context';
 import { VALID_HTML_TAGS } from '../constants/html_tags';
-import { uniq } from 'lodash';
 import { isUpperCase } from '../helpers/is-upper-case';
 import json5 from 'json5';
 

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -404,7 +404,7 @@ export const componentToSvelte =
       ${hasContext(component) ? 'import { getContext, setContext } from "svelte";' : ''}
 
       ${!hasData || options.stateType === 'variables' ? '' : `import onChange from 'on-change'`}
-      ${uniq(refs.map((ref) => stripStateAndPropsRefs(ref)).concat(props))
+      ${props
         .map((name) => {
           if (name === 'children') {
             return '';
@@ -439,6 +439,8 @@ export const componentToSvelte =
 
       ${functionsString.length < 4 ? '' : functionsString}
       ${getterString.length < 4 ? '' : getterString}
+
+      ${refs.map((ref) => `let ${stripStateAndPropsRefs(ref)}`).join('\n')}
 
       ${
         options.stateType === 'proxies'


### PR DESCRIPTION
## Description

Only export props and not refs.

In svelte `export let` defines a prop.

Before:
<img width="1206" alt="Screenshot 2022-08-28 at 22 26 39" src="https://user-images.githubusercontent.com/3808818/187093236-7084dca6-f687-4dd0-bfb1-0c4d192e4140.png">

After:
<img width="1287" alt="Screenshot 2022-08-28 at 22 26 31" src="https://user-images.githubusercontent.com/3808818/187093232-f05a96e4-63cf-4dcb-8dd5-97152ebfb790.png">

