### PR TITLE
fix(core): preComponent is of type extendedHook and should render the…

### DIFF
--- a/packages/core/src/helpers/render-imports.ts
+++ b/packages/core/src/helpers/render-imports.ts
@@ -186,7 +186,7 @@ export const renderPreComponent = ({
       excludeMitosisComponents,
     })}
     ${renderExportAndLocal(component)}
-    ${component.hooks.preComponent || ''}
+    ${component.hooks.preComponent?.code || ''}
   `;
 
 export const renderExportAndLocal = (component: MitosisComponent): string => {


### PR DESCRIPTION
… code

### Description
preComponent is of type extendedHook and should render the code as a string
