### PR TITLE
feat(cli): automatic ts output detection

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -118,7 +118,7 @@ const command: GluegunCommand = {
 
         switch (from_) {
           case 'mitosis':
-            json = parseJsx(data, { typescript: !!path.match(/\.tsx?$/) });
+            json = parseJsx(data, { typescript: generatorOpts.typescript });
             break;
 
           case 'builder':

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -118,7 +118,7 @@ const command: GluegunCommand = {
 
         switch (from_) {
           case 'mitosis':
-            json = parseJsx(data);
+            json = parseJsx(data, { typescript: !!path.match(/\.tsx?$/) });
             break;
 
           case 'builder':


### PR DESCRIPTION
## Description

- In cli compile run, none of the options were passed to the parseJSX function.
- Previously you would have missing types in outputs, if your types were declared outside of the component code
- This is not ideal solution. It should be overridable by user through options. Someone, more well versed in source code should look at it to say from where that option should come

closes https://github.com/BuilderIO/mitosis/issues/782 by the way