### PR TITLE
Updated snaps. Angular now has the options to skip out on certain fil…

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Angular with Preserve Imports Javascript Test AdvancedRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test AdvancedRef 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -65,7 +65,7 @@ export default class MyBasicRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface MyBasicComponentProps {
@@ -107,7 +107,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic 2`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic 2`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -137,7 +137,7 @@ export default class MyBasicForShowComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic Context 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic Context 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
@@ -173,7 +173,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic OnMount Update 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic OnMount Update 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -205,7 +205,7 @@ export default class MyBasicOnMountUpdateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic Outputs 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic Outputs 1`] = `
 "import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -230,7 +230,7 @@ export default class MyBasicOutputsComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Basic Outputs Meta 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Basic Outputs Meta 1`] = `
 "import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -255,7 +255,7 @@ export default class MyBasicOutputsComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicBooleanAttribute 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicBooleanAttribute 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -293,7 +293,7 @@ export default class MyBooleanAttribute {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicChildComponent 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicChildComponent 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 import MyBasicComponent from \\"./basic.raw\\";
@@ -321,7 +321,7 @@ export default class MyBasicChildComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicFor 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicFor 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -355,7 +355,7 @@ export default class MyBasicForComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicRef 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -416,7 +416,7 @@ export default class MyBasicRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicRefAssignment 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicRefAssignment 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -443,7 +443,7 @@ export default class MyBasicRefAssignmentComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test BasicRefPrevious 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test BasicRefPrevious 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -485,7 +485,7 @@ export default class MyPreviousComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Button 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Button 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -520,7 +520,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Columns 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Columns 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Column = {
@@ -595,7 +595,7 @@ export default class Column {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test ContentSlotHtml 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test ContentSlotHtml 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -623,7 +623,7 @@ export default class ContentSlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test ContentSlotJSX 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test ContentSlotJSX 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -650,7 +650,7 @@ export default class ContentSlotJsxCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test CustomCode 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test CustomCode 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
@@ -725,7 +725,7 @@ export default class CustomCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Embed 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Embed 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
@@ -800,7 +800,7 @@ export default class CustomCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Form 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Form 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface FormProps {
@@ -1144,7 +1144,7 @@ export default class FormComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Image 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Image 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 // TODO: AMP Support?
@@ -1260,7 +1260,7 @@ export default class Image {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Image State 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Image State 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -1282,7 +1282,7 @@ export default class ImgStateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Img 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Img 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ImgProps {
@@ -1328,7 +1328,7 @@ export default class ImgComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Input 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Input 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface FormInputProps {
@@ -1369,7 +1369,7 @@ export default class FormInputComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test RawText 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test RawText 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface RawTextProps {
@@ -1393,7 +1393,7 @@ export default class RawText {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Section 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Section 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface SectionProps {
@@ -1421,7 +1421,7 @@ export default class SectionComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Section 2`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Section 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface SectionProps {
@@ -1455,7 +1455,7 @@ export default class SectionStateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Select 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Select 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface FormSelectProps {
@@ -1498,7 +1498,7 @@ export default class SelectComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test SlotHtml 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test SlotHtml 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -1521,7 +1521,7 @@ export default class SlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test SlotJsx 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test SlotJsx 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -1542,7 +1542,7 @@ export default class SlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Stamped.io 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Stamped.io 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type SmileReviewsProps = {
@@ -1651,7 +1651,7 @@ export default class SmileReviews {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Submit 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Submit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -1672,7 +1672,7 @@ export default class SubmitButton {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Text 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Text 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface TextProps {
@@ -1706,7 +1706,7 @@ export default class Text {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Textarea 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Textarea 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface TextareaProps {
@@ -1738,7 +1738,7 @@ export default class Textarea {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test Video 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test Video 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface VideoProps {
@@ -1805,7 +1805,7 @@ export default class Video {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test basicForwardRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test basicForwardRef 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -1838,7 +1838,7 @@ export default class MyBasicForwardRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test basicForwardRefMetadata 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test basicForwardRefMetadata 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -1871,7 +1871,7 @@ export default class MyBasicForwardRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test basicOnUpdateReturn 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test basicOnUpdateReturn 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -1904,7 +1904,7 @@ export default class MyBasicOnUpdateReturnComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test class + ClassName + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test class + ClassName + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -1926,7 +1926,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test class + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test class + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -1948,7 +1948,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test className + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test className + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -1970,7 +1970,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test className 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test className 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -1994,7 +1994,7 @@ export default class ClassNameCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test classState 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test classState 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2019,7 +2019,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test defaultProps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test defaultProps 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -2060,7 +2060,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test defaultValsWithTypes 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test defaultValsWithTypes 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -2085,7 +2085,7 @@ export default class ComponentWithTypes {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test import types 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test import types 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type RenderContentProps = {
@@ -2115,7 +2115,7 @@ export default class RenderContent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test importRaw 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test importRaw 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2128,7 +2128,7 @@ export default class MyImportComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test multipleOnUpdate 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test multipleOnUpdate 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2146,7 +2146,7 @@ export default class MultipleOnUpdate {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test multipleOnUpdateWithDeps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test multipleOnUpdateWithDeps 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2177,7 +2177,7 @@ export default class MultipleOnUpdateWithDeps {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test nestedShow 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test nestedShow 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Props {
@@ -2202,7 +2202,7 @@ export default class NestedShow {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test nestedStyles 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test nestedStyles 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2234,7 +2234,7 @@ export default class NestedStyles {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test onInit & onMount 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test onInit & onMount 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2255,7 +2255,7 @@ export default class OnInit {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test onInit 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test onInit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -2285,7 +2285,7 @@ export default class OnInit {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test onMount 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test onMount 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2306,7 +2306,7 @@ export default class Comp {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test onUpdate 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test onUpdate 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2323,7 +2323,7 @@ export default class OnUpdate {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test onUpdateWithDeps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test onUpdateWithDeps 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -2354,7 +2354,7 @@ export default class OnUpdateWithDeps {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test preserveExportOrLocalStatement 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test preserveExportOrLocalStatement 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Types = {
@@ -2383,7 +2383,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test preserveTyping 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test preserveTyping 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export type A = \\"test\\";
@@ -2411,7 +2411,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test propsDestructure 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test propsDestructure 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -2437,7 +2437,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test propsInterface 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test propsInterface 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Person {
@@ -2457,7 +2457,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test propsType 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test propsType 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Person = {
@@ -2477,7 +2477,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test rootFragmentMultiNode 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test rootFragmentMultiNode 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -2512,7 +2512,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test rootShow 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test rootShow 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface RenderStylesProps {
@@ -2533,7 +2533,7 @@ export default class RenderStyles {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test self-referencing component 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test self-referencing component 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -2554,7 +2554,7 @@ export default class MyComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test self-referencing component with children 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test self-referencing component with children 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -2579,7 +2579,7 @@ export default class MyComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test showWithFor 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test showWithFor 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Props {
@@ -2604,10 +2604,10 @@ export default class NestedShow {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test subComponent 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test subComponent 1`] = `
 "import { Component } from \\"@angular/core\\";
 
-import Foo from \\"./foo-sub-component\\";
+import Foo from \\"./foo-sub-component.lite\\";
 
 @Component({
   selector: \\"sub-component, SubComponent\\",
@@ -2619,7 +2619,7 @@ export default class SubComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test typeDependency 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test typeDependency 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 import type { Foo } from \\"./foo-type\\";
@@ -2641,7 +2641,7 @@ export default class TypeDependency {
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test use-style 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test use-style 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2664,7 +2664,7 @@ export default class MyComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Javascript Test use-style-and-css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Javascript Test use-style-and-css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2690,7 +2690,7 @@ export default class MyComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Remove Internal mitosis package 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Remove Internal mitosis package 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2705,7 +2705,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test AdvancedRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test AdvancedRef 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -2770,7 +2770,7 @@ export default class MyBasicRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface MyBasicComponentProps {
@@ -2812,7 +2812,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic 2`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic 2`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -2842,7 +2842,7 @@ export default class MyBasicForShowComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic Context 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic Context 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 import { Injector, createInjector, MyService } from \\"@dummy/injection-js\\";
@@ -2878,7 +2878,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic OnMount Update 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic OnMount Update 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -2910,7 +2910,7 @@ export default class MyBasicOnMountUpdateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic Outputs 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic Outputs 1`] = `
 "import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -2935,7 +2935,7 @@ export default class MyBasicOutputsComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Basic Outputs Meta 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Basic Outputs Meta 1`] = `
 "import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -2960,7 +2960,7 @@ export default class MyBasicOutputsComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicBooleanAttribute 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicBooleanAttribute 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -2998,7 +2998,7 @@ export default class MyBooleanAttribute {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicChildComponent 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicChildComponent 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 import MyBasicComponent from \\"./basic.raw\\";
@@ -3026,7 +3026,7 @@ export default class MyBasicChildComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicFor 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicFor 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -3060,7 +3060,7 @@ export default class MyBasicForComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicRef 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface Props {
@@ -3121,7 +3121,7 @@ export default class MyBasicRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicRefAssignment 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicRefAssignment 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -3148,7 +3148,7 @@ export default class MyBasicRefAssignmentComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test BasicRefPrevious 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test BasicRefPrevious 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -3190,7 +3190,7 @@ export default class MyPreviousComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Button 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Button 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -3225,7 +3225,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Columns 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Columns 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Column = {
@@ -3300,7 +3300,7 @@ export default class Column {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test ContentSlotHtml 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test ContentSlotHtml 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -3328,7 +3328,7 @@ export default class ContentSlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test ContentSlotJSX 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test ContentSlotJSX 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -3355,7 +3355,7 @@ export default class ContentSlotJsxCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test CustomCode 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test CustomCode 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
@@ -3430,7 +3430,7 @@ export default class CustomCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Embed 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Embed 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface CustomCodeProps {
@@ -3505,7 +3505,7 @@ export default class CustomCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Form 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Form 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 export interface FormProps {
@@ -3849,7 +3849,7 @@ export default class FormComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Image 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Image 1`] = `
 "import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
 // TODO: AMP Support?
@@ -3965,7 +3965,7 @@ export default class Image {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Image State 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Image State 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -3987,7 +3987,7 @@ export default class ImgStateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Img 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Img 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ImgProps {
@@ -4033,7 +4033,7 @@ export default class ImgComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Input 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Input 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface FormInputProps {
@@ -4074,7 +4074,7 @@ export default class FormInputComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test RawText 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test RawText 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface RawTextProps {
@@ -4098,7 +4098,7 @@ export default class RawText {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Section 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Section 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface SectionProps {
@@ -4126,7 +4126,7 @@ export default class SectionComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Section 2`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Section 2`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface SectionProps {
@@ -4160,7 +4160,7 @@ export default class SectionStateComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Select 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Select 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface FormSelectProps {
@@ -4203,7 +4203,7 @@ export default class SelectComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test SlotHtml 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test SlotHtml 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -4226,7 +4226,7 @@ export default class SlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test SlotJsx 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test SlotJsx 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -4247,7 +4247,7 @@ export default class SlotCode {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Stamped.io 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Stamped.io 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type SmileReviewsProps = {
@@ -4356,7 +4356,7 @@ export default class SmileReviews {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Submit 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Submit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -4377,7 +4377,7 @@ export default class SubmitButton {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Text 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Text 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface TextProps {
@@ -4411,7 +4411,7 @@ export default class Text {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Textarea 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Textarea 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface TextareaProps {
@@ -4443,7 +4443,7 @@ export default class Textarea {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test Video 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test Video 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface VideoProps {
@@ -4510,7 +4510,7 @@ export default class Video {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test basicForwardRef 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test basicForwardRef 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -4543,7 +4543,7 @@ export default class MyBasicForwardRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test basicForwardRefMetadata 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test basicForwardRefMetadata 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 export interface Props {
@@ -4576,7 +4576,7 @@ export default class MyBasicForwardRefComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test basicOnUpdateReturn 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test basicOnUpdateReturn 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4609,7 +4609,7 @@ export default class MyBasicOnUpdateReturnComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test class + ClassName + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test class + ClassName + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4631,7 +4631,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test class + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test class + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4653,7 +4653,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test className + css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test className + css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4675,7 +4675,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test className 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test className 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Props = {
@@ -4699,7 +4699,7 @@ export default class ClassNameCode {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test classState 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test classState 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4724,7 +4724,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test defaultProps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test defaultProps 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -4765,7 +4765,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test defaultValsWithTypes 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test defaultValsWithTypes 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -4790,7 +4790,7 @@ export default class ComponentWithTypes {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test import types 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test import types 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type RenderContentProps = {
@@ -4821,12 +4821,13 @@ export default class RenderContent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test importRaw 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test importRaw 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 import Button1 from \\"./blocks/button.raw\\";
 import Button2 from \\"./blocks/button.raw\\";
 import * as Button3 from \\"./blocks/button.raw\\";
+import * as Button4 from \\"./blocks/button.raw.lite\\";
 
 @Component({
   selector: \\"my-import-component, MyImportComponent\\",
@@ -4838,7 +4839,7 @@ export default class MyImportComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test multipleOnUpdate 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test multipleOnUpdate 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4856,7 +4857,7 @@ export default class MultipleOnUpdate {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test multipleOnUpdateWithDeps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test multipleOnUpdateWithDeps 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4887,7 +4888,7 @@ export default class MultipleOnUpdateWithDeps {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test nestedShow 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test nestedShow 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Props {
@@ -4912,7 +4913,7 @@ export default class NestedShow {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test nestedStyles 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test nestedStyles 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4944,7 +4945,7 @@ export default class NestedStyles {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test onInit & onMount 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test onInit & onMount 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -4965,7 +4966,7 @@ export default class OnInit {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test onInit 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test onInit 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -4995,7 +4996,7 @@ export default class OnInit {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test onMount 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test onMount 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -5016,7 +5017,7 @@ export default class Comp {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test onUpdate 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test onUpdate 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -5033,7 +5034,7 @@ export default class OnUpdate {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test onUpdateWithDeps 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test onUpdateWithDeps 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -5064,7 +5065,7 @@ export default class OnUpdateWithDeps {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test preserveExportOrLocalStatement 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test preserveExportOrLocalStatement 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 type Types = {
@@ -5093,7 +5094,7 @@ export default class MyBasicComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test preserveTyping 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test preserveTyping 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export type A = \\"test\\";
@@ -5121,7 +5122,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test propsDestructure 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test propsDestructure 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Props = {
@@ -5147,7 +5148,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test propsInterface 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test propsInterface 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Person {
@@ -5167,7 +5168,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test propsType 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test propsType 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 type Person = {
@@ -5187,7 +5188,7 @@ export default class MyBasicComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test rootFragmentMultiNode 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test rootFragmentMultiNode 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface ButtonProps {
@@ -5222,7 +5223,7 @@ export default class Button {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test rootShow 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test rootShow 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 export interface RenderStylesProps {
@@ -5243,7 +5244,7 @@ export default class RenderStyles {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test self-referencing component 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test self-referencing component 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -5264,7 +5265,7 @@ export default class MyComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test self-referencing component with children 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test self-referencing component with children 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 @Component({
@@ -5289,7 +5290,7 @@ export default class MyComponent {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test showWithFor 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test showWithFor 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 interface Props {
@@ -5314,10 +5315,10 @@ export default class NestedShow {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test subComponent 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test subComponent 1`] = `
 "import { Component } from \\"@angular/core\\";
 
-import Foo from \\"./foo-sub-component\\";
+import Foo from \\"./foo-sub-component.lite\\";
 
 @Component({
   selector: \\"sub-component, SubComponent\\",
@@ -5329,7 +5330,7 @@ export default class SubComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test typeDependency 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test typeDependency 1`] = `
 "import { Component, Input } from \\"@angular/core\\";
 
 import type { Foo } from \\"./foo-type\\";
@@ -5351,7 +5352,7 @@ export default class TypeDependency {
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test use-style 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test use-style 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({
@@ -5374,7 +5375,7 @@ export default class MyComponent {}
 "
 `;
 
-exports[`Angular with Preserve Imports Typescript Test use-style-and-css 1`] = `
+exports[`Angular with Preserve Imports and File Extensions Typescript Test use-style-and-css 1`] = `
 "import { Component } from \\"@angular/core\\";
 
 @Component({

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -10015,6 +10015,7 @@ import { CommonModule } from \\"@angular/common\\";
 import Button1 from \\"./blocks/button.raw\\";
 import Button2 from \\"./blocks/button.raw\\";
 import * as Button3 from \\"./blocks/button.raw\\";
+import * as Button4 from \\"./blocks/button.raw\\";
 
 @Component({
   selector: \\"my-import-component, MyImportComponent\\",

--- a/packages/core/src/__tests__/angular.import.test.ts
+++ b/packages/core/src/__tests__/angular.import.test.ts
@@ -1,10 +1,11 @@
 import { componentToAngular } from '../generators/angular';
 import { runTestsForTarget } from './shared';
 
-describe('Angular with Preserve Imports', () => {
+describe('Angular with Preserve Imports and File Extensions', () => {
   runTestsForTarget({
     options: {
       preserveImports: true,
+      preserveFileExtensions: true,
     },
     target: 'angular',
     generator: componentToAngular,

--- a/packages/core/src/__tests__/data/blocks/button.raw.lite.tsx
+++ b/packages/core/src/__tests__/data/blocks/button.raw.lite.tsx
@@ -1,0 +1,29 @@
+import { Show } from '@builder.io/mitosis';
+
+export interface ButtonProps {
+  attributes?: any;
+  text?: string;
+  link?: string;
+  openLinkInNewTab?: boolean;
+}
+
+export default function Button(props: ButtonProps) {
+  return (
+    <div>
+      <Show when={props.link}>
+        <a
+          {...props.attributes}
+          href={props.link}
+          target={props.openLinkInNewTab ? '_blank' : undefined}
+        >
+          {props.text}
+        </a>
+      </Show>
+      <Show when={!props.link}>
+        <button {...props.attributes} type="button">
+          {props.text}
+        </button>
+      </Show>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/data/import.raw.tsx
+++ b/packages/core/src/__tests__/data/import.raw.tsx
@@ -1,6 +1,7 @@
 import { default as Button1 } from './blocks/button.raw'; // eslint-disable-line
 import Button2 from './blocks/button.raw'; // eslint-disable-line
 import * as Button3 from './blocks/button.raw'; // eslint-disable-line
+import * as Button4 from './blocks/button.raw.lite'; // eslint-disable-line
 
 export default function MyImportComponent() {
   return <div> Testing which imports get excluded! </div>;

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -35,6 +35,7 @@ const BUILT_IN_COMPONENTS = new Set(['Show', 'For', 'Fragment']);
 export interface ToAngularOptions extends BaseTranspilerOptions {
   standalone?: boolean;
   preserveImports?: boolean;
+  preserveFileExtensions?: boolean;
 }
 
 interface AngularBlockOptions {
@@ -228,6 +229,7 @@ export const componentToAngular: TranspilerGenerator<ToAngularOptions> =
   ({ component: _component }) => {
     const DEFAULT_OPTIONS = {
       preserveImports: false,
+      preserveFileExtensions: false,
     };
 
     const options = { ...DEFAULT_OPTIONS, ...userOptions };
@@ -379,6 +381,7 @@ export const componentToAngular: TranspilerGenerator<ToAngularOptions> =
       component: json,
       target: 'angular',
       excludeMitosisComponents: !options.standalone && !options.preserveImports,
+      preserveFileExtensions: options.preserveFileExtensions,
     })}
 
     @Component({

--- a/packages/core/src/helpers/render-imports.test.ts
+++ b/packages/core/src/helpers/render-imports.test.ts
@@ -12,6 +12,7 @@ describe('renderImport', () => {
       theImport: data[0],
       target: 'vue',
       asyncComponentImports: false,
+      preserveFileExtensions: false,
     });
     expect(output).toMatchSnapshot();
   });
@@ -27,6 +28,7 @@ describe('renderImport', () => {
       theImport: data[0],
       target: 'react',
       asyncComponentImports: false,
+      preserveFileExtensions: false,
     });
     expect(output).toEqual("import '../render-blocks.scss';");
   });

--- a/packages/core/src/helpers/render-imports.test.ts
+++ b/packages/core/src/helpers/render-imports.test.ts
@@ -12,7 +12,6 @@ describe('renderImport', () => {
       theImport: data[0],
       target: 'vue',
       asyncComponentImports: false,
-      preserveFileExtensions: false,
     });
     expect(output).toMatchSnapshot();
   });
@@ -28,7 +27,6 @@ describe('renderImport', () => {
       theImport: data[0],
       target: 'react',
       asyncComponentImports: false,
-      preserveFileExtensions: false,
     });
     expect(output).toEqual("import '../render-blocks.scss';");
   });

--- a/packages/core/src/helpers/render-imports.ts
+++ b/packages/core/src/helpers/render-imports.ts
@@ -107,12 +107,12 @@ export const renderImport = ({
   theImport,
   target,
   asyncComponentImports,
-  preserveFileExtensions,
+  preserveFileExtensions = false,
 }: {
   theImport: MitosisImport;
   target: Target;
   asyncComponentImports: boolean;
-  preserveFileExtensions: boolean;
+  preserveFileExtensions?: boolean;
 }): string => {
   const importedValues = getImportedValues({ theImport });
   const path = transformImportPath(theImport, target, preserveFileExtensions);


### PR DESCRIPTION
eact file:
import * as React from "react";
import ButtonCmp from "./button.lite";
export default function ButtonComposition(props: any) {
//....
angular file:
import { NgModule } from "@angular/core";
import { BrowserModule } from "@angular/platform-browser";

import { Inject, forwardRef, Component } from "@angular/core";
import ButtonCmp from "./button";
@Component({
//...


The fix adds a new option which is preserveFileExtensions which defaults to false. 

