### PR TITLE
Fix for Issue 927

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -3234,6 +3234,39 @@ export class OnUpdateWithDepsModule {}
 "
 `;
 
+exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { BrowserModule } from \\"@angular/platform-browser\\";
@@ -7172,6 +7205,39 @@ export class OnUpdateWithDeps {
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
+"
+`;
+
+exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -3299,6 +3299,40 @@ export class OnUpdateWithDepsModule {}
 "
 `;
 
+exports[`Angular with Import Mapper Tests > jsx > Javascript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+  bootstrap: [SomeOtherComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { BrowserModule } from \\"@angular/platform-browser\\";
@@ -7323,6 +7357,40 @@ export class OnUpdateWithDeps {
   bootstrap: [SomeOtherComponent],
 })
 export class OnUpdateWithDepsModule {}
+"
+`;
+
+exports[`Angular with Import Mapper Tests > jsx > Typescript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+  bootstrap: [SomeOtherComponent],
+})
+export class MyComponentModule {}
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -6661,6 +6661,75 @@ export class OnUpdateWithDepsModule {}
 "
 `;
 
+exports[`Angular > jsx > Javascript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular > jsx > Javascript Test > outputEventBinding 2`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { BrowserModule } from \\"@angular/platform-browser\\";
@@ -14792,6 +14861,75 @@ export class OnUpdateWithDeps {
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > outputEventBinding 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > outputEventBinding 2`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { BrowserModule } from \\"@angular/platform-browser\\";
+
+import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <input
+        [attr.value]=\\"name\\"
+        (input)=\\"name = $event.target.value\\"
+        (changeOrSomething)=\\"name = $event.target.value\\"
+      />
+
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  \`,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class MyComponent {
+  name = \\"Steve\\";
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [BrowserModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
 "
 `;
 

--- a/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
+++ b/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
@@ -1,16 +1,16 @@
-import { useState } from "@builder.io/mitosis";
+import { useState } from '@builder.io/mitosis';
 
 export default function MyComponent(props) {
-    const [name, setName] = useState("Steve");
+  const [name, setName] = useState('Steve');
 
-    return (
-        <div>
-            <input
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-                onChangeOrSomething={(event) => setName(event.target.value)}
-            />
-            Hello! I can run in React, Vue, Solid, or Liquid!
-        </div>
-    );
+  return (
+    <div>
+      <input
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        onChangeOrSomething={(event) => setName(event.target.value)}
+      />
+      Hello! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  );
 }

--- a/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
+++ b/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
@@ -1,46 +1,16 @@
-import { useStore } from '@builder.io/mitosis';
+import { useState } from "@builder.io/mitosis";
 
-export interface TestComponentProps {
-    toggled: boolean;
-    myToggleChange: (value: any) => void;
-}
-
-export function MyComponent(props: TestComponentProps) {
-    const state = useStore({
-        _toggled: false
-    });
-
-    function handleToggleSwitch(): void {
-        state._toggled = !state._toggled;
-        props.toggled = !props.toggled;
-
-        if (props.myToggleChange) {
-            props.myToggleChange(state._toggled);
-        }
-    }
-
-    return (
-        <button type="button" onClick={() => handleToggleSwitch()}>
-            Toggled [{state._toggled}]
-        </button>
-    );
-}
-
-export default function outputEventBindingExample(props: TestComponentProps) {
-    const state = useStore({
-        toggledParent: false,
-        testToggle: (val: boolean) => {
-            console.log('Inverse Event: ', val);
-            state.toggledParent = val;
-        },
-    });
+export default function MyComponent(props) {
+    const [name, setName] = useState("Steve");
 
     return (
         <div>
-            <MyComponent
-                toggled={state.toggledParent}
-                myToggleChange={(val) => state.testToggle(val)}
-            ></MyComponent>
+            <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                onChangeOrSomething={(event) => setName(event.target.value)}
+            />
+            Hello! I can run in React, Vue, Solid, or Liquid!
         </div>
     );
 }

--- a/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
+++ b/packages/core/src/__tests__/data/output-event-bindings.raw.tsx
@@ -1,0 +1,46 @@
+import { useStore } from '@builder.io/mitosis';
+
+export interface TestComponentProps {
+    toggled: boolean;
+    myToggleChange: (value: any) => void;
+}
+
+export function MyComponent(props: TestComponentProps) {
+    const state = useStore({
+        _toggled: false
+    });
+
+    function handleToggleSwitch(): void {
+        state._toggled = !state._toggled;
+        props.toggled = !props.toggled;
+
+        if (props.myToggleChange) {
+            props.myToggleChange(state._toggled);
+        }
+    }
+
+    return (
+        <button type="button" onClick={() => handleToggleSwitch()}>
+            Toggled [{state._toggled}]
+        </button>
+    );
+}
+
+export default function outputEventBindingExample(props: TestComponentProps) {
+    const state = useStore({
+        toggledParent: false,
+        testToggle: (val: boolean) => {
+            console.log('Inverse Event: ', val);
+            state.toggledParent = val;
+        },
+    });
+
+    return (
+        <div>
+            <MyComponent
+                toggled={state.toggledParent}
+                myToggleChange={(val) => state.testToggle(val)}
+            ></MyComponent>
+        </div>
+    );
+}

--- a/packages/core/src/__tests__/shared.ts
+++ b/packages/core/src/__tests__/shared.ts
@@ -239,6 +239,10 @@ const IMPORT_TEST: Tests = {
   importRaw: getRawFile('./data/import.raw.tsx'),
 };
 
+const OUTPUT_EVENT_BINDINGS_TEST: Tests = {
+  outputEventBinding: getRawFile('./data/output-event-bindings.raw.tsx'),
+}
+
 const CONTEXT_TEST: Tests = {
   componentWithContext,
 };
@@ -305,6 +309,7 @@ const JSX_TESTS_FOR_TARGET: Partial<Record<Target, Tests[]>> = {
     ADVANCED_REF,
     ON_UPDATE_RETURN,
     IMPORT_TEST,
+    OUTPUT_EVENT_BINDINGS_TEST,
   ],
   lit: [
     CONTEXT_TEST,

--- a/packages/core/src/__tests__/shared.ts
+++ b/packages/core/src/__tests__/shared.ts
@@ -241,7 +241,7 @@ const IMPORT_TEST: Tests = {
 
 const OUTPUT_EVENT_BINDINGS_TEST: Tests = {
   outputEventBinding: getRawFile('./data/output-event-bindings.raw.tsx'),
-}
+};
 
 const CONTEXT_TEST: Tests = {
   componentWithContext,

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -184,7 +184,9 @@ export const blockToAngular = (
       // TODO: proper babel transform to replace. Util for this
 
       if (key.startsWith('on')) {
-        let event = key.replace('on', '').toLowerCase();
+        let event = key.replace('on', '');
+        event = event.charAt(0).toLowerCase() + event.slice(1);
+
         if (event === 'change' && json.name === 'input' /* todo: other tags */) {
           event = 'input';
         }


### PR DESCRIPTION
## Description
[Fix for issue #927](https://github.com/BuilderIO/mitosis/issues/927)

### Changes
* Angular output event binding requires that the name be camel-cased and rendered with parens when using the prefix `on`. So I removed the `toLowercase()` to keep the camel-case format.
* Added tests with updated snapshots

