### PR TITLE
refactor(core): useStore runtime error

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ export type Context<T> = {};
 // These compile away
 export const useStore = <T>(obj: T): T => {
   throw new Error('useStore: Mitosis hook should have been compiled away');
-  return T;
+  return obj as T;
 };
 export const useState = <T>(obj: T): [T, (value: T) => void] => {
   throw new Error('useState: Mitosis hook should have been compiled away');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,10 @@ export * from './flow';
 export type Context<T> = {};
 
 // These compile away
-export const useStore = <T>(obj: T) => obj;
+export const useStore = <T>(obj: T): [T, (value: T) => T] => {
+  throw new Error('useStore: Mitosis hook should have been compiled away');
+  return obj as T;
+};
 export const useState = <T>(obj: T): [T, (value: T) => void] => {
   throw new Error('useState: Mitosis hook should have been compiled away');
   return null as any;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,9 +3,9 @@ export * from './flow';
 export type Context<T> = {};
 
 // These compile away
-export const useStore = <T>(obj: T): [T, (value: T) => T] => {
+export const useStore = <T>(obj: T): T => {
   throw new Error('useStore: Mitosis hook should have been compiled away');
-  return obj as T;
+  return T;
 };
 export const useState = <T>(obj: T): [T, (value: T) => void] => {
   throw new Error('useState: Mitosis hook should have been compiled away');


### PR DESCRIPTION
## Description
add runtime error if the Mitosis file was compiled through Babel and is imported.