### PR TITLE
fix: MonacoEditor onMount override by props.onMount

### DIFF
--- a/packages/fiddle/src/components/CodeEditor.tsx
+++ b/packages/fiddle/src/components/CodeEditor.tsx
@@ -137,10 +137,6 @@ export function CodeEditor(props: MonacoEditorProps) {
 
   return (
     <MonacoEditor
-      onMount={(editor, monaco) => {
-        setEditor(editor);
-        props.onMount?.(editor, monaco);
-      }}
       options={{
         renderLineHighlightOnlyWhenFocus: true,
         overviewRulerBorder: false,
@@ -153,6 +149,10 @@ export function CodeEditor(props: MonacoEditorProps) {
       language="typescript"
       path="mitosis.tsx"
       {...props}
+      onMount={(editor, monaco) => {
+        setEditor(editor);
+        props.onMount?.(editor, monaco);
+      }}
     />
   );
 }


### PR DESCRIPTION
## Description

Add a short description of:
- what changes you made, 
- why you made them, and 
- any other context that you think might be helpful for someone to better understand what is contained in this pull request. 

This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

fix #879 

