### PR TITLE
refactor(angular): refactored angular related imports generation

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Angular Javascript Test AdvancedRef 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -66,7 +66,7 @@ export default class MyBasicRefComponent {
 `;
 
 exports[`Angular Javascript Test AdvancedRef 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface Props {
@@ -135,14 +135,13 @@ export default class MyBasicRefComponent {
 
 exports[`Angular Javascript Test Basic 1`] = `
 "import { Component } from \\"@angular/core\\";
+export const DEFAULT_VALUES = {
+  name: \\"Steve\\",
+};
 
 export interface MyBasicComponentProps {
   id: string;
 }
-
-export const DEFAULT_VALUES = {
-  name: \\"Steve\\",
-};
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -208,14 +207,13 @@ export default class MyBasicForShowComponent {
 exports[`Angular Javascript Test Basic 3`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+export const DEFAULT_VALUES = {
+  name: \\"Steve\\",
+};
 
 export interface MyBasicComponentProps {
   id: string;
 }
-
-export const DEFAULT_VALUES = {
-  name: \\"Steve\\",
-};
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -284,9 +282,8 @@ export default class MyBasicForShowComponent {
 `;
 
 exports[`Angular Javascript Test Basic Context 1`] = `
-"import { Component } from \\"@angular/core\\";
-
-import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+"import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+import { Component } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -320,10 +317,9 @@ export default class MyBasicComponent {
 `;
 
 exports[`Angular Javascript Test Basic Context 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -426,7 +422,7 @@ export default class MyBasicOnMountUpdateComponent {
 `;
 
 exports[`Angular Javascript Test Basic Outputs 1`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-outputs-component\\",
@@ -451,7 +447,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Javascript Test Basic Outputs 2`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 @Component({
@@ -479,7 +475,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Javascript Test Basic Outputs Meta 1`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-outputs-component\\",
@@ -504,7 +500,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Javascript Test Basic Outputs Meta 2`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 @Component({
@@ -532,14 +528,13 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Javascript Test BasicBooleanAttribute 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
   children: any;
   type: string;
 };
-
-import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 @Component({
   selector: \\"my-boolean-attribute\\",
@@ -570,15 +565,14 @@ export default class MyBooleanAttribute {
 `;
 
 exports[`Angular Javascript Test BasicBooleanAttribute 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   children: any;
   type: string;
 };
-
-import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 @Component({
   selector: \\"my-boolean-attribute\\",
@@ -611,10 +605,9 @@ export default class MyBooleanAttribute {
 `;
 
 exports[`Angular Javascript Test BasicChildComponent 1`] = `
-"import { Component } from \\"@angular/core\\";
-
-import MyBasicComponent from \\"./basic.raw\\";
+"import MyBasicComponent from \\"./basic.raw\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
+import { Component } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-child-component\\",
@@ -639,11 +632,10 @@ export default class MyBasicChildComponent {
 `;
 
 exports[`Angular Javascript Test BasicChildComponent 2`] = `
-"import { Component } from \\"@angular/core\\";
-import { CommonModule } from \\"@angular/common\\";
-
-import MyBasicComponent from \\"./basic.raw\\";
+"import MyBasicComponent from \\"./basic.raw\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
+import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
 
 @Component({
   selector: \\"my-basic-child-component\\",
@@ -741,7 +733,7 @@ export default class MyBasicForComponent {
 `;
 
 exports[`Angular Javascript Test BasicRef 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -802,7 +794,7 @@ export default class MyBasicRefComponent {
 `;
 
 exports[`Angular Javascript Test BasicRef 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface Props {
@@ -924,11 +916,6 @@ export default class MyBasicRefAssignmentComponent {
 
 exports[`Angular Javascript Test BasicRefPrevious 1`] = `
 "import { Component } from \\"@angular/core\\";
-
-export interface Props {
-  showInput: boolean;
-}
-
 export function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
@@ -940,6 +927,10 @@ export function usePrevious<T>(value: T) {
   // Return previous value (happens before update in useEffect above)
 
   return ref;
+}
+
+export interface Props {
+  showInput: boolean;
 }
 
 @Component({
@@ -967,11 +958,6 @@ export default class MyPreviousComponent {
 exports[`Angular Javascript Test BasicRefPrevious 2`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-export interface Props {
-  showInput: boolean;
-}
-
 export function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
@@ -983,6 +969,10 @@ export function usePrevious<T>(value: T) {
   // Return previous value (happens before update in useEffect above)
 
   return ref;
+}
+
+export interface Props {
+  showInput: boolean;
 }
 
 @Component({
@@ -1352,7 +1342,7 @@ export default class ContentSlotJsxCode {}
 `;
 
 exports[`Angular Javascript Test CustomCode 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -1427,7 +1417,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Javascript Test CustomCode 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface CustomCodeProps {
@@ -1505,7 +1495,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Javascript Test Embed 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -1580,7 +1570,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Javascript Test Embed 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface CustomCodeProps {
@@ -1658,7 +1648,12 @@ export default class CustomCode {
 `;
 
 exports[`Angular Javascript Test Form 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
+import { Builder, builder } from \\"@builder.io/sdk\\";
+import { BuilderBlocks } from \\"@fake\\";
+import { set } from \\"@fake\\";
+import { get } from \\"@fake\\";
+import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface FormProps {
   attributes?: any;
@@ -1683,12 +1678,6 @@ export interface FormProps {
   errorMessagePath?: string;
 }
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
-
-import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
-import { Builder, builder } from \\"@builder.io/sdk\\";
-import { BuilderBlocks } from \\"@fake\\";
-import { set } from \\"@fake\\";
-import { get } from \\"@fake\\";
 
 @Component({
   selector: \\"form-component\\",
@@ -2002,7 +1991,12 @@ export default class FormComponent {
 `;
 
 exports[`Angular Javascript Test Form 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
+import { Builder, builder } from \\"@builder.io/sdk\\";
+import { BuilderBlocks } from \\"@fake\\";
+import { set } from \\"@fake\\";
+import { get } from \\"@fake\\";
+import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormProps {
@@ -2028,12 +2022,6 @@ export interface FormProps {
   errorMessagePath?: string;
 }
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
-
-import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
-import { Builder, builder } from \\"@builder.io/sdk\\";
-import { BuilderBlocks } from \\"@fake\\";
-import { set } from \\"@fake\\";
-import { get } from \\"@fake\\";
 
 @Component({
   selector: \\"form-component\\",
@@ -2349,7 +2337,7 @@ export default class FormComponent {
 `;
 
 exports[`Angular Javascript Test Image 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 // TODO: AMP Support?
 export interface ImageProps {
@@ -2465,7 +2453,7 @@ export default class Image {
 `;
 
 exports[`Angular Javascript Test Image 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 // TODO: AMP Support?
@@ -2631,7 +2619,8 @@ export default class ImgStateComponent {
 `;
 
 exports[`Angular Javascript Test Img 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface ImgProps {
   attributes?: any;
@@ -2649,8 +2638,6 @@ export interface ImgProps {
     | \\"bottom left\\"
     | \\"bottom right\\";
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"img-component\\",
@@ -2677,7 +2664,8 @@ export default class ImgComponent {
 `;
 
 exports[`Angular Javascript Test Img 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface ImgProps {
@@ -2696,8 +2684,6 @@ export interface ImgProps {
     | \\"bottom left\\"
     | \\"bottom right\\";
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"img-component\\",
@@ -2726,7 +2712,8 @@ export default class ImgComponent {
 `;
 
 exports[`Angular Javascript Test Input 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface FormInputProps {
   type?: string;
@@ -2737,8 +2724,6 @@ export interface FormInputProps {
   defaultValue?: string;
   required?: boolean;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"form-input-component\\",
@@ -2767,7 +2752,8 @@ export default class FormInputComponent {
 `;
 
 exports[`Angular Javascript Test Input 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormInputProps {
@@ -2779,8 +2765,6 @@ export interface FormInputProps {
   defaultValue?: string;
   required?: boolean;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"form-input-component\\",
@@ -2992,7 +2976,8 @@ export default class SectionStateComponent {
 `;
 
 exports[`Angular Javascript Test Select 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface FormSelectProps {
   options?: {
@@ -3004,8 +2989,6 @@ export interface FormSelectProps {
   value?: string;
   defaultValue?: string;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"select-component\\",
@@ -3035,7 +3018,8 @@ export default class SelectComponent {
 `;
 
 exports[`Angular Javascript Test Select 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormSelectProps {
@@ -3048,8 +3032,6 @@ export interface FormSelectProps {
   value?: string;
   defaultValue?: string;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"select-component\\",
@@ -3081,13 +3063,12 @@ export default class SelectComponent {
 `;
 
 exports[`Angular Javascript Test SlotHtml 1`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -3104,14 +3085,13 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Javascript Test SlotHtml 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -3130,13 +3110,12 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Javascript Test SlotJsx 1`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -3151,14 +3130,13 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Javascript Test SlotJsx 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -3175,15 +3153,14 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Javascript Test Stamped.io 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
 };
-
-import { kebabCase } from \\"lodash\\";
-import { snakeCase } from \\"lodash\\";
 
 @Component({
   selector: \\"smile-reviews\\",
@@ -3284,16 +3261,15 @@ export default class SmileReviews {
 `;
 
 exports[`Angular Javascript Test Stamped.io 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
 };
-
-import { kebabCase } from \\"lodash\\";
-import { snakeCase } from \\"lodash\\";
 
 @Component({
   selector: \\"smile-reviews\\",
@@ -3441,7 +3417,8 @@ export default class SubmitButton {
 `;
 
 exports[`Angular Javascript Test Text 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface TextProps {
   attributes?: any;
@@ -3450,8 +3427,6 @@ export interface TextProps {
   content?: string;
   builderBlock?: any;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"text\\",
@@ -3475,7 +3450,8 @@ export default class Text {
 `;
 
 exports[`Angular Javascript Test Text 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface TextProps {
@@ -3485,8 +3461,6 @@ export interface TextProps {
   content?: string;
   builderBlock?: any;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"text\\",
@@ -4252,13 +4226,12 @@ export default class Button {
 
 exports[`Angular Javascript Test defaultValsWithTypes 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
+const DEFAULT_VALUES: Props = {
+  name: \\"Sami\\",
+};
 
 type Props = {
   name: string;
-};
-
-const DEFAULT_VALUES: Props = {
-  name: \\"Sami\\",
 };
 
 @Component({
@@ -4278,13 +4251,12 @@ export default class ComponentWithTypes {
 exports[`Angular Javascript Test defaultValsWithTypes 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+const DEFAULT_VALUES: Props = {
+  name: \\"Sami\\",
+};
 
 type Props = {
   name: string;
-};
-
-const DEFAULT_VALUES: Props = {
-  name: \\"Sami\\",
 };
 
 @Component({
@@ -4304,15 +4276,14 @@ export default class ComponentWithTypes {
 `;
 
 exports[`Angular Javascript Test import types 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import RenderBlock from \\"./builder-render-block.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type RenderContentProps = {
   options?: GetContentOptions;
   content: BuilderContent;
   renderContentProps: RenderBlockProps;
 };
-
-import RenderBlock from \\"./builder-render-block.raw\\";
 
 @Component({
   selector: \\"render-content\\",
@@ -4334,7 +4305,8 @@ export default class RenderContent {
 `;
 
 exports[`Angular Javascript Test import types 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import RenderBlock from \\"./builder-render-block.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type RenderContentProps = {
@@ -4342,8 +4314,6 @@ type RenderContentProps = {
   content: BuilderContent;
   renderContentProps: RenderBlockProps;
 };
-
-import RenderBlock from \\"./builder-render-block.raw\\";
 
 @Component({
   selector: \\"render-content\\",
@@ -4637,13 +4607,12 @@ export default class OnInit {
 
 exports[`Angular Javascript Test onInit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
+export const defaultValues = {
+  name: \\"PatrickJS\\",
+};
 
 type Props = {
   name: string;
-};
-
-export const defaultValues = {
-  name: \\"PatrickJS\\",
 };
 
 @Component({
@@ -4668,13 +4637,12 @@ export default class OnInit {
 exports[`Angular Javascript Test onInit 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+export const defaultValues = {
+  name: \\"PatrickJS\\",
+};
 
 type Props = {
   name: string;
-};
-
-export const defaultValues = {
-  name: \\"PatrickJS\\",
 };
 
 @Component({
@@ -4847,6 +4815,11 @@ export default class OnUpdateWithDeps {
 
 exports[`Angular Javascript Test preserveExportOrLocalStatement 1`] = `
 "import { Component } from \\"@angular/core\\";
+const b = 3;
+const foo = () => {};
+export const a = 3;
+export const bar = () => {};
+export function run<T>(value: T) {}
 
 type Types = {
   s: any[];
@@ -4857,12 +4830,6 @@ interface IPost {
 export interface MyBasicComponentProps {
   id: string;
 }
-
-const b = 3;
-const foo = () => {};
-export const a = 3;
-export const bar = () => {};
-export function run<T>(value: T) {}
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -4877,6 +4844,11 @@ export default class MyBasicComponent {}
 exports[`Angular Javascript Test preserveExportOrLocalStatement 2`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+const b = 3;
+const foo = () => {};
+export const a = 3;
+export const bar = () => {};
+export function run<T>(value: T) {}
 
 type Types = {
   s: any[];
@@ -4887,12 +4859,6 @@ interface IPost {
 export interface MyBasicComponentProps {
   id: string;
 }
-
-const b = 3;
-const foo = () => {};
-export const a = 3;
-export const bar = () => {};
-export function run<T>(value: T) {}
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -5389,10 +5355,9 @@ export default class SubComponent {}
 `;
 
 exports[`Angular Javascript Test subComponent 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import Foo from \\"./foo-sub-component\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-import Foo from \\"./foo-sub-component\\";
 
 @Component({
   selector: \\"sub-component\\",
@@ -5487,7 +5452,7 @@ export default class MyBasicComponent {
 `;
 
 exports[`Angular Typescript Test AdvancedRef 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -5552,7 +5517,7 @@ export default class MyBasicRefComponent {
 `;
 
 exports[`Angular Typescript Test AdvancedRef 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface Props {
@@ -5621,14 +5586,13 @@ export default class MyBasicRefComponent {
 
 exports[`Angular Typescript Test Basic 1`] = `
 "import { Component } from \\"@angular/core\\";
+export const DEFAULT_VALUES = {
+  name: \\"Steve\\",
+};
 
 export interface MyBasicComponentProps {
   id: string;
 }
-
-export const DEFAULT_VALUES = {
-  name: \\"Steve\\",
-};
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -5694,14 +5658,13 @@ export default class MyBasicForShowComponent {
 exports[`Angular Typescript Test Basic 3`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+export const DEFAULT_VALUES = {
+  name: \\"Steve\\",
+};
 
 export interface MyBasicComponentProps {
   id: string;
 }
-
-export const DEFAULT_VALUES = {
-  name: \\"Steve\\",
-};
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -5770,9 +5733,8 @@ export default class MyBasicForShowComponent {
 `;
 
 exports[`Angular Typescript Test Basic Context 1`] = `
-"import { Component } from \\"@angular/core\\";
-
-import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+"import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+import { Component } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -5806,10 +5768,9 @@ export default class MyBasicComponent {
 `;
 
 exports[`Angular Typescript Test Basic Context 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -5912,7 +5873,7 @@ export default class MyBasicOnMountUpdateComponent {
 `;
 
 exports[`Angular Typescript Test Basic Outputs 1`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-outputs-component\\",
@@ -5937,7 +5898,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Typescript Test Basic Outputs 2`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 @Component({
@@ -5965,7 +5926,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Typescript Test Basic Outputs Meta 1`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-outputs-component\\",
@@ -5990,7 +5951,7 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Typescript Test Basic Outputs Meta 2`] = `
-"import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
+"import { Component, Input, Output, EventEmitter } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 @Component({
@@ -6018,14 +5979,13 @@ export default class MyBasicOutputsComponent {
 `;
 
 exports[`Angular Typescript Test BasicBooleanAttribute 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
   children: any;
   type: string;
 };
-
-import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 @Component({
   selector: \\"my-boolean-attribute\\",
@@ -6056,15 +6016,14 @@ export default class MyBooleanAttribute {
 `;
 
 exports[`Angular Typescript Test BasicBooleanAttribute 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   children: any;
   type: string;
 };
-
-import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 @Component({
   selector: \\"my-boolean-attribute\\",
@@ -6097,10 +6056,9 @@ export default class MyBooleanAttribute {
 `;
 
 exports[`Angular Typescript Test BasicChildComponent 1`] = `
-"import { Component } from \\"@angular/core\\";
-
-import MyBasicComponent from \\"./basic.raw\\";
+"import MyBasicComponent from \\"./basic.raw\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
+import { Component } from \\"@angular/core\\";
 
 @Component({
   selector: \\"my-basic-child-component\\",
@@ -6125,11 +6083,10 @@ export default class MyBasicChildComponent {
 `;
 
 exports[`Angular Typescript Test BasicChildComponent 2`] = `
-"import { Component } from \\"@angular/core\\";
-import { CommonModule } from \\"@angular/common\\";
-
-import MyBasicComponent from \\"./basic.raw\\";
+"import MyBasicComponent from \\"./basic.raw\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
+import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
 
 @Component({
   selector: \\"my-basic-child-component\\",
@@ -6227,7 +6184,7 @@ export default class MyBasicForComponent {
 `;
 
 exports[`Angular Typescript Test BasicRef 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -6288,7 +6245,7 @@ export default class MyBasicRefComponent {
 `;
 
 exports[`Angular Typescript Test BasicRef 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface Props {
@@ -6410,11 +6367,6 @@ export default class MyBasicRefAssignmentComponent {
 
 exports[`Angular Typescript Test BasicRefPrevious 1`] = `
 "import { Component } from \\"@angular/core\\";
-
-export interface Props {
-  showInput: boolean;
-}
-
 export function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
@@ -6426,6 +6378,10 @@ export function usePrevious<T>(value: T) {
   // Return previous value (happens before update in useEffect above)
 
   return ref;
+}
+
+export interface Props {
+  showInput: boolean;
 }
 
 @Component({
@@ -6453,11 +6409,6 @@ export default class MyPreviousComponent {
 exports[`Angular Typescript Test BasicRefPrevious 2`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-export interface Props {
-  showInput: boolean;
-}
-
 export function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
@@ -6469,6 +6420,10 @@ export function usePrevious<T>(value: T) {
   // Return previous value (happens before update in useEffect above)
 
   return ref;
+}
+
+export interface Props {
+  showInput: boolean;
 }
 
 @Component({
@@ -6838,7 +6793,7 @@ export default class ContentSlotJsxCode {}
 `;
 
 exports[`Angular Typescript Test CustomCode 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -6913,7 +6868,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Typescript Test CustomCode 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface CustomCodeProps {
@@ -6991,7 +6946,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Typescript Test Embed 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
   code: string;
@@ -7066,7 +7021,7 @@ export default class CustomCode {
 `;
 
 exports[`Angular Typescript Test Embed 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface CustomCodeProps {
@@ -7144,7 +7099,12 @@ export default class CustomCode {
 `;
 
 exports[`Angular Typescript Test Form 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
+import { BuilderElement, Builder, builder } from \\"@builder.io/sdk\\";
+import { BuilderBlocks } from \\"@fake\\";
+import { set } from \\"@fake\\";
+import { get } from \\"@fake\\";
+import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 export interface FormProps {
   attributes?: any;
@@ -7169,12 +7129,6 @@ export interface FormProps {
   errorMessagePath?: string;
 }
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
-
-import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
-import { BuilderElement, Builder, builder } from \\"@builder.io/sdk\\";
-import { BuilderBlocks } from \\"@fake\\";
-import { set } from \\"@fake\\";
-import { get } from \\"@fake\\";
 
 @Component({
   selector: \\"form-component\\",
@@ -7488,7 +7442,12 @@ export default class FormComponent {
 `;
 
 exports[`Angular Typescript Test Form 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
+import { BuilderElement, Builder, builder } from \\"@builder.io/sdk\\";
+import { BuilderBlocks } from \\"@fake\\";
+import { set } from \\"@fake\\";
+import { get } from \\"@fake\\";
+import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormProps {
@@ -7514,12 +7473,6 @@ export interface FormProps {
   errorMessagePath?: string;
 }
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
-
-import { BuilderBlock as BuilderBlockComponent } from \\"@fake\\";
-import { BuilderElement, Builder, builder } from \\"@builder.io/sdk\\";
-import { BuilderBlocks } from \\"@fake\\";
-import { set } from \\"@fake\\";
-import { get } from \\"@fake\\";
 
 @Component({
   selector: \\"form-component\\",
@@ -7835,7 +7788,7 @@ export default class FormComponent {
 `;
 
 exports[`Angular Typescript Test Image 1`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 
 // TODO: AMP Support?
 export interface ImageProps {
@@ -7951,7 +7904,7 @@ export default class Image {
 `;
 
 exports[`Angular Typescript Test Image 2`] = `
-"import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
+"import { Component, Input, ViewChild, ElementRef } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 // TODO: AMP Support?
@@ -8117,7 +8070,8 @@ export default class ImgStateComponent {
 `;
 
 exports[`Angular Typescript Test Img 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface ImgProps {
   attributes?: any;
@@ -8135,8 +8089,6 @@ export interface ImgProps {
     | \\"bottom left\\"
     | \\"bottom right\\";
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"img-component\\",
@@ -8163,7 +8115,8 @@ export default class ImgComponent {
 `;
 
 exports[`Angular Typescript Test Img 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface ImgProps {
@@ -8182,8 +8135,6 @@ export interface ImgProps {
     | \\"bottom left\\"
     | \\"bottom right\\";
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"img-component\\",
@@ -8212,7 +8163,8 @@ export default class ImgComponent {
 `;
 
 exports[`Angular Typescript Test Input 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface FormInputProps {
   type?: string;
@@ -8223,8 +8175,6 @@ export interface FormInputProps {
   defaultValue?: string;
   required?: boolean;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"form-input-component\\",
@@ -8253,7 +8203,8 @@ export default class FormInputComponent {
 `;
 
 exports[`Angular Typescript Test Input 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormInputProps {
@@ -8265,8 +8216,6 @@ export interface FormInputProps {
   defaultValue?: string;
   required?: boolean;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"form-input-component\\",
@@ -8478,7 +8427,8 @@ export default class SectionStateComponent {
 `;
 
 exports[`Angular Typescript Test Select 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface FormSelectProps {
   options?: {
@@ -8490,8 +8440,6 @@ export interface FormSelectProps {
   value?: string;
   defaultValue?: string;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"select-component\\",
@@ -8521,7 +8469,8 @@ export default class SelectComponent {
 `;
 
 exports[`Angular Typescript Test Select 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface FormSelectProps {
@@ -8534,8 +8483,6 @@ export interface FormSelectProps {
   value?: string;
   defaultValue?: string;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"select-component\\",
@@ -8567,13 +8514,12 @@ export default class SelectComponent {
 `;
 
 exports[`Angular Typescript Test SlotHtml 1`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -8590,14 +8536,13 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Typescript Test SlotHtml 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -8616,13 +8561,12 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Typescript Test SlotJsx 1`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -8637,14 +8581,13 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Typescript Test SlotJsx 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type Props = {
   [key: string]: string;
 };
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 @Component({
   selector: \\"slot-code\\",
@@ -8661,15 +8604,14 @@ export default class SlotCode {}
 `;
 
 exports[`Angular Typescript Test Stamped.io 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
 };
-
-import { kebabCase } from \\"lodash\\";
-import { snakeCase } from \\"lodash\\";
 
 @Component({
   selector: \\"smile-reviews\\",
@@ -8770,16 +8712,15 @@ export default class SmileReviews {
 `;
 
 exports[`Angular Typescript Test Stamped.io 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
 };
-
-import { kebabCase } from \\"lodash\\";
-import { snakeCase } from \\"lodash\\";
 
 @Component({
   selector: \\"smile-reviews\\",
@@ -8927,7 +8868,8 @@ export default class SubmitButton {
 `;
 
 exports[`Angular Typescript Test Text 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 
 export interface TextProps {
   attributes?: any;
@@ -8936,8 +8878,6 @@ export interface TextProps {
   content?: string;
   builderBlock?: any;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"text\\",
@@ -8961,7 +8901,8 @@ export default class Text {
 `;
 
 exports[`Angular Typescript Test Text 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { Builder } from \\"@builder.io/sdk\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 export interface TextProps {
@@ -8971,8 +8912,6 @@ export interface TextProps {
   content?: string;
   builderBlock?: any;
 }
-
-import { Builder } from \\"@builder.io/sdk\\";
 
 @Component({
   selector: \\"text\\",
@@ -9738,13 +9677,12 @@ export default class Button {
 
 exports[`Angular Typescript Test defaultValsWithTypes 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
+const DEFAULT_VALUES: Props = {
+  name: \\"Sami\\",
+};
 
 type Props = {
   name: string;
-};
-
-const DEFAULT_VALUES: Props = {
-  name: \\"Sami\\",
 };
 
 @Component({
@@ -9764,13 +9702,12 @@ export default class ComponentWithTypes {
 exports[`Angular Typescript Test defaultValsWithTypes 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+const DEFAULT_VALUES: Props = {
+  name: \\"Sami\\",
+};
 
 type Props = {
   name: string;
-};
-
-const DEFAULT_VALUES: Props = {
-  name: \\"Sami\\",
 };
 
 @Component({
@@ -9790,16 +9727,15 @@ export default class ComponentWithTypes {
 `;
 
 exports[`Angular Typescript Test import types 1`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { BuilderContent, GetContentOptions } from \\"@builder.io/sdk\\";
+import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 
 type RenderContentProps = {
   options?: GetContentOptions;
   content: BuilderContent;
   renderContentProps: RenderBlockProps;
 };
-
-import { BuilderContent, GetContentOptions } from \\"@builder.io/sdk\\";
-import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
 
 @Component({
   selector: \\"render-content\\",
@@ -9821,7 +9757,9 @@ export default class RenderContent {
 `;
 
 exports[`Angular Typescript Test import types 2`] = `
-"import { Component, Input } from \\"@angular/core\\";
+"import { BuilderContent, GetContentOptions } from \\"@builder.io/sdk\\";
+import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
+import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 type RenderContentProps = {
@@ -9829,9 +9767,6 @@ type RenderContentProps = {
   content: BuilderContent;
   renderContentProps: RenderBlockProps;
 };
-
-import { BuilderContent, GetContentOptions } from \\"@builder.io/sdk\\";
-import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
 
 @Component({
   selector: \\"render-content\\",
@@ -10125,13 +10060,12 @@ export default class OnInit {
 
 exports[`Angular Typescript Test onInit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
+export const defaultValues = {
+  name: \\"PatrickJS\\",
+};
 
 type Props = {
   name: string;
-};
-
-export const defaultValues = {
-  name: \\"PatrickJS\\",
 };
 
 @Component({
@@ -10156,13 +10090,12 @@ export default class OnInit {
 exports[`Angular Typescript Test onInit 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+export const defaultValues = {
+  name: \\"PatrickJS\\",
+};
 
 type Props = {
   name: string;
-};
-
-export const defaultValues = {
-  name: \\"PatrickJS\\",
 };
 
 @Component({
@@ -10335,6 +10268,11 @@ export default class OnUpdateWithDeps {
 
 exports[`Angular Typescript Test preserveExportOrLocalStatement 1`] = `
 "import { Component } from \\"@angular/core\\";
+const b = 3;
+const foo = () => {};
+export const a = 3;
+export const bar = () => {};
+export function run<T>(value: T) {}
 
 type Types = {
   s: any[];
@@ -10345,12 +10283,6 @@ interface IPost {
 export interface MyBasicComponentProps {
   id: string;
 }
-
-const b = 3;
-const foo = () => {};
-export const a = 3;
-export const bar = () => {};
-export function run<T>(value: T) {}
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -10365,6 +10297,11 @@ export default class MyBasicComponent {}
 exports[`Angular Typescript Test preserveExportOrLocalStatement 2`] = `
 "import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
+const b = 3;
+const foo = () => {};
+export const a = 3;
+export const bar = () => {};
+export function run<T>(value: T) {}
 
 type Types = {
   s: any[];
@@ -10375,12 +10312,6 @@ interface IPost {
 export interface MyBasicComponentProps {
   id: string;
 }
-
-const b = 3;
-const foo = () => {};
-export const a = 3;
-export const bar = () => {};
-export function run<T>(value: T) {}
 
 @Component({
   selector: \\"my-basic-component\\",
@@ -10877,10 +10808,9 @@ export default class SubComponent {}
 `;
 
 exports[`Angular Typescript Test subComponent 2`] = `
-"import { Component } from \\"@angular/core\\";
+"import Foo from \\"./foo-sub-component\\";
+import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
-
-import Foo from \\"./foo-sub-component\\";
 
 @Component({
   selector: \\"sub-component\\",

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -254,10 +254,10 @@ const populatedWithAngularImports = (params: {
       return imports;
     }, {});
   if (Object.keys(coreImports).length > 0) {
-    addImportToMitosisComponent(json, { imports: commonImports, path: '@angular/common' });
+    addImportToMitosisComponent(json, { imports: coreImports, path: '@angular/core' });
   }
   if (Object.keys(commonImports).length > 0) {
-    addImportToMitosisComponent(json, { imports: coreImports, path: '@angular/core' });
+    addImportToMitosisComponent(json, { imports: commonImports, path: '@angular/common' });
   }
   return json;
 };

--- a/packages/core/src/helpers/add-import.ts
+++ b/packages/core/src/helpers/add-import.ts
@@ -1,0 +1,26 @@
+import { MitosisComponent, MitosisImport } from '@builder.io/mitosis';
+
+/**
+ * Add an import to a component, if it doesn't already exist.
+ * Returns modified MitosisComponent, which is NOT a new object
+ * @param json The component to add the import to
+ * @param theImport The import to add
+ */
+export function addImportToMitosisComponent(
+  json: MitosisComponent,
+  theImport: MitosisImport,
+): MitosisComponent {
+  if (!json.imports) {
+    json.imports = [];
+  }
+  const existingImport = json.imports.find((item) => item.path === theImport.path);
+  if (!existingImport) {
+    json.imports.push(theImport);
+  } else {
+    existingImport.imports = {
+      ...existingImport.imports,
+      ...(theImport.imports || {}),
+    };
+  }
+  return json;
+}


### PR DESCRIPTION
## Description

- added `populatedWithAngularImports` and moved adding Angular related imports to be BEFORE `json.post` call.
- added one helper for adding an import to `MitosisComponent`. I do not know if something like it existed, could not find it, so added it. if there is any, please refer me to it.

## Reasoning
I added these because otherwise in `json.post` you can not see which imports are gonna end up in file completely. Also, output code's structure is now better because it follows a widely accepted pattern:
- imports
- types
- anything else
- class declaration
