### PR TITLE
feat(core): allow parser option to be async

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -118,14 +118,14 @@ const getMitosisComponentJSONs = async (options: MitosisConfig): Promise<ParsedM
           let javascriptMitosisJson: ParsedMitosisJson['javascriptMitosisJson'];
           if (requiredParses.typescript && requiredParses.javascript) {
             typescriptMitosisJson = options.parser
-              ? options.parser(file, path)
+              ? await options.parser(file, path)
               : parseJsx(file, { typescript: true });
             javascriptMitosisJson = options.parser
-              ? options.parser(file, path)
+              ? await options.parser(file, path)
               : parseJsx(file, { typescript: false });
           } else {
             const singleParse = options.parser
-              ? options.parser(file, path)
+              ? await options.parser(file, path)
               : parseJsx(file, { typescript: requiredParses.typescript });
 
             // technically only one of these will be used, but we set both to simplify things types-wise.

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -62,7 +62,7 @@ export type MitosisConfig = {
    * Configure a custom parser function which takes a string and returns MitosisJSON
    * Defaults to the JSXParser of this project (src/parsers/jsx)
    */
-  parser?: (code: string, path?: string) => MitosisComponent;
+  parser?: (code: string, path?: string) => MitosisComponent | Promise<MitosisComponent>;
 
   /**
    * Configure a custom function that provides the output path for each target.


### PR DESCRIPTION
## Description

To support Typescript in Sveltosis, we need to preprocess the svelte code first (with https://github.com/sveltejs/svelte-preprocess for example), which is an async fn :)

