### PR TITLE
fix(core): append .value to refs when using Vue 3 composition API

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -40,7 +40,7 @@ watch([inputRef, inputNoArgRef], ([inputRef, inputNoArgRef]) => {
 });
 function onBlur() {
   // Maintain focus
-  inputRef.focus();
+  inputRef.value.focus();
 }
 
 function lowerCaseName() {
@@ -324,7 +324,7 @@ const inputNoArgRef = ref(null);
 
 function onBlur() {
   // Maintain focus
-  inputRef.focus();
+  inputRef.value.focus();
 }
 
 function lowerCaseName() {
@@ -353,7 +353,7 @@ const holdValueRef = ref(null);
 function handlerClick(event) {
   event.preventDefault();
   console.log(\\"current value\\", holdValueRef);
-  holdValueRef = holdValueRef + \\"JS\\";
+  holdValueRef.value = holdValueRef.value + \\"JS\\";
 }
 </script>
 "
@@ -387,8 +387,8 @@ const count = ref(0);
 
 const prevCount = ref(null);
 
-watch([count.value], ([count]) => {
-  prevCount = count.value;
+watch([count], ([count]) => {
+  prevCount.value = count;
 });
 </script>
 "
@@ -543,9 +543,9 @@ onMounted(() => {
 
 function findAndRunScripts() {
   // TODO: Move this function to standalone one in '@builder.io/utils'
-  if (elem && typeof window !== \\"undefined\\") {
+  if (elem.value && typeof window !== \\"undefined\\") {
     /** @type {HTMLScriptElement[]} */
-    const scripts = elem.getElementsByTagName(\\"script\\");
+    const scripts = elem.value.getElementsByTagName(\\"script\\");
 
     for (let i = 0; i < scripts.length; i++) {
       const script = scripts[i];
@@ -630,9 +630,9 @@ onMounted(() => {
 
 function findAndRunScripts() {
   // TODO: Move this function to standalone one in '@builder.io/utils'
-  if (elem && typeof window !== \\"undefined\\") {
+  if (elem.value && typeof window !== \\"undefined\\") {
     /** @type {HTMLScriptElement[]} */
-    const scripts = elem.getElementsByTagName(\\"script\\");
+    const scripts = elem.value.getElementsByTagName(\\"script\\");
 
     for (let i = 0; i < scripts.length; i++) {
       const script = scripts[i];
@@ -881,8 +881,8 @@ function onSubmit(event) {
       },
     });
 
-    if (formRef) {
-      formRef.dispatchEvent(presubmitEvent);
+    if (formRef.value) {
+      formRef.value.dispatchEvent(presubmitEvent);
 
       if (presubmitEvent.defaultPrevented) {
         return;
@@ -940,8 +940,8 @@ function onSubmit(event) {
             },
           });
 
-          if (formRef) {
-            formRef.dispatchEvent(submitSuccessEvent);
+          if (formRef.value) {
+            formRef.value.dispatchEvent(submitSuccessEvent);
 
             if (submitSuccessEvent.defaultPrevented) {
               return;
@@ -949,19 +949,19 @@ function onSubmit(event) {
             /* TODO: option to turn this on/off? */
 
             if (props.resetFormOnSubmit !== false) {
-              formRef.reset();
+              formRef.value.reset();
             }
           }
           /* TODO: client side route event first that can be preventDefaulted */
 
           if (props.successUrl) {
-            if (formRef) {
+            if (formRef.value) {
               const event = new CustomEvent(\\"route\\", {
                 detail: {
                   url: props.successUrl,
                 },
               });
-              formRef.dispatchEvent(event);
+              formRef.value.dispatchEvent(event);
 
               if (!event.defaultPrevented) {
                 location.href = props.successUrl;
@@ -979,8 +979,8 @@ function onSubmit(event) {
           },
         });
 
-        if (formRef) {
-          formRef.dispatchEvent(submitErrorEvent);
+        if (formRef.value) {
+          formRef.value.dispatchEvent(submitErrorEvent);
 
           if (submitErrorEvent.defaultPrevented) {
             return;
@@ -1053,8 +1053,8 @@ onMounted(() => {
   if (useLazyLoading()) {
     // throttled scroll capture listener
     const listener = () => {
-      if (pictureRef) {
-        const rect = pictureRef.getBoundingClientRect();
+      if (pictureRef.value) {
+        const rect = pictureRef.value.getBoundingClientRect();
         const buffer = window.innerHeight / 2;
 
         if (rect.top < window.innerHeight + buffer) {
@@ -1383,58 +1383,50 @@ exports[`Vue Javascript Test Stamped.io 1`] = `
 </template>
 
 <script setup>
-    import { onMounted, ref } from \\"vue\\"
+import { onMounted, ref } from \\"vue\\";
 
+import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
 
+const props = defineProps([\\"apiKey\\", \\"productId\\"]);
+const reviews = ref([]);
+const name = ref(\\"test\\");
+const showReviewPrompt = ref(false);
 
-  import { kebabCase } from 'lodash';
-import { snakeCase } from 'lodash';
-
-
-
-
-    const props = defineProps(['apiKey','productId'])
-const reviews= ref([])
-const name= ref('test')
-const showReviewPrompt= ref(false)
-
-
-
-
-
-
-
-
-onMounted(() => { fetch(\`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${props.apiKey || 'pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM'}&productId=\${props.productId || '2410511106127'}\`).then(res => res.json()).then(data => {
-reviews.value = data.data;
-})})
-
-
-
-
+onMounted(() => {
+  fetch(
+    \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
+      props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
+    }&productId=\${props.productId || \\"2410511106127\\"}\`
+  )
+    .then((res) => res.json())
+    .then((data) => {
+      reviews.value = data.data;
+    });
+});
 
 function kebabCaseValue() {
-return kebabCase('testThat');
+  return kebabCase(\\"testThat\\");
 }
 
 function snakeCaseValue() {
-return snakeCase('testThis');
+  return snakeCase(\\"testThis\\");
 }
 
 function _classStringToObject(str) {
-const obj = {};
+  const obj = {};
 
-if (typeof str !== 'string') {
-return obj;
-}
+  if (typeof str !== \\"string\\") {
+    return obj;
+  }
 
-const classNames = str.trim().split(/\\\\s+/);
+  const classNames = str.trim().split(/\\\\s+/);
 
-for (const name.value of classNames) {
-obj[name] = true;
-}
+  for (const name of classNames) {
+    obj[name] = true;
+  }
 
-return obj;
+  return obj;
 }
 </script>
 
@@ -1627,7 +1619,7 @@ import { ref, watch } from \\"vue\\";
 
 const name = ref(\\"PatrickJS\\");
 
-watch([name.value], ([name]) => {
+watch([name], ([name]) => {
   const controller = new AbortController();
   const signal = controller.signal;
   fetch(\\"https://patrickjs.com/api/resource.json\\", {
@@ -1862,14 +1854,14 @@ const b = ref(\\"b\\");
 const c = ref(\\"c\\");
 const d = ref(\\"d\\");
 
-watch([a.value, b.value], ([a, b]) => {
+watch([a, b], ([a, b]) => {
   console.log(\\"Runs when a or b changes\\", a, b);
 
-  if (a.value === \\"a\\") {
+  if (a === \\"a\\") {
     a.value = \\"b\\";
   }
 }),
-  watch([c.value, d.value], ([c, d]) => {
+  watch([c, d], ([c, d]) => {
     console.log(\\"Runs when c or d changes\\", c, d);
 
     if (a.value === \\"a\\") {
@@ -2010,7 +2002,7 @@ const props = defineProps([\\"size\\"]);
 const a = ref(\\"a\\");
 const b = ref(\\"b\\");
 
-watch([a.value, b.value, props.size], ([a, b, size]) => {
+watch([a, b, props.size], ([a, b, size]) => {
   console.log(\\"Runs when a, b or size changes\\", a, b, props.size);
 });
 </script>
@@ -2297,7 +2289,7 @@ watch([inputRef, inputNoArgRef], ([inputRef, inputNoArgRef]) => {
 });
 function onBlur() {
   // Maintain focus
-  inputRef.focus();
+  inputRef.value.focus();
 }
 
 function lowerCaseName() {
@@ -2596,7 +2588,7 @@ const inputNoArgRef = ref<HTMLLabelElement>();
 
 function onBlur() {
   // Maintain focus
-  inputRef.focus();
+  inputRef.value.focus();
 }
 
 function lowerCaseName() {
@@ -2629,7 +2621,7 @@ const holdValueRef = ref<undefined>();
 function handlerClick(event) {
   event.preventDefault();
   console.log(\\"current value\\", holdValueRef);
-  holdValueRef = holdValueRef + \\"JS\\";
+  holdValueRef.value = holdValueRef.value + \\"JS\\";
 }
 </script>
 "
@@ -2666,8 +2658,8 @@ const count = ref(0);
 
 const prevCount = ref<undefined>();
 
-watch([count.value], ([count]) => {
-  prevCount = count.value;
+watch([count], ([count]) => {
+  prevCount.value = count;
 });
 </script>
 "
@@ -2857,9 +2849,9 @@ onMounted(() => {
 
 function findAndRunScripts() {
   // TODO: Move this function to standalone one in '@builder.io/utils'
-  if (elem && typeof window !== \\"undefined\\") {
+  if (elem.value && typeof window !== \\"undefined\\") {
     /** @type {HTMLScriptElement[]} */
-    const scripts = elem.getElementsByTagName(\\"script\\");
+    const scripts = elem.value.getElementsByTagName(\\"script\\");
 
     for (let i = 0; i < scripts.length; i++) {
       const script = scripts[i];
@@ -2948,9 +2940,9 @@ onMounted(() => {
 
 function findAndRunScripts() {
   // TODO: Move this function to standalone one in '@builder.io/utils'
-  if (elem && typeof window !== \\"undefined\\") {
+  if (elem.value && typeof window !== \\"undefined\\") {
     /** @type {HTMLScriptElement[]} */
-    const scripts = elem.getElementsByTagName(\\"script\\");
+    const scripts = elem.value.getElementsByTagName(\\"script\\");
 
     for (let i = 0; i < scripts.length; i++) {
       const script = scripts[i];
@@ -3203,8 +3195,8 @@ function onSubmit(event) {
       },
     });
 
-    if (formRef) {
-      formRef.dispatchEvent(presubmitEvent);
+    if (formRef.value) {
+      formRef.value.dispatchEvent(presubmitEvent);
 
       if (presubmitEvent.defaultPrevented) {
         return;
@@ -3262,8 +3254,8 @@ function onSubmit(event) {
             },
           });
 
-          if (formRef) {
-            formRef.dispatchEvent(submitSuccessEvent);
+          if (formRef.value) {
+            formRef.value.dispatchEvent(submitSuccessEvent);
 
             if (submitSuccessEvent.defaultPrevented) {
               return;
@@ -3271,19 +3263,19 @@ function onSubmit(event) {
             /* TODO: option to turn this on/off? */
 
             if (props.resetFormOnSubmit !== false) {
-              formRef.reset();
+              formRef.value.reset();
             }
           }
           /* TODO: client side route event first that can be preventDefaulted */
 
           if (props.successUrl) {
-            if (formRef) {
+            if (formRef.value) {
               const event = new CustomEvent(\\"route\\", {
                 detail: {
                   url: props.successUrl,
                 },
               });
-              formRef.dispatchEvent(event);
+              formRef.value.dispatchEvent(event);
 
               if (!event.defaultPrevented) {
                 location.href = props.successUrl;
@@ -3301,8 +3293,8 @@ function onSubmit(event) {
           },
         });
 
-        if (formRef) {
-          formRef.dispatchEvent(submitErrorEvent);
+        if (formRef.value) {
+          formRef.value.dispatchEvent(submitErrorEvent);
 
           if (submitErrorEvent.defaultPrevented) {
             return;
@@ -3385,8 +3377,8 @@ onMounted(() => {
   if (useLazyLoading()) {
     // throttled scroll capture listener
     const listener = () => {
-      if (pictureRef) {
-        const rect = pictureRef.getBoundingClientRect();
+      if (pictureRef.value) {
+        const rect = pictureRef.value.getBoundingClientRect();
         const buffer = window.innerHeight / 2;
 
         if (rect.top < window.innerHeight + buffer) {
@@ -3757,61 +3749,54 @@ exports[`Vue Typescript Test Stamped.io 1`] = `
 </template>
 
 <script setup lang=\\"ts\\">
-    import { onMounted, ref } from \\"vue\\"
-    type SmileReviewsProps = {
-productId: string;
-apiKey: string;
+import { onMounted, ref } from \\"vue\\";
+type SmileReviewsProps = {
+  productId: string;
+  apiKey: string;
 };
 
+import { kebabCase } from \\"lodash\\";
+import { snakeCase } from \\"lodash\\";
 
-  import { kebabCase } from 'lodash';
-import { snakeCase } from 'lodash';
+const props = defineProps<SmileReviewsProps>();
+const reviews = ref([]);
+const name = ref(\\"test\\");
+const showReviewPrompt = ref(false);
 
-
-
-
-    const props = defineProps<SmileReviewsProps>()
-const reviews= ref([])
-const name= ref('test')
-const showReviewPrompt= ref(false)
-
-
-
-
-
-
-
-
-onMounted(() => { fetch(\`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${props.apiKey || 'pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM'}&productId=\${props.productId || '2410511106127'}\`).then(res => res.json()).then(data => {
-reviews.value = data.data;
-})})
-
-
-
-
+onMounted(() => {
+  fetch(
+    \`https://stamped.io/api/widget/reviews?storeUrl=builder-io.myshopify.com&apiKey=\${
+      props.apiKey || \\"pubkey-8bbDq7W6w4sB3OWeM1HUy2s47702hM\\"
+    }&productId=\${props.productId || \\"2410511106127\\"}\`
+  )
+    .then((res) => res.json())
+    .then((data) => {
+      reviews.value = data.data;
+    });
+});
 
 function kebabCaseValue() {
-return kebabCase('testThat');
+  return kebabCase(\\"testThat\\");
 }
 
 function snakeCaseValue() {
-return snakeCase('testThis');
+  return snakeCase(\\"testThis\\");
 }
 
 function _classStringToObject(str) {
-const obj = {};
+  const obj = {};
 
-if (typeof str !== 'string') {
-return obj;
-}
+  if (typeof str !== \\"string\\") {
+    return obj;
+  }
 
-const classNames = str.trim().split(/\\\\s+/);
+  const classNames = str.trim().split(/\\\\s+/);
 
-for (const name.value of classNames) {
-obj[name] = true;
-}
+  for (const name of classNames) {
+    obj[name] = true;
+  }
 
-return obj;
+  return obj;
 }
 </script>
 
@@ -4042,7 +4027,7 @@ import { ref, watch } from \\"vue\\";
 
 const name = ref(\\"PatrickJS\\");
 
-watch([name.value], ([name]) => {
+watch([name], ([name]) => {
   const controller = new AbortController();
   const signal = controller.signal;
   fetch(\\"https://patrickjs.com/api/resource.json\\", {
@@ -4299,14 +4284,14 @@ const b = ref(\\"b\\");
 const c = ref(\\"c\\");
 const d = ref(\\"d\\");
 
-watch([a.value, b.value], ([a, b]) => {
+watch([a, b], ([a, b]) => {
   console.log(\\"Runs when a or b changes\\", a, b);
 
-  if (a.value === \\"a\\") {
+  if (a === \\"a\\") {
     a.value = \\"b\\";
   }
 }),
-  watch([c.value, d.value], ([c, d]) => {
+  watch([c, d], ([c, d]) => {
     console.log(\\"Runs when c or d changes\\", c, d);
 
     if (a.value === \\"a\\") {
@@ -4458,7 +4443,7 @@ const props = defineProps<Props>();
 const a = ref(\\"a\\");
 const b = ref(\\"b\\");
 
-watch([a.value, b.value, props.size], ([a, b, size]) => {
+watch([a, b, props.size], ([a, b, size]) => {
   console.log(\\"Runs when a, b or size changes\\", a, b, props.size);
 });
 </script>

--- a/packages/core/src/generators/vue/compositionApi.ts
+++ b/packages/core/src/generators/vue/compositionApi.ts
@@ -30,21 +30,59 @@ const getCompositionPropDefinition = ({
   }
   return str;
 };
+
+function shouldAppendValueToRef(path: babel.NodePath<babel.types.Identifier>) {
+  const { parent, node } = path;
+
+  if (types.isFunctionDeclaration(parent) && parent.id === node) {
+    return false;
+  }
+
+  if (types.isCallExpression(parent)) {
+    return false;
+  }
+
+  const isMemberExpression = types.isMemberExpression(parent);
+
+  if (
+    isMemberExpression &&
+    types.isThisExpression(parent.object) &&
+    types.isProgram(path.scope.block) &&
+    path.scope.hasReference(node.name)
+  ) {
+    return false;
+  }
+
+  if (
+    isMemberExpression &&
+    types.isIdentifier(parent.object) &&
+    types.isIdentifier(parent.property) &&
+    parent.property.name === node.name
+  ) {
+    return false;
+  }
+
+  if (Object.keys(path.scope.bindings).includes(path.node.name)) {
+    return false;
+  }
+
+  if (path.parentPath.listKey === 'arguments' || path.parentPath.listKey === 'params') {
+    return false;
+  }
+
+  return true;
+}
+
 function appendValueToRefs(input: string, component: MitosisComponent, options: ToVueOptions) {
-  const refKeys = Object.keys(pickBy(component.state, (i) => i?.type === 'property'));
+  const refKeys = Object.keys(component.refs);
+  const stateKeys = Object.keys(pickBy(component.state, (i) => i?.type === 'property'));
+  const allKeys = [...refKeys, ...stateKeys];
 
   let output = processBinding({ code: input, options, json: component, includeProps: false });
 
   return babelTransformExpression(output, {
     Identifier(path: babel.NodePath<babel.types.Identifier>) {
-      if (
-        !(types.isFunctionDeclaration(path.parent) && path.parent.id === path.node) &&
-        !types.isCallExpression(path.parent) &&
-        (!types.isMemberExpression(path.parent) || types.isThisExpression(path.parent.object)) &&
-        path.parentPath.listKey !== 'arguments' &&
-        path.parentPath.listKey !== 'params' &&
-        refKeys.includes(path.node.name)
-      ) {
+      if (allKeys.includes(path.node.name) && shouldAppendValueToRef(path)) {
         path.replaceWith(types.identifier(`${path.node.name}.value`));
       }
     },


### PR DESCRIPTION
# Fix(core): append `.value` to refs when using Vue 3 composition API

## Description

Currently only usages of state keys are being appended with `.value` in the Vue 3 composition API generator.  This PR ensures that `.value` is also appended to usages of refs.

- Include Mitosis component ref keys when checking which nodes should have `.value` appended to them
- Added extra checks to ensure `.value` is not appended in watcher definitions, or in function declarations
- Updated snapshots
