### PR TITLE
feat(core): more basic context setting

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -133,11 +133,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <div>
-      {myService.method(\\"hello\\") + name}
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      <input onChange={(event) => onChange} />
-    </div>
+    <Context.Provider value={createInjector()}>
+      <div>
+        {myService.method(\\"hello\\") + name}
+        Hello! I can run in React, Vue, Solid, or Liquid!
+        <input onChange={(event) => onChange} />
+      </div>
+    </Context.Provider>
   );
 }
 "
@@ -2626,11 +2628,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <div>
-      {myService.method(\\"hello\\") + name}
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      <input onChange={(event) => onChange} />
-    </div>
+    <Context.Provider value={createInjector()}>
+      <div>
+        {myService.method(\\"hello\\") + name}
+        Hello! I can run in React, Vue, Solid, or Liquid!
+        <input onChange={(event) => onChange} />
+      </div>
+    </Context.Provider>
   );
 }
 "

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -127,11 +127,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <View>
-      <Text>{myService.method(\\"hello\\") + name}</Text>
-      <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
-      <View onChange={(event) => onChange} />
-    </View>
+    <Context.Provider value={createInjector()}>
+      <View>
+        <Text>{myService.method(\\"hello\\") + name}</Text>
+        <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
+        <View onChange={(event) => onChange} />
+      </View>
+    </Context.Provider>
   );
 }
 "
@@ -2543,11 +2545,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <View>
-      <Text>{myService.method(\\"hello\\") + name}</Text>
-      <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
-      <View onChange={(event) => onChange} />
-    </View>
+    <Context.Provider value={createInjector()}>
+      <View>
+        <Text>{myService.method(\\"hello\\") + name}</Text>
+        <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
+        <View onChange={(event) => onChange} />
+      </View>
+    </Context.Provider>
   );
 }
 "

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -130,11 +130,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <div>
-      {myService.method(\\"hello\\") + name}
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      <input onChange={(event) => onChange} />
-    </div>
+    <Context.Provider value={createInjector()}>
+      <div>
+        {myService.method(\\"hello\\") + name}
+        Hello! I can run in React, Vue, Solid, or Liquid!
+        <input onChange={(event) => onChange} />
+      </div>
+    </Context.Provider>
   );
 }
 "
@@ -2557,11 +2559,13 @@ export default function MyBasicComponent(props: any) {
   }, []);
 
   return (
-    <div>
-      {myService.method(\\"hello\\") + name}
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      <input onChange={(event) => onChange} />
-    </div>
+    <Context.Provider value={createInjector()}>
+      <div>
+        {myService.method(\\"hello\\") + name}
+        Hello! I can run in React, Vue, Solid, or Liquid!
+        <input onChange={(event) => onChange} />
+      </div>
+    </Context.Provider>
   );
 }
 "

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -119,7 +119,7 @@ exports[`Svelte Javascript Test Basic Context 1`] = `
   import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
 
   let myService = getContext(MyService.key);
-  setContext(Injector.key, undefined);
+  setContext(Injector, createInjector());
 
   function onChange() {
     const change = myService.method(\\"change\\");
@@ -1992,7 +1992,7 @@ exports[`Svelte Typescript Test Basic Context 1`] = `
   import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
 
   let myService = getContext(MyService.key);
-  setContext(Injector.key, undefined);
+  setContext(Injector, createInjector());
 
   function onChange() {
     const change = myService.method(\\"change\\");

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -152,7 +152,7 @@ export default {
   provide() {
     const _this = this;
     return {
-      Injector: null,
+      Injector: createInjector(),
     };
   },
   inject: {
@@ -2557,7 +2557,7 @@ export default {
   provide() {
     const _this = this;
     return {
-      Injector: null,
+      Injector: createInjector(),
     };
   },
   inject: {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -275,7 +275,7 @@ const getRefsString = (json: MitosisComponent, refs: string[], options: ToReactO
 
 function addProviderComponents(json: MitosisComponent, options: ToReactOptions) {
   for (const key in json.context.set) {
-    const { name, value } = json.context.set[key];
+    const { name, ref, value } = json.context.set[key];
     if (value) {
       json.children = [
         createMitosisNode({
@@ -285,6 +285,20 @@ function addProviderComponents(json: MitosisComponent, options: ToReactOptions) 
             bindings: {
               value: {
                 code: stringifyContextValue(value),
+              },
+            },
+          }),
+        }),
+      ];
+    } else if (ref) {
+      json.children = [
+        createMitosisNode({
+          name: 'Context.Provider',
+          children: json.children,
+          ...(ref && {
+            bindings: {
+              value: {
+                code: ref,
               },
             },
           }),

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -36,7 +36,6 @@ import { isUpperCase } from '../helpers/is-upper-case';
 import json5 from 'json5';
 import { FUNCTION_HACK_PLUGIN } from './helpers/functions';
 import { getForArguments } from '../helpers/nodes/for';
-import { clone } from 'lodash';
 
 export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';

--- a/packages/core/src/generators/svelte.ts
+++ b/packages/core/src/generators/svelte.ts
@@ -36,6 +36,7 @@ import { isUpperCase } from '../helpers/is-upper-case';
 import json5 from 'json5';
 import { FUNCTION_HACK_PLUGIN } from './helpers/functions';
 import { getForArguments } from '../helpers/nodes/for';
+import { clone } from 'lodash';
 
 export interface ToSvelteOptions extends BaseTranspilerOptions {
   stateType?: 'proxies' | 'variables';
@@ -127,9 +128,14 @@ const setContextCode = (json: MitosisComponent) => {
   const contextSetters = json.context.set;
   return Object.keys(contextSetters)
     .map((key) => {
-      const { value, name } = contextSetters[key];
-      return `setContext(${name}.key, ${
-        value ? stripStateAndPropsRefs(stringifyContextValue(value)) : 'undefined'
+      const { ref, value, name } = contextSetters[key];
+
+      return `setContext(${value ? `${name}.key` : name}, ${
+        value
+          ? stripStateAndPropsRefs(stringifyContextValue(value))
+          : ref
+          ? stripStateAndPropsRefs(ref)
+          : 'undefined'
       });`;
     })
     .join('\n');

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -539,13 +539,15 @@ function getContextProvideString(component: MitosisComponent, options: ToVueOpti
   let str = '{';
 
   for (const key in component.context.set) {
-    const { value, name } = component.context.set[key];
+    const { ref, value, name } = component.context.set[key];
     str += `
       ${name}: ${
       value
         ? stringifyContextValue(value, {
             valueMapper: (code) => stripStateAndPropsRefs(code, { replaceWith: '_this.' }),
           })
+        : ref
+        ? stripStateAndPropsRefs(ref, { replaceWith: '_this.' })
         : null
     },
     `;

--- a/packages/core/src/parsers/jsx/function-parser.ts
+++ b/packages/core/src/parsers/jsx/function-parser.ts
@@ -37,10 +37,10 @@ export const componentFunctionToJson = (
             expression.callee.name === 'provideContext'
           ) {
             const keyNode = expression.arguments[0];
+            const valueNode = expression.arguments[1];
             if (types.isIdentifier(keyNode)) {
               const key = keyNode.name;
               const keyPath = traceReferenceToModulePath(context.builder.component.imports, key)!;
-              const valueNode = expression.arguments[1];
               if (valueNode) {
                 if (types.isObjectExpression(valueNode)) {
                   const value = parseStateObjectToMitosisState(valueNode);
@@ -55,6 +55,13 @@ export const componentFunctionToJson = (
                     ref,
                   };
                 }
+              }
+            } else if (types.isStringLiteral(keyNode)) {
+              if (types.isExpression(valueNode)) {
+                setContext[keyNode.value] = {
+                  name: `"${keyNode.value}"`,
+                  ref: generate(valueNode).code,
+                };
               }
             }
           } else if (


### PR DESCRIPTION
## Description

This allows for more basic and imo easier context setting.
For example:
```
import { setContext} from '@builder.io/mitosis';

export default function MyBasicComponent(props) {
  setContext('joined', props.joined);

  return (
    <div>
      {props.joined}
    </div>
  );
}

```
Svelte
<img width="1371" alt="Screenshot 2022-09-24 at 15 06 56" src="https://user-images.githubusercontent.com/3808818/192099674-a9f7c4a1-a73b-4640-95b5-746442448f99.png">

Vue
<img width="1230" alt="Screenshot 2022-09-24 at 15 06 51" src="https://user-images.githubusercontent.com/3808818/192099677-faed8587-5770-4e7e-aa1d-2462056ca986.png">

React
<img width="1401" alt="Screenshot 2022-09-24 at 15 06 43" src="https://user-images.githubusercontent.com/3808818/192099683-8ebbf16b-1b70-4639-90ac-9760f15af4ef.png">

