### PR TITLE
fix: remove slots from prop definitions in vue

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -549,9 +549,7 @@ exports[`Vue Javascript Test ContentSlotHtml 1`] = `
   </div>
 </template>
 
-<script setup>
-const props = defineProps([\\"slotTesting\\"]);
-</script>
+<script setup></script>
 "
 `;
 
@@ -570,7 +568,7 @@ exports[`Vue Javascript Test ContentSlotJSX 1`] = `
 </template>
 
 <script setup>
-const props = defineProps([\\"slotTesting\\", \\"children\\"]);
+const props = defineProps([\\"children\\"]);
 </script>
 "
 `;
@@ -2805,8 +2803,6 @@ type Props = {
   [key: string]: string | JSX.Element;
   slotTesting: JSX.Element;
 };
-
-const props = defineProps<Props>();
 </script>
 "
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -560,8 +560,6 @@ exports[`Vue Javascript Test ContentSlotHtml 1`] = `
 <script>
 export default {
   name: \\"content-slot-code\\",
-
-  props: [\\"slotTesting\\"],
 };
 </script>
 "
@@ -585,7 +583,7 @@ exports[`Vue Javascript Test ContentSlotJSX 1`] = `
 export default {
   name: \\"content-slot-jsx-code\\",
 
-  props: [\\"slotTesting\\"],
+  props: [],
 };
 </script>
 "
@@ -3016,8 +3014,6 @@ type Props = {
 
 export default {
   name: \\"content-slot-code\\",
-
-  props: [\\"slotTesting\\"],
 };
 </script>
 "
@@ -3045,7 +3041,7 @@ type Props = {
 export default {
   name: \\"content-slot-jsx-code\\",
 
-  props: [\\"slotTesting\\"],
+  props: [],
 };
 </script>
 "

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -579,7 +579,7 @@ function generateOptionsApiScript(
   options: ToVueOptions,
   path: string | undefined,
   template: string,
-  props: Set<string>,
+  props: string[],
   onUpdateWithDeps: extendedHook[],
   onUpdateWithoutDeps: extendedHook[],
 ) {
@@ -682,7 +682,7 @@ function generateOptionsApiScript(
               }${kebabCase(component.name)}',`
         }
         ${generateComponents(componentsUsed, options)}
-        ${props.size ? `props: ${json5.stringify(propsDefinition)},` : ''}
+        ${props.length ? `props: ${json5.stringify(propsDefinition)},` : ''}
         ${
           dataString.length < 4
             ? ''
@@ -768,7 +768,7 @@ const getCompositionPropDefinition = ({
 }: {
   options: ToVueOptions;
   component: MitosisComponent;
-  props: Set<string>;
+  props: string[];
 }) => {
   let str = 'const props = ';
 
@@ -778,7 +778,7 @@ const getCompositionPropDefinition = ({
   } else if (options.typescript && component.propsTypeRef && component.propsTypeRef !== 'any') {
     str += `defineProps<${component.propsTypeRef}>()`;
   } else {
-    str += `defineProps(${json5.stringify(Array.from(props))})`;
+    str += `defineProps(${json5.stringify(props)})`;
   }
   return str;
 };
@@ -808,7 +808,7 @@ function generateCompositionApiScript(
   component: MitosisComponent,
   options: ToVueOptions,
   template: string,
-  props: Set<string>,
+  props: Array<string>,
   onUpdateWithDeps: extendedHook[],
   onUpdateWithoutDeps: extendedHook[],
 ) {
@@ -846,7 +846,7 @@ function generateCompositionApiScript(
   const getterKeys = Object.keys(pickBy(component.state, (i) => i?.type === 'getter'));
 
   let str = dedent`
-    ${props.size ? getCompositionPropDefinition({ component, props, options }) : ''}
+    ${props.length ? getCompositionPropDefinition({ component, props, options }) : ''}
     ${refs}
 
     ${Object.keys(component.context.get)
@@ -966,7 +966,7 @@ const componentToVue: TranspilerGenerator<ToVueOptions> =
 
     const getterKeys = Object.keys(pickBy(component.state, (i) => i?.type === 'getter'));
 
-    const elementProps = getProps(component);
+    const elementProps = Array.from(getProps(component)).filter((prop) => !prop.startsWith('slot'));
 
     // import from vue
     let vueImports: string[] = [];


### PR DESCRIPTION
## Description
Remove slots from the prop definition in Vue

Before:
<img width="1159" alt="Screenshot 2022-09-20 at 22 32 25" src="https://user-images.githubusercontent.com/3808818/191359214-9524c819-61f7-4c95-91e5-7f7c020c5d52.png">

After:
<img width="1720" alt="Screenshot 2022-09-20 at 22 32 11" src="https://user-images.githubusercontent.com/3808818/191359231-705fedce-eb34-434a-8099-7d02d8818b4a.png">
