### PR TITLE
fix: transform imports regex

### DIFF
--- a/packages/cli/src/build/helpers/transpile.ts
+++ b/packages/cli/src/build/helpers/transpile.ts
@@ -22,7 +22,7 @@ export const transformImports = (target: Target, options: MitosisConfig) => (cod
       `${getFileExtensionForTarget({ type: 'import', target, options })}$1`,
     )
     .replace(
-      new RegExp(`.${options.extension}`, 'g'),
+      new RegExp(`.${options.extension}['"]`, 'g'),
       `${getFileExtensionForTarget({ type: 'import', target, options })}`,
     );
 

--- a/packages/cli/src/build/helpers/transpile.ts
+++ b/packages/cli/src/build/helpers/transpile.ts
@@ -22,7 +22,7 @@ export const transformImports = (target: Target, options: MitosisConfig) => (cod
       `${getFileExtensionForTarget({ type: 'import', target, options })}$1`,
     )
     .replace(
-      `.${options.extension}`,
+      new RegExp(`.${options.extension}`, 'g'),
       `${getFileExtensionForTarget({ type: 'import', target, options })}`,
     );
 


### PR DESCRIPTION
## Description

If a custom extension is provided in the Mitosis config, it currently only replaces the first match, as the global flag is missing from the regex.

