### PR TITLE
add prohibited Vue keywords

### DIFF
--- a/packages/core/src/helpers/get-props.ts
+++ b/packages/core/src/helpers/get-props.ts
@@ -11,7 +11,12 @@ const prohibitedKeywordRE = new RegExp(
     (
       'do,if,for,let,new,try,var,case,else,with,await,break,catch,class,const,' +
       'super,throw,while,yield,delete,export,import,return,switch,default,' +
-      'extends,finally,continue,debugger,function,arguments,typeof,void'
+      'extends,finally,continue,debugger,function,arguments,typeof,void,' +
+      // both below conditions added based on https://github.com/vuejs/vue/blob/e80cd09fff570df57d608f8f5aaccee6d7f31917/src/core/instance/state.ts#L89-L96
+      // below line added from https://github.com/vuejs/vue/blob/8880b55d52f8d873f79ef67436217c8752cddef5/src/shared/util.ts#L130
+      'key,ref,slot,slot-scope,is,' +
+      // below line added from https://github.com/vuejs/vue/blob/72aed6a149b94b5b929fb47370a7a6d4cb7491c5/src/platforms/web/util/attrs.ts#L5
+      'style'
     )
       .split(',')
       .join('\\b|\\b') +


### PR DESCRIPTION
## Description

Catch more edge cases of prohibited Vue keywords. Applies to all generators, but if that becomes a problem we can scope it to just the Vue generator