### PR TITLE
feat: avoid using JavaScript keyword as property name

### DIFF
--- a/examples/basic/src/blocks/image.lite.tsx
+++ b/examples/basic/src/blocks/image.lite.tsx
@@ -1,7 +1,7 @@
 import { Show } from '@builder.io/mitosis';
 
 export interface ImageProps {
-  class?: string;
+  classProp?: string;
   image: string;
   sizes?: string;
   lazy?: boolean;
@@ -37,7 +37,7 @@ export default function Image(props: ImageProps) {
             objectPosition: props.backgroundSize || 'center',
             objectFit: (props.backgroundSize as any) || 'cover',
           }}
-          class={'class-image' + (props.class ? ' ' + props.class : '')}
+          class={'class-image' + (props.classProp ? ' ' + props.classProp : '')}
           src={props.image}
           // TODO: memoize on image on client
           srcset={props.srcset}

--- a/packages/core/src/helpers/get-props.ts
+++ b/packages/core/src/helpers/get-props.ts
@@ -15,8 +15,8 @@ const prohibitedKeywordRE = new RegExp(
     )
       .split(',')
       .join('\\b|\\b') +
-    '\\b'
-)
+    '\\b',
+);
 
 /**
  * Get props used in the components by reference
@@ -29,9 +29,9 @@ export const getProps = (json: MitosisComponent) => {
       const matches = item.match(allPropsMatchesRegex);
       if (matches) {
         for (const match of matches) {
-          const prop = match.match(propsRegex)![1]
-          if(prop.match(prohibitedKeywordRE)) {
-            throw new Error(`avoid using JavaScript keyword as property name: "${prop}"`)
+          const prop = match.match(propsRegex)![1];
+          if (prop.match(prohibitedKeywordRE)) {
+            throw new Error(`avoid using JavaScript keyword as property name: "${prop}"`);
           }
           props.add(prop);
         }

--- a/packages/core/src/helpers/get-props.ts
+++ b/packages/core/src/helpers/get-props.ts
@@ -4,6 +4,7 @@ import { MitosisComponent } from '../types/mitosis-component';
 const propsRegex = /props\s*\.\s*([a-zA-Z0-9_\$]+)/;
 const allPropsMatchesRegex = new RegExp(propsRegex, 'g');
 
+// copied from https://github.com/vuejs/core/blob/fa6556a0d56eeff1fec4f948460351ccf8f99f35/packages/compiler-core/src/validateExpression.ts
 // typeof, instanceof and in are allowed
 const prohibitedKeywordRE = new RegExp(
   '\\b' +

--- a/packages/core/src/helpers/get-props.ts
+++ b/packages/core/src/helpers/get-props.ts
@@ -4,6 +4,19 @@ import { MitosisComponent } from '../types/mitosis-component';
 const propsRegex = /props\s*\.\s*([a-zA-Z0-9_\$]+)/;
 const allPropsMatchesRegex = new RegExp(propsRegex, 'g');
 
+// typeof, instanceof and in are allowed
+const prohibitedKeywordRE = new RegExp(
+  '\\b' +
+    (
+      'do,if,for,let,new,try,var,case,else,with,await,break,catch,class,const,' +
+      'super,throw,while,yield,delete,export,import,return,switch,default,' +
+      'extends,finally,continue,debugger,function,arguments,typeof,void'
+    )
+      .split(',')
+      .join('\\b|\\b') +
+    '\\b'
+)
+
 /**
  * Get props used in the components by reference
  */
@@ -15,7 +28,11 @@ export const getProps = (json: MitosisComponent) => {
       const matches = item.match(allPropsMatchesRegex);
       if (matches) {
         for (const match of matches) {
-          props.add(match.match(propsRegex)![1]);
+          const prop = match.match(propsRegex)![1]
+          if(prop.match(prohibitedKeywordRE)) {
+            throw new Error(`avoid using JavaScript keyword as property name: "${prop}"`)
+          }
+          props.add(prop);
         }
       }
     }


### PR DESCRIPTION
## Description
#688 
Add a short description of:
- throw an Error when js keywords used as props, 
-  js keywords should not be used as var

I get the `prohibitedKeywordRE` from [vue/core](https://github.com/vuejs/core/blob/fa6556a0d56eeff1fec4f948460351ccf8f99f35/packages/compiler-core/src/validateExpression.ts)

