### PR TITLE
fix(core): move `vue-template-compiler` to peerDependencies (fix #316)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,8 +87,7 @@
     "svelte": "^3.30.0",
     "traverse": "^0.6.6",
     "typescript": "^4.7.3",
-    "vue": "~2.6",
-    "vue-template-compiler": "~2.6"
+    "vue": "~2.6"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.6.0",
@@ -117,7 +116,11 @@
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
     "typescript": "^4",
-    "universalify": "^2.0.0"
+    "universalify": "^2.0.0",
+    "vue-template-compiler": "~2.6"
+  },
+  "peerDependencies": {
+    "vue-template-compiler": "~2.6"
   },
   "stableVersion": "0.0.56-107"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,6 +2654,8 @@ __metadata:
     universalify: ^2.0.0
     vue: ~2.6
     vue-template-compiler: ~2.6
+  peerDependencies:
+    vue-template-compiler: ~2.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Move `vue-template-compiler` (used in packages/core/parsers/liquid) from `dependencies` to `peerDependencies`, allowing people to use Mitosis together with Vue 3 packages (otherwise a conflict is raised and they can't be installed). See #316

It was also necessary to add `vue-template-compiler` to the `devDependencies` so that the tests can run.