### PR TITLE
feat: Speed up builds with turborepo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ e2e/**/output
 packages/e2e-*/**
 **/test-results/
 **/playwright-report/
+
+.turbo
+**/.turbo

--- a/e2e/e2e-app/package.json
+++ b/e2e/e2e-app/package.json
@@ -21,6 +21,7 @@
     "mitosis-webcomponent": "mitosis build webcomponent",
     "run-mitosis-separately": "concurrently \"npm:mitosis-*\" --max-processes 3 --group || echo continuing",
     "run-mitosis-all": "mitosis build",
+    "build": "syncdir ./cases/01-one-component ./src -do --exclude '.gitkeep' && mitosis build",
     "e2e": "ts-node --project tsconfig.node.json e2e",
     "playwright": "../../node_modules/.bin/playwright test",
     "report": "../../node_modules/.bin/playwright show-report"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "npm": "99999999.9.9"
   },
   "scripts": {
-    "build:core": "yarn workspace @builder.io/mitosis run build",
-    "build:fiddle": "yarn workspace @builder.io/mitosis-fiddle run build",
-    "ci:build": "yarn workspaces foreach -pt --exclude \"*/e2e*\" --exclude @builder.io/mitosis-fiddle --verbose run build",
+    "build:core": "yarn turbo build --filter mitosis",
+    "build:fiddle": "yarn turbo build --filter mitosis-fiddle",
+    "ci:build": "yarn turbo build --filter='!*e2e*' --filter='!*fiddle'",
     "ci:build:core": "yarn run build:core",
     "ci:build:fiddle": "yarn run build:fiddle",
     "ci:lint": "yarn run lint:prettier && yarn run lint:eslint",
@@ -51,6 +51,7 @@
     "execa": "6.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
+    "turbo": "^1.6.3",
     "typescript": "^4.8.4"
   },
   "packageManager": "yarn@3.2.0",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      // A package's `build` script depends on that package's
+      // dependencies and devDependencies
+      // `build` tasks  being completed first
+      // (the `^` symbol signifies `upstream`).
+      "dependsOn": ["^build"],
+      // note: output globs are relative to each package's `package.json`
+      // (and not the monorepo root)
+      "outputs": [".next/**", "dist/**", "output/**"]
+    },
+    "test": {
+      // A package's `test` script depends on that package's
+      // own `build` script being completed first.
+      "dependsOn": ["build"],
+      "outputs": []
+      // A package's `test` script should only be rerun when
+      // either a `.tsx` or `.ts` file has changed in `src` or `test` folders.
+      //"inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+    },
+    "lint": {
+      // A package's `lint` script has no dependencies and
+      // can be run whenever. It also has no filesystem outputs.
+      "outputs": []
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,9 @@
       // A package's `lint` script has no dependencies and
       // can be run whenever. It also has no filesystem outputs.
       "outputs": []
+    },
+    "start": {
+        "dependsOn": ["^build", "build"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2588,6 +2588,7 @@ __metadata:
     execa: 6.1.0
     npm-run-all: ^4.1.5
     prettier: ^2.3.2
+    turbo: ^1.6.3
     typescript: ^4.8.4
   languageName: unknown
   linkType: soft
@@ -22113,6 +22114,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"turbo-darwin-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-64@npm:1.6.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-arm64@npm:1.6.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-64@npm:1.6.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-arm64@npm:1.6.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-64@npm:1.6.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-arm64@npm:1.6.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "turbo@npm:1.6.3"
+  dependencies:
+    turbo-darwin-64: 1.6.3
+    turbo-darwin-arm64: 1.6.3
+    turbo-linux-64: 1.6.3
+    turbo-linux-arm64: 1.6.3
+    turbo-windows-64: 1.6.3
+    turbo-windows-arm64: 1.6.3
+  dependenciesMeta:
+    turbo-darwin-64:
+      optional: true
+    turbo-darwin-arm64:
+      optional: true
+    turbo-linux-64:
+      optional: true
+    turbo-linux-arm64:
+      optional: true
+    turbo-windows-64:
+      optional: true
+    turbo-windows-arm64:
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 35195f4b7623014c25ba152c11a8cb23e51cbd75dc9266d0656692665f85b28faf3496dea8cecacf52795a917410668124186ffbdcf276325ccc3e11df9e9623
+  languageName: node
+  linkType: hard
+
 "tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
@@ -22256,17 +22328,17 @@ __metadata:
 
 "typescript@patch:typescript@*#~builtin<compat/typescript>":
   version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=bda367"
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
+  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
   version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=bda367"
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
## Description

This PR attempts to demonstrate the benefits of using [turborepo](https://turbo.build/repo/docs), chiefly:

- Build steps are only run if their dependencies change.
- Running a task (i.e. `build`) for one package will automatically build its dependencies. No more forgetting to run `yarn build:core` before running the fiddle.
- Build tasks can be cached, which can dramatically speed up a stateful CI pipeline.

This works great for `@builder.io/mitosis` and `@builder.io/mitosis-fiddle`, but falls down with the e2e tests. I've tried to set it up to only run the `01-one-component` tests, but it seems like some of them might be broken?

Because the e2e tests rebuild their packages with each `case` folder, a radical change to the setup of the e2e tests would be required to make this work properly.

## How to use

```bash
git clone -b feature/turborepo git@github.com:sbrow/mitosis.git
cd mitosis
yarn && yarn turbo run start --filter='*fiddle'
// run it again to see the effects of caching
yarn && yarn turbo run start --filter='*fiddle'
```