### PR TITLE
feat: pass path to custom parser

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -64,7 +64,7 @@ const getMitosisComponentJSONs = async (options: MitosisConfig) => {
       async (path) => {
         try {
           const file = await readFile(path, 'utf8');
-          const parsed = await (options.parser ? options.parser(file) : parseJsx(file));
+          const parsed = await (options.parser ? options.parser(file, path) : parseJsx(file));
           return {
             path,
             mitosisJson: parsed,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -62,5 +62,5 @@ export type MitosisConfig = {
    * Configure a custom parser function which takes a string and returns MitosisJSON
    * Defaults to the JSXParser of this project (src/parsers/jsx)
    */
-  parser?: (code: string) => MitosisComponent;
+  parser?: (code: string, path?: string) => MitosisComponent;
 };


### PR DESCRIPTION
## Description

Pass a second argument containing the path to a custom parser to allow a custom parser to derive the component name.