### PR TITLE
feat: Alpine.js generator

### DIFF
--- a/packages/core/src/generators/alpine/generate.ts
+++ b/packages/core/src/generators/alpine/generate.ts
@@ -167,7 +167,8 @@ const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string
       } else if (key === 'ref') {
         str += ` x-ref="${useValue}"`;
       } else if (isValidAlpineBinding(useValue)) {
-        str += ` :${key}="${useValue}" `;
+        const bind = options.useShorthandSyntax ? ':' : 'x-bind:'
+        str += ` ${bind}${key}="${useValue}" `;
       }
     }
     if (selfClosingTags.has(json.name)) {

--- a/packages/core/src/generators/alpine/generate.ts
+++ b/packages/core/src/generators/alpine/generate.ts
@@ -88,7 +88,7 @@ const bindEventHandlerValue = compose(
   stripStateAndPropsRefs
 );
 
-const bindEventHandler = ({useShorthandSyntax}: ToAlpineOptions) => (eventName: string, code: string) => {
+const bindEventHandler = ({ useShorthandSyntax }: ToAlpineOptions) => (eventName: string, code: string) => {
   const bind = useShorthandSyntax ? '@' : 'x-on:'
   return ` ${bind}${bindEventHandlerKey(eventName)}="${bindEventHandlerValue(code).trim()}"`;
 };
@@ -166,16 +166,9 @@ const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string
       str += ` ${bind}${key}="${useValue}" `;
     }
   }
-  if (selfClosingTags.has(json.name)) {
-    return str + ' />';
-  }
-  str += '>';
-  if (json.children) {
-    str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
-  }
-
-  str += `</${json.name}>`;
-  return str;
+  return selfClosingTags.has(json.name)
+    ? `${str} />`
+    : `${str}>${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('\n')}</${json.name}>`;
 };
 
 
@@ -197,10 +190,10 @@ export const componentToAlpine: TranspilerGenerator<ToAlpineOptions> =
         ? stateObjectString
         : `${camelCase(json.name)}()`;
 
-      let str = json.children.map((item) => blockToAlpine(item, options)).join('\n');
-      if (css.trim().length) {
-        str += `<style>${css}</style>`;
-      }
+      let str = css.trim().length
+        ? `<style>${css}</style>`
+        : '';
+      str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
 
       if (!options.inlineState) {
         str += `<script>

--- a/packages/core/src/generators/alpine/generate.ts
+++ b/packages/core/src/generators/alpine/generate.ts
@@ -103,12 +103,9 @@ const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string
   }
 
   if (json.bindings._text?.code) {
-    if (!isValidAlpineBinding(json.bindings._text.code as string)) {
-      return '';
-    }
-    // @todo
-    return `<span x-html="${stripStateAndPropsRefs(json.bindings._text.code as string)}"></span>`;
-    // return `{{${stripStateAndPropsRefs(json.bindings._text.code as string)}}}`;
+    return isValidAlpineBinding(json.bindings._text.code)
+    ? `<span x-html="${stripStateAndPropsRefs(json.bindings._text.code as string)}"></span>`
+    : '';
   }
 
   let str = '';
@@ -143,9 +140,9 @@ const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string
       isValidAlpineBinding(json.bindings._spread.code)
     ) {
       str += `
-          {% for _attr in ${json.bindings._spread.code} %}
+          <template x-for="_attr in ${json.bindings._spread.code}">
             {{ _attr[0] }}="{{ _attr[1] }}"
-          {% endfor %}
+          </template>
         `;
     }
 
@@ -187,10 +184,8 @@ const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string
 const mappers: {
   [key: string]: (json: MitosisNode, options: ToAlpineOptions) => string;
 } = {
-  Fragment: (json, options) => {
-    return `<div>${json.children.map((item) => blockToAlpine(item, options)).join('\n')}</div>`;
-  },
-};
+  Fragment: (json, options) => blockToAlpine({...json, name: "div"}, options),
+  };
 
 export const componentToAlpine: TranspilerGenerator<ToAlpineOptions> =
   (options = {}) =>

--- a/packages/core/src/generators/alpine/generate.ts
+++ b/packages/core/src/generators/alpine/generate.ts
@@ -1,0 +1,190 @@
+import { format } from 'prettier/standalone';
+import { collectCss } from '../../helpers/styles/collect-css';
+import { fastClone } from '../../helpers/fast-clone';
+import { stripStateAndPropsRefs } from '../../helpers/strip-state-and-props-refs';
+import { selfClosingTags } from '../../parsers/jsx';
+import { checkIsForNode, MitosisNode } from '../../types/mitosis-node';
+import {
+  runPostCodePlugins,
+  runPostJsonPlugins,
+  runPreCodePlugins,
+  runPreJsonPlugins,
+} from '../../modules/plugins';
+import { stripMetaProperties } from '../../helpers/strip-meta-properties';
+import { getStateObjectStringFromComponent } from '../../helpers/get-state-object-string';
+import { BaseTranspilerOptions, TranspilerGenerator } from '../../types/transpiler';
+
+export interface ToAlpineOptions extends BaseTranspilerOptions {
+  reactive?: boolean;
+}
+
+/**
+ * Test if the binding expression would be likely to generate
+ * valid or invalid liquid. If we generate invalid liquid tags
+ * Shopify will reject our PUT to update the template
+ */
+export const isValidAlpineBinding = (str = '') => {
+  const strictMatches = Boolean(
+    // Test for our `context.shopify.liquid.*(expression), which
+    // we regex out later to transform back into valid liquid expressions
+    str.match(/(context|ctx)\s*(\.shopify\s*)?\.liquid\s*\./),
+  );
+
+  return (
+    strictMatches ||
+    // Test is the expression is simple and would map to Shopify bindings	    // Test for our `context.shopify.liquid.*(expression), which
+    // e.g. `state.product.price` -> `{{product.price}}	    // we regex out later to transform back into valid liquid expressions
+    Boolean(str.match(/^[a-z0-9_\.\s]+$/i))
+  );
+};
+
+// TODO: spread support
+const blockToAlpine = (json: MitosisNode, options: ToAlpineOptions = {}): string => {
+  if (mappers[json.name]) {
+    return mappers[json.name](json, options);
+  }
+
+  // TODO: Add support for `{props.children}` bindings
+
+  if (json.properties._text) {
+    return json.properties._text;
+  }
+
+  if (json.bindings._text?.code) {
+    if (!isValidAlpineBinding(json.bindings._text.code as string)) {
+      return '';
+    }
+    return `{{${stripStateAndPropsRefs(json.bindings._text.code as string)}}}`;
+  }
+
+  let str = '';
+
+  if (checkIsForNode(json)) {
+    if (
+      !(isValidAlpineBinding(json.bindings.each?.code) && isValidAlpineBinding(json.scope.forName))
+    ) {
+      return str;
+    }
+    str += `{% for ${json.scope.forName} in ${stripStateAndPropsRefs(json.bindings.each?.code)} %}`;
+    if (json.children) {
+      str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
+    }
+
+    str += '{% endfor %}';
+  } else if (json.name === 'Show') {
+    if (!isValidAlpineBinding(json.bindings.when?.code)) {
+      return str;
+    }
+    str += `{% if ${stripStateAndPropsRefs(json.bindings.when?.code)} %}`;
+    if (json.children) {
+      str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
+    }
+
+    str += '{% endif %}';
+  } else {
+    str += `<${json.name} `;
+
+    if (
+      json.bindings._spread?.code === '_spread' &&
+      isValidAlpineBinding(json.bindings._spread.code)
+    ) {
+      str += `
+          {% for _attr in ${json.bindings._spread.code} %}
+            {{ _attr[0] }}="{{ _attr[1] }}"
+          {% endfor %}
+        `;
+    }
+
+    for (const key in json.properties) {
+      const value = json.properties[key];
+      str += ` ${key}="${value}" `;
+    }
+
+    for (const key in json.bindings) {
+      if (key === '_spread' || key === 'ref' || key === 'css') {
+        continue;
+      }
+      const { code: value } = json.bindings[key]!;
+      // TODO: proper babel transform to replace. Util for this
+      const useValue = stripStateAndPropsRefs(value);
+
+      if (key.startsWith('on')) {
+        // Do nothing
+      } else if (isValidAlpineBinding(useValue)) {
+        str += ` ${key}="{{${useValue}}}" `;
+      }
+    }
+    if (selfClosingTags.has(json.name)) {
+      return str + ' />';
+    }
+    str += '>';
+    if (json.children) {
+      str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
+    }
+
+    str += `</${json.name}>`;
+  }
+  return str;
+};
+
+const mappers: {
+  [key: string]: (json: MitosisNode, options: ToAlpineOptions) => string;
+} = {
+  Fragment: (json, options) => {
+    return `<div>${json.children.map((item) => blockToAlpine(item, options)).join('\n')}</div>`;
+  },
+};
+
+// TODO: add JS support similar to componentToHtml()
+export const componentToAlpine: TranspilerGenerator<ToAlpineOptions> =
+  (options = {}) =>
+  ({ component }) => {
+    let json = fastClone(component);
+    if (options.plugins) {
+      json = runPreJsonPlugins(json, options.plugins);
+    }
+    const css = collectCss(json);
+    stripMetaProperties(json);
+    if (options.plugins) {
+      json = runPostJsonPlugins(json, options.plugins);
+    }
+    let str = json.children.map((item) => blockToAlpine(item)).join('\n');
+    if (css.trim().length) {
+      str += `<style>${css}</style>`;
+    }
+
+    if (options.reactive) {
+      const stateObjectString = getStateObjectStringFromComponent(json);
+      if (stateObjectString.trim().length > 4) {
+        str += `<script reactive>
+        export default {
+          state: ${stateObjectString}
+        }
+      </script>`;
+      }
+    }
+
+    if (options.plugins) {
+      str = runPreCodePlugins(str, options.plugins);
+    }
+    if (options.prettier !== false) {
+      try {
+        str = format(str, {
+          parser: 'html',
+          htmlWhitespaceSensitivity: 'ignore',
+          plugins: [
+            // To support running in browsers
+            require('prettier/parser-html'),
+            require('prettier/parser-postcss'),
+            require('prettier/parser-babel'),
+          ],
+        });
+      } catch (err) {
+        console.warn('Could not prettify', { string: str }, err);
+      }
+    }
+    if (options.plugins) {
+      str = runPostCodePlugins(str, options.plugins);
+    }
+    return str;
+  };

--- a/packages/core/src/generators/alpine/index.ts
+++ b/packages/core/src/generators/alpine/index.ts
@@ -1,0 +1,1 @@
+export * from './generate'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export * from './parsers/builder';
 export * from './parsers/angular';
 export * from './parsers/context';
 export * from './generators/vue';
+export * from './generators/alpine';
 export * from './generators/angular';
 export * from './generators/context/react';
 export * from './generators/context/qwik';

--- a/packages/fiddle/src/components/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle.tsx
@@ -64,6 +64,7 @@ import stringify from 'fast-json-stable-stringify';
 
 import MonacoEditor, { EditorProps, useMonaco } from '@monaco-editor/react/';
 import { CodeEditor } from './CodeEditor';
+import { ToAlpineOptions } from '@builder.io/mitosis';
 
 type Position = { row: number; column: number };
 
@@ -301,6 +302,8 @@ export default function Fiddle() {
         localStorageGet('options.svelteStateType') || ('variables' as 'variables' | 'proxies'),
       vueApi: localStorageGet('options.vueApi') || ('options' as 'options' | 'composition'),
       vueVersion: localStorageGet('options.vueVersion') || ('2' as '2' | '3'),
+      alpineShorthandSyntax: localStorageGet('options.alpineShorthandSyntax') || 'false',
+      alpineInline: localStorageGet('options.alpineInline') || 'false',
     },
     applyPendingBuilderChange(update?: any) {
       const builderJson = update || state.pendingBuilderChange;
@@ -324,12 +327,16 @@ export default function Fiddle() {
         let commonOptions: { typescript: boolean } = {
           typescript: hasBothTsAndJsSupport(state.outputTab) && state.options.typescript === 'true',
         };
+        let alpineOptions: ToAlpineOptions = {
+          useShorthandSyntax: this.options.alpineShorthandSyntax === 'true',
+          inlineState: this.options.alpineInline === 'true',
+        }
 
         state.output =
           state.outputTab === 'liquid'
             ? componentToLiquid({ plugins, ...commonOptions })({ component: json })
             : state.outputTab === 'alpine'
-            ? componentToAlpine({ plugins, ...commonOptions})({ component: json })
+            ? componentToAlpine({ plugins, ...commonOptions, ...alpineOptions})({ component: json })
             : state.outputTab === 'html'
             ? componentToHtml({ plugins, ...commonOptions })({ component: json })
             : state.outputTab === 'webcomponents'
@@ -1287,6 +1294,89 @@ export default function Fiddle() {
                 </RadioGroup>
               </div>
               <Divider />
+            </Show>
+            <Show when={state.outputTab === 'alpine'}>
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  backgroundColor: 'rgba(0, 0, 0, 0.03)',
+                }}
+              >
+                <Typography variant="body2" css={{ marginRight: 'auto', marginLeft: 10 }}>
+                  Bindings:
+                </Typography>
+                <RadioGroup
+                  css={{
+                    flexDirection: 'row',
+                    marginRight: 10,
+                    '& .MuiFormControlLabel-label': {
+                      fontSize: 12,
+                    },
+                  }}
+                  aria-label="Alpine Binding Type"
+                  name="alpineShorthandSyntax"
+                  value={state.options.alpineShorthandSyntax}
+                  onChange={(e) => {
+                    state.options.alpineShorthandSyntax = e.target.value;
+                    state.updateOutput();
+                  }}
+                >
+                  <FormControlLabel
+                    value="true"
+                    control={<Radio color="primary" />}
+                    labelPlacement="start"
+                    label="Short"
+                  />
+                  <FormControlLabel
+                    value="false"
+                    labelPlacement="start"
+                    control={<Radio color="primary" />}
+                    label="Full"
+                  />
+                </RadioGroup>
+              </div>
+              <Divider css={{ opacity: 0.6 }} />
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  backgroundColor: 'rgba(0, 0, 0, 0.03)',
+                }}
+              >
+                <Typography variant="body2" css={{ marginRight: 'auto', marginLeft: 10 }}>
+                  Inline:
+                </Typography>
+                <RadioGroup
+                  css={{
+                    flexDirection: 'row',
+                    marginRight: 10,
+                    '& .MuiFormControlLabel-label': {
+                      fontSize: 12,
+                    },
+                  }}
+                  aria-label="Alpine Component Type"
+                  name="alpineInline"
+                  value={state.options.alpineInline}
+                  onChange={(e) => {
+                    state.options.alpineInline = e.target.value;
+                    state.updateOutput();
+                  }}
+                >
+                  <FormControlLabel
+                    value="true"
+                    control={<Radio color="primary" />}
+                    labelPlacement="start"
+                    label="Inline"
+                  />
+                  <FormControlLabel
+                    value="false"
+                    labelPlacement="start"
+                    control={<Radio color="primary" />}
+                    label="Separate"
+                  />
+                </RadioGroup>
+              </div>
             </Show>
             <div css={{ flexGrow: 1 }}>
               <div css={{ paddingTop: 15, height: '100%' }}>

--- a/packages/fiddle/src/components/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle.tsx
@@ -2,6 +2,7 @@ import {
   builderContentToMitosisComponent,
   compileAwayBuilderComponents,
   componentToAngular,
+  componentToAlpine,
   componentToBuilder,
   componentToCustomElement,
   componentToHtml,
@@ -327,6 +328,8 @@ export default function Fiddle() {
         state.output =
           state.outputTab === 'liquid'
             ? componentToLiquid({ plugins, ...commonOptions })({ component: json })
+            : state.outputTab === 'alpine'
+            ? componentToAlpine({ plugins, ...commonOptions})({ component: json })
             : state.outputTab === 'html'
             ? componentToHtml({ plugins, ...commonOptions })({ component: json })
             : state.outputTab === 'webcomponents'
@@ -925,6 +928,7 @@ export default function Fiddle() {
                 indicatorColor="primary"
                 textColor="primary"
               >
+                <Tab label={<TabLabelWithIcon label="Alpine.js" />} value="alpine" />
                 <Tab
                   label={
                     <TabLabelWithIcon

--- a/yarn.lock
+++ b/yarn.lock
@@ -22044,17 +22044,17 @@ __metadata:
 
 "typescript@patch:typescript@*#~builtin<compat/typescript>":
   version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=bda367"
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
+  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
   version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=bda367"
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
## Description

This PR adds a new `alpine` generator to `@builder.io/mitosis` (core). It makes no changes to the existing codebase except for adding the `alpine` generator to the fiddle and to the cli.

## Status: Work In Progress

This PR Is by no means production ready. However, as there is currently limited documentation on the subject of wrtining custom generators, by opening this PR I hope to get feedback from the Builder.io team on exactly what needs to happen in order for this to be merged; or, how to integrate the generator as a plugin of some sort if the Builder.io team is not interested in maintaining Alpine.js support.

### To-dos
- [ ] Tests: How should we test?
  - Is there a standard suite of components we should render w/ Alpine.js?
- [x] Fiddle integration
- [ ] CLI Integration
- [ ] directives
  - [x] [x-data](https://alpinejs.dev/directives/data): Currently supports inline (`x-data={open: false}`) and separate: 
 ```html
<script>
  document.addEventListener('alpine:init', () => {
    Alpine.data('dropdown', () => ({open: false}))
  })
</script>
```
  - [ ] [x-init](https://alpinejs.dev/directives/init)
  - [ ] [x-show](https://alpinejs.dev/directives/show): Should be implemented the same as `v-show` in Vue.
  - [ ] [x-bind](https://alpinejs.dev/directives/bind)
  - [x] [x-on](https://alpinejs.dev/directives/on)
    - [ ] Modifiers?
  - [ ] [x-text](https://alpinejs.dev/directives/text)
  - [ ] [x-html](https://alpinejs.dev/directives/html)
  - [ ] [x-model](https://alpinejs.dev/directives/model)
  - [ ] [x-modelable](https://alpinejs.dev/directives/modelable)
  - [x] [x-for](https://alpinejs.dev/directives/for)
  - [ ] [x-transition](https://alpinejs.dev/directives/transition)
  - [ ] [x-effect](https://alpinejs.dev/directives/effect)
  - [ ] [x-ignore](https://alpinejs.dev/directives/ignore)
  - [x] [x-ref](https://alpinejs.dev/directives/ref)
    - [ ] Should refnames be altered? i.e. `const inputRef = useRef();` => `this.$refs.input` ?
  - [ ] [x-cloak](https://alpinejs.dev/directives/cloak)
  - [ ] [x-teleport](https://alpinejs.dev/directives/teleport)
  - [x] [x-if](https://alpinejs.dev/directives/if)
  - [ ] [x-id](https://alpinejs.dev/directives/id)



