### PR TITLE
feat: Generators can now export more than one output file.

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -307,7 +307,9 @@ async function buildAndOutputComponentFiles({
     try {
       const component = shouldOutputTypescript ? typescriptMitosisJson : javascriptMitosisJson;
 
-      transpiled = overrideFile ?? generator(options.options[target])({ path, component });
+      // TODO: this fix is only temporary.
+      transpiled =
+        overrideFile ?? generator(options.options[target])({ path, component })[0].content;
       debugTarget(`Success: transpiled ${path}. Output length: ${transpiled.length}`);
     } catch (error) {
       debugTarget(`Failure: transpiled ${path}.`);

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -23,7 +23,12 @@ import { getPropFunctions } from '../helpers/get-prop-functions';
 import { kebabCase, uniq } from 'lodash';
 import { stripMetaProperties } from '../helpers/strip-meta-properties';
 import { removeSurroundingBlock } from '../helpers/remove-surrounding-block';
-import { BaseTranspilerOptions, TranspilerGenerator } from '../types/transpiler';
+import {
+  BaseTranspilerOptions,
+  GeneratorOutput,
+  Transpiler,
+  TranspilerGenerator,
+} from '../types/transpiler';
 import { indent } from '../helpers/indent';
 import { isSlotProperty } from '../helpers/slots';
 import { getCustomImports } from '../helpers/get-custom-imports';
@@ -548,7 +553,7 @@ export const componentToAngular: TranspilerGenerator<ToAngularOptions> =
       str = runPostCodePlugins(str, options.plugins);
     }
 
-    return str;
+    return [{ content: str, type: 'component' }];
   };
 
 const tryFormat = (str: string, parser: string) => {

--- a/packages/core/src/generators/html.ts
+++ b/packages/core/src/generators/html.ts
@@ -825,7 +825,7 @@ export const componentToHtml: TranspilerGenerator<ToHtmlOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };
 
 // TODO: props support via custom elements
@@ -1472,5 +1472,5 @@ export const componentToCustomElement: TranspilerGenerator<ToHtmlOptions> =
       str = runPostCodePlugins(str, options.plugins);
     }
 
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/liquid.ts
+++ b/packages/core/src/generators/liquid.ts
@@ -187,5 +187,5 @@ export const componentToLiquid: TranspilerGenerator<ToLiquidOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/lit/generate.ts
+++ b/packages/core/src/generators/lit/generate.ts
@@ -296,5 +296,5 @@ export const componentToLit: TranspilerGenerator<ToLitOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/marko/generate.ts
+++ b/packages/core/src/generators/marko/generate.ts
@@ -291,7 +291,7 @@ ${htmlString}
     if (options.plugins) {
       finalStr = runPostCodePlugins(finalStr, options.plugins);
     }
-    return finalStr;
+    return [{ content: finalStr, type: 'component' }];
   };
 
 /**

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -211,5 +211,5 @@ export const componentToMitosis: TranspilerGenerator<Partial<ToMitosisOptions>> 
         throw err;
       }
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/qwik/component-generator.ts
+++ b/packages/core/src/generators/qwik/component-generator.ts
@@ -48,7 +48,7 @@ type StateValues = Record<
 
 export const componentToQwik: TranspilerGenerator<ToQwikOptions> =
   (userOptions = {}) =>
-  ({ component: _component, path }): string => {
+  ({ component: _component, path }) => {
     // Make a copy we can safely mutate, similar to babel's toolchain
     let component = fastClone(_component);
     if (userOptions.plugins) {
@@ -119,10 +119,10 @@ export const componentToQwik: TranspilerGenerator<ToQwikOptions> =
         sourceFile = runPreCodePlugins(sourceFile, userOptions.plugins);
         sourceFile = runPostCodePlugins(sourceFile, userOptions.plugins);
       }
-      return sourceFile;
+      return [{ content: sourceFile, type: 'component' }];
     } catch (e) {
       console.error(e);
-      return (e as Error).stack || String(e);
+      return [{ content: (e as Error).stack || String(e), type: 'error' }];
     }
   };
 

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -407,7 +407,7 @@ export const componentToReact: TranspilerGenerator<ToReactOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };
 
 const _componentToReact = (

--- a/packages/core/src/generators/solid/index.ts
+++ b/packages/core/src/generators/solid/index.ts
@@ -406,5 +406,5 @@ export const componentToSolid: TranspilerGenerator<Partial<ToSolidOptions>> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/stencil/generate.ts
+++ b/packages/core/src/generators/stencil/generate.ts
@@ -217,5 +217,6 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/svelte/svelte.ts
+++ b/packages/core/src/generators/svelte/svelte.ts
@@ -340,5 +340,5 @@ export const componentToSvelte: TranspilerGenerator<ToSvelteOptions> =
     }
     str = runPostCodePlugins(str, options.plugins);
 
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/swift-ui.ts
+++ b/packages/core/src/generators/swift-ui.ts
@@ -383,5 +383,5 @@ export const componentToSwift: TranspilerGenerator<ToSwiftOptions> =
       str = format(str);
     }
 
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/template.ts
+++ b/packages/core/src/generators/template.ts
@@ -147,5 +147,5 @@ export const componentToTemplate: TranspilerGenerator<ToTemplateOptions> =
     if (options.plugins) {
       str = runPostCodePlugins(str, options.plugins);
     }
-    return str;
+    return [{ content: str, type: 'component' }];
   };

--- a/packages/core/src/generators/vue/vue.ts
+++ b/packages/core/src/generators/vue/vue.ts
@@ -285,7 +285,7 @@ const componentToVue: TranspilerGenerator<Partial<ToVueOptions>> =
       str = str.replace(pattern, '');
     }
 
-    return str;
+    return [{ content: str, type: 'component' }];
   };
 
 export const componentToVue2 = (vueOptions?: VueOptsWithoutVersion) =>

--- a/packages/core/src/types/transpiler.ts
+++ b/packages/core/src/types/transpiler.ts
@@ -6,7 +6,14 @@ export interface TranspilerArgs {
   component: MitosisComponent;
 }
 
-export type Transpiler<R = string> = (args: TranspilerArgs) => R;
+export type GeneratorOutput<R = string> = {
+  // content of output. Currently either a component string or a builder component JSON.
+  content: R;
+  // in the future, we will add more types like 'styles' for CSS Modules, etc.
+  type: 'css' | 'html' | 'js' | 'jsx' | 'component' | 'error';
+};
+
+export type Transpiler<R = string> = (args: TranspilerArgs) => GeneratorOutput<R>[];
 
 /**
  * This type guarantees that all code generators receive the same base options

--- a/packages/fiddle/src/components/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle.tsx
@@ -307,7 +307,7 @@ export default function Fiddle() {
         return;
       }
       const jsxJson = builderContentToMitosisComponent(builderJson);
-      state.code = componentToMitosis()({ component: jsxJson });
+      state.code = componentToMitosis()({ component: jsxJson })[0].content;
       state.pendingBuilderChange = null;
     },
 
@@ -324,7 +324,7 @@ export default function Fiddle() {
           typescript: hasBothTsAndJsSupport(state.outputTab) && state.options.typescript === 'true',
         };
 
-        state.output =
+        const output =
           state.outputTab === 'liquid'
             ? componentToLiquid({ plugins, ...commonOptions })({ component: json })
             : state.outputTab === 'html'
@@ -409,6 +409,8 @@ export default function Fiddle() {
                 component: json,
                 path: '',
               });
+
+        state.output = output[0].content;
 
         const newBuilderData = componentToBuilder()({ component: json });
         setBuilderData(newBuilderData);


### PR DESCRIPTION
BREAKING CHANGE: Generators no longer return a string.

# Description

This PR makes the changes discussed in #808, and (when completed) will also close issue #818. The basic premise is to allow generators to output to more than one file, allowing Mitosis to output Multi-file components as well as Single-file components.

# To-Dos
- [ ] core
  - [x] Change the output of existing generators from string to array
  - [ ] Enumerate the types of outputs a component should have. e.g.
    - file extension based: `html`, `css`, `js`, `jsx`, `scss`, etc.
    - 'type' based: `component`, `dom`, `styles`, `state`...
- [ ] cli
  - [ ] save more than one file
- [ ] fiddle
  - [ ] Display multiple files