### PR TITLE
Remove Browser Module in favor of Common. Add Slot to whitelist.

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -68,7 +68,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -77,7 +77,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -122,7 +122,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -131,7 +131,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -162,7 +162,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -171,7 +171,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -208,7 +208,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -217,7 +217,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -250,7 +250,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -259,7 +259,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -285,7 +285,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -294,7 +294,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -320,7 +320,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -329,7 +329,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -343,7 +343,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -352,7 +352,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -391,7 +391,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -400,7 +400,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -430,7 +430,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -442,7 +442,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -477,7 +477,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -486,7 +486,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -548,7 +548,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -557,7 +557,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -585,7 +585,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -594,7 +594,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -637,7 +637,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -646,7 +646,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -685,7 +685,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -694,7 +694,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -770,7 +770,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -779,7 +779,7 @@ export class ColumnModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -808,7 +808,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -817,7 +817,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -845,7 +845,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -854,7 +854,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -930,7 +930,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -939,7 +939,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1015,7 +1015,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -1024,7 +1024,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1369,7 +1369,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -1378,7 +1378,7 @@ export class FormComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1495,7 +1495,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -1504,7 +1504,7 @@ export class ImageModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1527,7 +1527,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -1536,7 +1536,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1583,7 +1583,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -1592,7 +1592,7 @@ export class ImgComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1634,7 +1634,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -1643,7 +1643,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1668,7 +1668,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -1677,7 +1677,7 @@ export class RawTextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1706,7 +1706,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -1715,7 +1715,7 @@ export class SectionComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1750,7 +1750,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -1759,7 +1759,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1803,7 +1803,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -1812,7 +1812,7 @@ export class SelectComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1834,7 +1834,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -1843,7 +1843,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1867,7 +1867,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -1876,7 +1876,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1898,7 +1898,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -1907,7 +1907,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1931,7 +1931,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -1940,7 +1940,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2050,7 +2050,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -2059,7 +2059,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2081,7 +2081,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -2090,7 +2090,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2125,7 +2125,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -2134,7 +2134,7 @@ export class TextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2167,7 +2167,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -2176,7 +2176,7 @@ export class TextareaModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2244,7 +2244,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -2253,7 +2253,7 @@ export class VideoModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2275,7 +2275,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -2284,7 +2284,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2318,7 +2318,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -2327,7 +2327,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2361,7 +2361,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -2370,7 +2370,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2404,7 +2404,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -2413,7 +2413,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2436,7 +2436,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -2445,7 +2445,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2468,7 +2468,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -2477,7 +2477,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2500,7 +2500,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -2509,7 +2509,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2534,7 +2534,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -2543,7 +2543,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2571,7 +2571,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -2580,7 +2580,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2607,7 +2607,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -2616,7 +2616,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2635,7 +2635,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -2644,7 +2644,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -2697,7 +2697,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -2706,7 +2706,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -2757,7 +2757,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -2766,7 +2766,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2792,7 +2792,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -2801,7 +2801,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2821,7 +2821,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -2830,7 +2830,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2861,7 +2861,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -2870,7 +2870,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2884,7 +2884,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -2893,7 +2893,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2912,7 +2912,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -2921,7 +2921,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2953,7 +2953,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -2962,7 +2962,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2980,7 +2980,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -2989,7 +2989,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3015,7 +3015,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -3024,7 +3024,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3057,7 +3057,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -3066,7 +3066,7 @@ export class NestedStylesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3088,7 +3088,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -3097,7 +3097,7 @@ export class OnInitModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3128,7 +3128,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -3137,7 +3137,7 @@ export class OnInitModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3159,7 +3159,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -3168,7 +3168,7 @@ export class CompModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3186,7 +3186,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -3195,7 +3195,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3227,7 +3227,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -3236,7 +3236,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3260,7 +3260,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3269,7 +3269,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3299,7 +3299,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3308,7 +3308,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3337,7 +3337,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3346,7 +3346,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3373,7 +3373,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3382,7 +3382,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3403,7 +3403,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3412,7 +3412,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3433,7 +3433,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3442,7 +3442,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3470,7 +3470,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -3479,7 +3479,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3532,7 +3532,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -3541,7 +3541,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3580,7 +3580,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -3589,7 +3589,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3611,7 +3611,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -3620,7 +3620,7 @@ export class RenderStylesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3642,7 +3642,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3651,7 +3651,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3677,7 +3677,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3686,7 +3686,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3712,7 +3712,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -3721,7 +3721,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3735,7 +3735,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3744,7 +3744,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3760,7 +3760,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3769,7 +3769,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3783,7 +3783,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3792,7 +3792,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3808,7 +3808,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -3817,7 +3817,7 @@ export class SubComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3840,7 +3840,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -3849,7 +3849,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3873,7 +3873,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3882,7 +3882,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3909,7 +3909,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3918,7 +3918,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3942,7 +3942,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -3951,7 +3951,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Remove Internal mitosis package 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3967,7 +3967,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -3976,7 +3976,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4042,7 +4042,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -4051,7 +4051,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4096,7 +4096,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -4105,7 +4105,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4136,7 +4136,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -4145,7 +4145,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4182,7 +4182,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -4191,7 +4191,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4224,7 +4224,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -4233,7 +4233,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -4259,7 +4259,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -4268,7 +4268,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -4294,7 +4294,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -4303,7 +4303,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4317,7 +4317,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -4326,7 +4326,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4365,7 +4365,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -4374,7 +4374,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4404,7 +4404,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -4416,7 +4416,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4451,7 +4451,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -4460,7 +4460,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4522,7 +4522,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -4531,7 +4531,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4559,7 +4559,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -4568,7 +4568,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4611,7 +4611,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -4620,7 +4620,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4659,7 +4659,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -4668,7 +4668,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4744,7 +4744,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -4753,7 +4753,7 @@ export class ColumnModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4782,7 +4782,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -4791,7 +4791,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4819,7 +4819,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -4828,7 +4828,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4904,7 +4904,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -4913,7 +4913,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4989,7 +4989,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -4998,7 +4998,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5343,7 +5343,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -5352,7 +5352,7 @@ export class FormComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5469,7 +5469,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -5478,7 +5478,7 @@ export class ImageModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5501,7 +5501,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -5510,7 +5510,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5557,7 +5557,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -5566,7 +5566,7 @@ export class ImgComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5608,7 +5608,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -5617,7 +5617,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5642,7 +5642,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -5651,7 +5651,7 @@ export class RawTextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5680,7 +5680,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -5689,7 +5689,7 @@ export class SectionComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5724,7 +5724,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -5733,7 +5733,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5777,7 +5777,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -5786,7 +5786,7 @@ export class SelectComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5808,7 +5808,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -5817,7 +5817,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5841,7 +5841,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -5850,7 +5850,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5872,7 +5872,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -5881,7 +5881,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5905,7 +5905,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -5914,7 +5914,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6024,7 +6024,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -6033,7 +6033,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6055,7 +6055,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -6064,7 +6064,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6099,7 +6099,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -6108,7 +6108,7 @@ export class TextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6141,7 +6141,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -6150,7 +6150,7 @@ export class TextareaModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6218,7 +6218,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -6227,7 +6227,7 @@ export class VideoModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6249,7 +6249,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -6258,7 +6258,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6292,7 +6292,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -6301,7 +6301,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6335,7 +6335,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -6344,7 +6344,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6378,7 +6378,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -6387,7 +6387,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6410,7 +6410,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6419,7 +6419,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6442,7 +6442,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6451,7 +6451,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6474,7 +6474,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6483,7 +6483,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6508,7 +6508,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -6517,7 +6517,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6545,7 +6545,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6554,7 +6554,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6581,7 +6581,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -6590,7 +6590,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6609,7 +6609,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -6618,7 +6618,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -6671,7 +6671,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -6680,7 +6680,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -6731,7 +6731,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -6740,7 +6740,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6766,7 +6766,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -6775,7 +6775,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6795,7 +6795,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -6804,7 +6804,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6835,7 +6835,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -6844,7 +6844,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6858,7 +6858,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -6867,7 +6867,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6886,7 +6886,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -6895,7 +6895,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6927,7 +6927,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -6936,7 +6936,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6954,7 +6954,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6963,7 +6963,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6989,7 +6989,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -6998,7 +6998,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7031,7 +7031,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -7040,7 +7040,7 @@ export class NestedStylesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7062,7 +7062,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -7071,7 +7071,7 @@ export class OnInitModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7102,7 +7102,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -7111,7 +7111,7 @@ export class OnInitModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7133,7 +7133,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -7142,7 +7142,7 @@ export class CompModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7160,7 +7160,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -7169,7 +7169,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7201,7 +7201,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -7210,7 +7210,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7234,7 +7234,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7243,7 +7243,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7273,7 +7273,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7282,7 +7282,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7311,7 +7311,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7320,7 +7320,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7347,7 +7347,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7356,7 +7356,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7377,7 +7377,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7386,7 +7386,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7407,7 +7407,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7416,7 +7416,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7444,7 +7444,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -7453,7 +7453,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7506,7 +7506,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -7515,7 +7515,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7554,7 +7554,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -7563,7 +7563,7 @@ export class ButtonModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7585,7 +7585,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -7594,7 +7594,7 @@ export class RenderStylesModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7616,7 +7616,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7625,7 +7625,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7651,7 +7651,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7660,7 +7660,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7686,7 +7686,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -7695,7 +7695,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7709,7 +7709,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7718,7 +7718,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7734,7 +7734,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7743,7 +7743,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7757,7 +7757,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7766,7 +7766,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7782,7 +7782,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -7791,7 +7791,7 @@ export class SubComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7814,7 +7814,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -7823,7 +7823,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7847,7 +7847,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7856,7 +7856,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7883,7 +7883,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7892,7 +7892,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7916,7 +7916,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7925,7 +7925,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7945,7 +7945,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7954,7 +7954,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8018,7 +8018,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8027,7 +8027,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8043,7 +8043,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8052,7 +8052,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8074,7 +8074,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8083,7 +8083,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8101,7 +8101,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8110,7 +8110,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8130,7 +8130,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8139,7 +8139,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8161,7 +8161,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8170,7 +8170,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8186,7 +8186,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8195,7 +8195,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8216,7 +8216,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8225,7 +8225,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8247,7 +8247,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8256,7 +8256,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8282,7 +8282,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8291,7 +8291,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8314,7 +8314,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8323,7 +8323,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8353,7 +8353,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8362,7 +8362,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8379,7 +8379,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8388,7 +8388,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8414,7 +8414,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8423,7 +8423,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8445,7 +8445,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8454,7 +8454,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8474,7 +8474,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8483,7 +8483,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8547,7 +8547,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8556,7 +8556,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8572,7 +8572,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8581,7 +8581,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8603,7 +8603,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8612,7 +8612,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8630,7 +8630,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8639,7 +8639,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8659,7 +8659,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8668,7 +8668,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8690,7 +8690,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8699,7 +8699,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8715,7 +8715,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8724,7 +8724,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8745,7 +8745,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8754,7 +8754,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8776,7 +8776,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8785,7 +8785,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8811,7 +8811,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8820,7 +8820,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8843,7 +8843,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8852,7 +8852,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8882,7 +8882,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8891,7 +8891,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8908,7 +8908,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8917,7 +8917,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8943,7 +8943,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8952,7 +8952,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8974,7 +8974,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -68,7 +68,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -78,7 +78,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -123,7 +123,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -133,7 +133,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -164,7 +164,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -174,7 +174,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -211,7 +211,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -221,7 +221,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -254,7 +254,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -264,7 +264,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -290,7 +290,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -300,7 +300,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -326,7 +326,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -336,7 +336,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -350,7 +350,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -360,7 +360,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -399,7 +399,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
   bootstrap: [SomeOtherComponent],
 })
@@ -409,7 +409,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -439,7 +439,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -452,7 +452,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -487,7 +487,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -497,7 +497,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -559,7 +559,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -569,7 +569,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -597,7 +597,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -607,7 +607,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -650,7 +650,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -660,7 +660,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -699,7 +699,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -709,7 +709,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -785,7 +785,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
   bootstrap: [SomeOtherComponent],
 })
@@ -795,7 +795,7 @@ export class ColumnModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -824,7 +824,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -834,7 +834,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -862,7 +862,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -872,7 +872,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -948,7 +948,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -958,7 +958,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1034,7 +1034,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -1044,7 +1044,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1389,7 +1389,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1399,7 +1399,7 @@ export class FormComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1516,7 +1516,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
   bootstrap: [SomeOtherComponent],
 })
@@ -1526,7 +1526,7 @@ export class ImageModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1549,7 +1549,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1559,7 +1559,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1606,7 +1606,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1616,7 +1616,7 @@ export class ImgComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1658,7 +1658,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1668,7 +1668,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1693,7 +1693,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
   bootstrap: [SomeOtherComponent],
 })
@@ -1703,7 +1703,7 @@ export class RawTextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1732,7 +1732,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1742,7 +1742,7 @@ export class SectionComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1777,7 +1777,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1787,7 +1787,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1831,7 +1831,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -1841,7 +1841,7 @@ export class SelectComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1863,7 +1863,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -1873,7 +1873,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1897,7 +1897,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -1907,7 +1907,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1929,7 +1929,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -1939,7 +1939,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1963,7 +1963,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -1973,7 +1973,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2083,7 +2083,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
   bootstrap: [SomeOtherComponent],
 })
@@ -2093,7 +2093,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2115,7 +2115,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
   bootstrap: [SomeOtherComponent],
 })
@@ -2125,7 +2125,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2160,7 +2160,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
   bootstrap: [SomeOtherComponent],
 })
@@ -2170,7 +2170,7 @@ export class TextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2203,7 +2203,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
   bootstrap: [SomeOtherComponent],
 })
@@ -2213,7 +2213,7 @@ export class TextareaModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2281,7 +2281,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
   bootstrap: [SomeOtherComponent],
 })
@@ -2291,7 +2291,7 @@ export class VideoModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2313,7 +2313,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2323,7 +2323,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2357,7 +2357,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2367,7 +2367,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2401,7 +2401,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2411,7 +2411,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2445,7 +2445,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2455,7 +2455,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2478,7 +2478,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2488,7 +2488,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2511,7 +2511,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2521,7 +2521,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2544,7 +2544,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2554,7 +2554,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2579,7 +2579,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -2589,7 +2589,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2617,7 +2617,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2627,7 +2627,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2654,7 +2654,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
   bootstrap: [SomeOtherComponent],
 })
@@ -2664,7 +2664,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2683,7 +2683,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2693,7 +2693,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -2746,7 +2746,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -2756,7 +2756,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -2807,7 +2807,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -2817,7 +2817,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2843,7 +2843,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
   bootstrap: [SomeOtherComponent],
 })
@@ -2853,7 +2853,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2873,7 +2873,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2883,7 +2883,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -2914,7 +2914,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2924,7 +2924,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2938,7 +2938,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -2948,7 +2948,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -2967,7 +2967,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -2977,7 +2977,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3009,7 +3009,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
   bootstrap: [SomeOtherComponent],
 })
@@ -3019,7 +3019,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3037,7 +3037,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3047,7 +3047,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3073,7 +3073,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
   bootstrap: [SomeOtherComponent],
 })
@@ -3083,7 +3083,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3116,7 +3116,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
   bootstrap: [SomeOtherComponent],
 })
@@ -3126,7 +3126,7 @@ export class NestedStylesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3148,7 +3148,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
   bootstrap: [SomeOtherComponent],
 })
@@ -3158,7 +3158,7 @@ export class OnInitModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3189,7 +3189,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
   bootstrap: [SomeOtherComponent],
 })
@@ -3199,7 +3199,7 @@ export class OnInitModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3221,7 +3221,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
   bootstrap: [SomeOtherComponent],
 })
@@ -3231,7 +3231,7 @@ export class CompModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3249,7 +3249,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -3259,7 +3259,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3291,7 +3291,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
   bootstrap: [SomeOtherComponent],
 })
@@ -3301,7 +3301,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3325,7 +3325,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3335,7 +3335,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3365,7 +3365,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3375,7 +3375,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3404,7 +3404,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3414,7 +3414,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3441,7 +3441,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3451,7 +3451,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3472,7 +3472,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3482,7 +3482,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3503,7 +3503,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3513,7 +3513,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3541,7 +3541,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -3551,7 +3551,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3604,7 +3604,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3614,7 +3614,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3653,7 +3653,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -3663,7 +3663,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3685,7 +3685,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
   bootstrap: [SomeOtherComponent],
 })
@@ -3695,7 +3695,7 @@ export class RenderStylesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3717,7 +3717,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3727,7 +3727,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3753,7 +3753,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3763,7 +3763,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3789,7 +3789,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
   bootstrap: [SomeOtherComponent],
 })
@@ -3799,7 +3799,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3813,7 +3813,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3823,7 +3823,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3839,7 +3839,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3849,7 +3849,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3863,7 +3863,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3873,7 +3873,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3889,7 +3889,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3899,7 +3899,7 @@ export class SubComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3922,7 +3922,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
   bootstrap: [SomeOtherComponent],
 })
@@ -3932,7 +3932,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3956,7 +3956,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -3966,7 +3966,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3993,7 +3993,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4003,7 +4003,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4027,7 +4027,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4037,7 +4037,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Remove Internal mitosis package 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4053,7 +4053,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4063,7 +4063,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4129,7 +4129,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4139,7 +4139,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4184,7 +4184,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4194,7 +4194,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4225,7 +4225,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4235,7 +4235,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4272,7 +4272,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4282,7 +4282,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4315,7 +4315,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4325,7 +4325,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -4351,7 +4351,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4361,7 +4361,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -4387,7 +4387,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4397,7 +4397,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4411,7 +4411,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4421,7 +4421,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4460,7 +4460,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
   bootstrap: [SomeOtherComponent],
 })
@@ -4470,7 +4470,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4500,7 +4500,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -4513,7 +4513,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4548,7 +4548,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4558,7 +4558,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -4620,7 +4620,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4630,7 +4630,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4658,7 +4658,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4668,7 +4668,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4711,7 +4711,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -4721,7 +4721,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4760,7 +4760,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -4770,7 +4770,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4846,7 +4846,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
   bootstrap: [SomeOtherComponent],
 })
@@ -4856,7 +4856,7 @@ export class ColumnModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4885,7 +4885,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -4895,7 +4895,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4923,7 +4923,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -4933,7 +4933,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5009,7 +5009,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -5019,7 +5019,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5095,7 +5095,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -5105,7 +5105,7 @@ export class CustomCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5450,7 +5450,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5460,7 +5460,7 @@ export class FormComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -5577,7 +5577,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
   bootstrap: [SomeOtherComponent],
 })
@@ -5587,7 +5587,7 @@ export class ImageModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5610,7 +5610,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5620,7 +5620,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5667,7 +5667,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5677,7 +5677,7 @@ export class ImgComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5719,7 +5719,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5729,7 +5729,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5754,7 +5754,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
   bootstrap: [SomeOtherComponent],
 })
@@ -5764,7 +5764,7 @@ export class RawTextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5793,7 +5793,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5803,7 +5803,7 @@ export class SectionComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5838,7 +5838,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5848,7 +5848,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5892,7 +5892,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -5902,7 +5902,7 @@ export class SelectComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5924,7 +5924,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -5934,7 +5934,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5958,7 +5958,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -5968,7 +5968,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5990,7 +5990,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -6000,7 +6000,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6024,7 +6024,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -6034,7 +6034,7 @@ export class SlotCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6144,7 +6144,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
   bootstrap: [SomeOtherComponent],
 })
@@ -6154,7 +6154,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6176,7 +6176,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
   bootstrap: [SomeOtherComponent],
 })
@@ -6186,7 +6186,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6221,7 +6221,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
   bootstrap: [SomeOtherComponent],
 })
@@ -6231,7 +6231,7 @@ export class TextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6264,7 +6264,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
   bootstrap: [SomeOtherComponent],
 })
@@ -6274,7 +6274,7 @@ export class TextareaModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6342,7 +6342,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
   bootstrap: [SomeOtherComponent],
 })
@@ -6352,7 +6352,7 @@ export class VideoModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6374,7 +6374,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6384,7 +6384,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6418,7 +6418,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6428,7 +6428,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6462,7 +6462,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6472,7 +6472,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6506,7 +6506,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6516,7 +6516,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6539,7 +6539,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6549,7 +6549,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6572,7 +6572,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6582,7 +6582,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6605,7 +6605,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6615,7 +6615,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6640,7 +6640,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
   bootstrap: [SomeOtherComponent],
 })
@@ -6650,7 +6650,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6678,7 +6678,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6688,7 +6688,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6715,7 +6715,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
   bootstrap: [SomeOtherComponent],
 })
@@ -6725,7 +6725,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6744,7 +6744,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6754,7 +6754,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -6807,7 +6807,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -6817,7 +6817,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -6868,7 +6868,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -6878,7 +6878,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6904,7 +6904,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
   bootstrap: [SomeOtherComponent],
 })
@@ -6914,7 +6914,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6934,7 +6934,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6944,7 +6944,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6975,7 +6975,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -6985,7 +6985,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6999,7 +6999,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7009,7 +7009,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7028,7 +7028,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -7038,7 +7038,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7070,7 +7070,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
   bootstrap: [SomeOtherComponent],
 })
@@ -7080,7 +7080,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7098,7 +7098,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7108,7 +7108,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7134,7 +7134,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
   bootstrap: [SomeOtherComponent],
 })
@@ -7144,7 +7144,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7177,7 +7177,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
   bootstrap: [SomeOtherComponent],
 })
@@ -7187,7 +7187,7 @@ export class NestedStylesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7209,7 +7209,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
   bootstrap: [SomeOtherComponent],
 })
@@ -7219,7 +7219,7 @@ export class OnInitModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7250,7 +7250,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
   bootstrap: [SomeOtherComponent],
 })
@@ -7260,7 +7260,7 @@ export class OnInitModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7282,7 +7282,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
   bootstrap: [SomeOtherComponent],
 })
@@ -7292,7 +7292,7 @@ export class CompModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7310,7 +7310,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -7320,7 +7320,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7352,7 +7352,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
   bootstrap: [SomeOtherComponent],
 })
@@ -7362,7 +7362,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7386,7 +7386,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7396,7 +7396,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7426,7 +7426,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7436,7 +7436,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7465,7 +7465,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7475,7 +7475,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7502,7 +7502,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7512,7 +7512,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7533,7 +7533,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7543,7 +7543,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7564,7 +7564,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7574,7 +7574,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7602,7 +7602,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
   bootstrap: [SomeOtherComponent],
 })
@@ -7612,7 +7612,7 @@ export class OnUpdateModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7665,7 +7665,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7675,7 +7675,7 @@ export class RenderContentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7714,7 +7714,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
   bootstrap: [SomeOtherComponent],
 })
@@ -7724,7 +7724,7 @@ export class ButtonModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7746,7 +7746,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
   bootstrap: [SomeOtherComponent],
 })
@@ -7756,7 +7756,7 @@ export class RenderStylesModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7778,7 +7778,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7788,7 +7788,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7814,7 +7814,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7824,7 +7824,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7850,7 +7850,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
   bootstrap: [SomeOtherComponent],
 })
@@ -7860,7 +7860,7 @@ export class NestedShowModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7874,7 +7874,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7884,7 +7884,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7900,7 +7900,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7910,7 +7910,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7924,7 +7924,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7934,7 +7934,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7950,7 +7950,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -7960,7 +7960,7 @@ export class SubComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7983,7 +7983,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
   bootstrap: [SomeOtherComponent],
 })
@@ -7993,7 +7993,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8017,7 +8017,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8027,7 +8027,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8054,7 +8054,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8064,7 +8064,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8088,7 +8088,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8098,7 +8098,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8118,7 +8118,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8128,7 +8128,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8192,7 +8192,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8202,7 +8202,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8218,7 +8218,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8228,7 +8228,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8250,7 +8250,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8260,7 +8260,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8278,7 +8278,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8288,7 +8288,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8308,7 +8308,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8318,7 +8318,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8340,7 +8340,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8350,7 +8350,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8366,7 +8366,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8376,7 +8376,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8397,7 +8397,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8407,7 +8407,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8429,7 +8429,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8439,7 +8439,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8465,7 +8465,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8475,7 +8475,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8498,7 +8498,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8508,7 +8508,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8538,7 +8538,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8548,7 +8548,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8565,7 +8565,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8575,7 +8575,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8601,7 +8601,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8611,7 +8611,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Javascript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8633,7 +8633,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8643,7 +8643,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8663,7 +8663,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8673,7 +8673,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8737,7 +8737,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8747,7 +8747,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8763,7 +8763,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8773,7 +8773,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8795,7 +8795,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8805,7 +8805,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8823,7 +8823,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8833,7 +8833,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8853,7 +8853,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8863,7 +8863,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8885,7 +8885,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8895,7 +8895,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8911,7 +8911,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8921,7 +8921,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8942,7 +8942,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8952,7 +8952,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8974,7 +8974,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -8984,7 +8984,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9010,7 +9010,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -9020,7 +9020,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9043,7 +9043,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -9053,7 +9053,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9083,7 +9083,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -9093,7 +9093,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9110,7 +9110,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -9120,7 +9120,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9146,7 +9146,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })
@@ -9156,7 +9156,7 @@ export class MyComponentModule {}
 
 exports[`Angular with Import Mapper Tests > svelte > Typescript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9178,7 +9178,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Angular > jsx > Javascript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -68,7 +68,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -77,7 +77,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > AdvancedRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -146,7 +146,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -155,7 +155,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -200,7 +200,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -209,7 +209,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -240,7 +240,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -249,7 +249,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic 3`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -297,7 +297,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -306,7 +306,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic 4`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -340,7 +340,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -349,7 +349,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -386,7 +386,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -395,7 +395,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Context 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -435,7 +435,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -444,7 +444,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -477,7 +477,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -486,7 +486,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic OnMount Update 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -522,7 +522,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -531,7 +531,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -557,7 +557,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -566,7 +566,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Outputs 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -595,7 +595,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -604,7 +604,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -630,7 +630,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -639,7 +639,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Basic Outputs Meta 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -668,7 +668,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -677,7 +677,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -691,7 +691,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -700,7 +700,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicAttribute 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -717,7 +717,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -726,7 +726,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -765,7 +765,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -774,7 +774,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicBooleanAttribute 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -816,7 +816,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -825,7 +825,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -855,7 +855,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -867,7 +867,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicChildComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -900,7 +900,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -912,7 +912,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -947,7 +947,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -956,7 +956,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicFor 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -994,7 +994,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -1003,7 +1003,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1065,7 +1065,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -1074,7 +1074,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1139,7 +1139,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -1148,7 +1148,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1176,7 +1176,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -1185,7 +1185,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRefAssignment 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1216,7 +1216,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -1225,7 +1225,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -1268,7 +1268,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -1277,7 +1277,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > BasicRefPrevious 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1323,7 +1323,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -1332,7 +1332,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1371,7 +1371,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -1380,7 +1380,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > Button 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1422,7 +1422,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -1431,7 +1431,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1507,7 +1507,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -1516,7 +1516,7 @@ export class ColumnModule {}
 
 exports[`Angular > jsx > Javascript Test > Columns 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1595,7 +1595,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -1604,7 +1604,7 @@ export class ColumnModule {}
 
 exports[`Angular > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1633,7 +1633,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -1642,7 +1642,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > ContentSlotHtml 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1668,13 +1668,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -1683,7 +1683,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -1711,7 +1711,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -1720,7 +1720,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > ContentSlotJSX 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1751,7 +1751,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -1760,7 +1760,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -1836,7 +1836,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -1845,7 +1845,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > CustomCode 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -1924,7 +1924,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -1933,7 +1933,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -2009,7 +2009,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -2018,7 +2018,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > Embed 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -2097,7 +2097,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -2106,7 +2106,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -2451,7 +2451,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -2460,7 +2460,7 @@ export class FormComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Form 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -2808,7 +2808,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -2817,7 +2817,7 @@ export class FormComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -2934,7 +2934,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -2943,7 +2943,7 @@ export class ImageModule {}
 
 exports[`Angular > jsx > Javascript Test > Image 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3063,7 +3063,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -3072,7 +3072,7 @@ export class ImageModule {}
 
 exports[`Angular > jsx > Javascript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3095,7 +3095,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -3104,7 +3104,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Image State 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3130,7 +3130,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -3139,7 +3139,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3186,7 +3186,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -3195,7 +3195,7 @@ export class ImgComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Img 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3245,7 +3245,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -3254,7 +3254,7 @@ export class ImgComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3296,7 +3296,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -3305,7 +3305,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Input 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3350,7 +3350,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -3359,7 +3359,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3384,7 +3384,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -3393,7 +3393,7 @@ export class RawTextModule {}
 
 exports[`Angular > jsx > Javascript Test > RawText 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3421,7 +3421,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -3430,7 +3430,7 @@ export class RawTextModule {}
 
 exports[`Angular > jsx > Javascript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3459,7 +3459,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -3468,7 +3468,7 @@ export class SectionComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3503,7 +3503,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -3512,7 +3512,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Section 3`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3544,7 +3544,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -3553,7 +3553,7 @@ export class SectionComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Section 4`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3591,7 +3591,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -3600,7 +3600,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -3644,7 +3644,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -3653,7 +3653,7 @@ export class SelectComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > Select 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3700,7 +3700,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -3709,7 +3709,7 @@ export class SelectComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3731,7 +3731,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3740,7 +3740,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotDefault 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3759,13 +3759,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3774,7 +3774,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3798,7 +3798,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3807,7 +3807,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotHtml 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3828,13 +3828,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, ContentSlotCode, Slot],
+  imports: [CommonModule, ContentSlotCode],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3843,7 +3843,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3865,7 +3865,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3874,7 +3874,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotJsx 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3899,7 +3899,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3908,7 +3908,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -3932,7 +3932,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3941,7 +3941,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > SlotNamed 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -3962,13 +3962,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -3977,7 +3977,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4087,7 +4087,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -4096,7 +4096,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular > jsx > Javascript Test > Stamped.io 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4209,7 +4209,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -4218,7 +4218,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular > jsx > Javascript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4240,7 +4240,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -4249,7 +4249,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > Submit 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4274,7 +4274,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -4283,7 +4283,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4318,7 +4318,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -4327,7 +4327,7 @@ export class TextModule {}
 
 exports[`Angular > jsx > Javascript Test > Text 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4365,7 +4365,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -4374,7 +4374,7 @@ export class TextModule {}
 
 exports[`Angular > jsx > Javascript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4407,7 +4407,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -4416,7 +4416,7 @@ export class TextareaModule {}
 
 exports[`Angular > jsx > Javascript Test > Textarea 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4452,7 +4452,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -4461,7 +4461,7 @@ export class TextareaModule {}
 
 exports[`Angular > jsx > Javascript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -4529,7 +4529,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -4538,7 +4538,7 @@ export class VideoModule {}
 
 exports[`Angular > jsx > Javascript Test > Video 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4609,7 +4609,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -4618,7 +4618,7 @@ export class VideoModule {}
 
 exports[`Angular > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4640,7 +4640,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -4649,7 +4649,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > arrowFunctionInUseStore 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4674,7 +4674,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -4683,7 +4683,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4717,7 +4717,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -4726,7 +4726,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicForwardRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4763,7 +4763,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -4772,7 +4772,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4806,7 +4806,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -4815,7 +4815,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicForwardRefMetadata 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4852,7 +4852,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -4861,7 +4861,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4895,7 +4895,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -4904,7 +4904,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > basicOnUpdateReturn 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -4941,7 +4941,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -4950,7 +4950,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -4973,7 +4973,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -4982,7 +4982,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > class + ClassName + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5008,7 +5008,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5017,7 +5017,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5040,7 +5040,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5049,7 +5049,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > class + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5075,7 +5075,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5084,7 +5084,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5107,7 +5107,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5116,7 +5116,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > className + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5142,7 +5142,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5151,7 +5151,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5176,7 +5176,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -5185,7 +5185,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > className 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5213,7 +5213,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -5222,7 +5222,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular > jsx > Javascript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5250,7 +5250,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5259,7 +5259,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > classState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5290,7 +5290,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -5299,7 +5299,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5326,7 +5326,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -5335,7 +5335,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular > jsx > Javascript Test > componentWithContext 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5365,7 +5365,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -5374,7 +5374,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular > jsx > Javascript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5391,7 +5391,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -5400,7 +5400,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > contentState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5422,7 +5422,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -5431,7 +5431,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -5484,7 +5484,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -5493,7 +5493,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5549,7 +5549,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -5558,7 +5558,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -5609,7 +5609,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -5618,7 +5618,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultPropsOutsideComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5672,7 +5672,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -5681,7 +5681,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5707,7 +5707,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -5716,7 +5716,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular > jsx > Javascript Test > defaultValsWithTypes 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5745,7 +5745,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -5754,7 +5754,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular > jsx > Javascript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5774,7 +5774,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -5783,7 +5783,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > expressionState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5806,7 +5806,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -5815,7 +5815,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -5846,7 +5846,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -5855,7 +5855,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > import types 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5889,7 +5889,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -5898,7 +5898,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5912,7 +5912,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -5921,7 +5921,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > importRaw 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5938,7 +5938,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -5947,7 +5947,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -5966,7 +5966,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -5975,7 +5975,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleOnUpdate 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5997,7 +5997,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -6006,7 +6006,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6038,7 +6038,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -6047,7 +6047,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleOnUpdateWithDeps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6082,7 +6082,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -6091,7 +6091,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6109,7 +6109,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6118,7 +6118,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > multipleSpreads 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6139,7 +6139,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6148,7 +6148,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6174,7 +6174,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -6183,7 +6183,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Javascript Test > nestedShow 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6212,7 +6212,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -6221,7 +6221,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Javascript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6254,7 +6254,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -6263,7 +6263,7 @@ export class NestedStylesModule {}
 
 exports[`Angular > jsx > Javascript Test > nestedStyles 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6299,7 +6299,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -6308,7 +6308,7 @@ export class NestedStylesModule {}
 
 exports[`Angular > jsx > Javascript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6330,7 +6330,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -6339,7 +6339,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Javascript Test > onInit & onMount 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6364,7 +6364,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -6373,7 +6373,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Javascript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6404,7 +6404,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -6413,7 +6413,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Javascript Test > onInit 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6447,7 +6447,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -6456,7 +6456,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Javascript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6478,7 +6478,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -6487,7 +6487,7 @@ export class CompModule {}
 
 exports[`Angular > jsx > Javascript Test > onMount 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6512,7 +6512,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -6521,7 +6521,7 @@ export class CompModule {}
 
 exports[`Angular > jsx > Javascript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6539,7 +6539,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -6548,7 +6548,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > onUpdate 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6569,7 +6569,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -6578,7 +6578,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6610,7 +6610,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -6619,7 +6619,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Javascript Test > onUpdateWithDeps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6654,7 +6654,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -6663,7 +6663,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Javascript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6687,7 +6687,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -6696,7 +6696,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > outputEventBinding 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6723,7 +6723,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -6732,7 +6732,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -6762,7 +6762,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6771,7 +6771,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > preserveExportOrLocalStatement 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6804,7 +6804,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6813,7 +6813,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6842,7 +6842,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6851,7 +6851,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > preserveTyping 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6883,7 +6883,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6892,7 +6892,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6919,7 +6919,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6928,7 +6928,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsDestructure 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -6958,7 +6958,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6967,7 +6967,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -6988,7 +6988,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -6997,7 +6997,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsInterface 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7021,7 +7021,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7030,7 +7030,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7051,7 +7051,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7060,7 +7060,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > propsType 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7084,7 +7084,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7093,7 +7093,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7121,7 +7121,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -7130,7 +7130,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > referencingFunInsideHook 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7161,7 +7161,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -7170,7 +7170,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Javascript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7221,7 +7221,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -7230,7 +7230,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > renderContentExample 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7286,7 +7286,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -7295,7 +7295,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7334,7 +7334,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -7343,7 +7343,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > rootFragmentMultiNode 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7385,7 +7385,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -7394,7 +7394,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Javascript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7416,7 +7416,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -7425,7 +7425,7 @@ export class RenderStylesModule {}
 
 exports[`Angular > jsx > Javascript Test > rootShow 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7450,7 +7450,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -7459,7 +7459,7 @@ export class RenderStylesModule {}
 
 exports[`Angular > jsx > Javascript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7481,7 +7481,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7490,7 +7490,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > self-referencing component 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7515,7 +7515,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7524,7 +7524,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7550,7 +7550,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7559,7 +7559,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > self-referencing component with children 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7588,7 +7588,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7597,7 +7597,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7623,7 +7623,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -7632,7 +7632,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Javascript Test > showWithFor 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7661,7 +7661,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -7670,7 +7670,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7684,7 +7684,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7693,7 +7693,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadAttrs 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7710,7 +7710,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7719,7 +7719,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7735,7 +7735,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7744,7 +7744,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadNestedProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7763,7 +7763,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7772,7 +7772,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7786,7 +7786,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7795,7 +7795,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > spreadProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7812,7 +7812,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -7821,7 +7821,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7835,7 +7835,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -7844,7 +7844,7 @@ export class SubComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > subComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7863,7 +7863,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -7872,7 +7872,7 @@ export class SubComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -7895,7 +7895,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -7904,7 +7904,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular > jsx > Javascript Test > typeDependency 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7930,7 +7930,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -7939,7 +7939,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -7963,7 +7963,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -7972,7 +7972,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -7999,7 +7999,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8008,7 +8008,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8035,7 +8035,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8044,7 +8044,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style-and-css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8074,7 +8074,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8083,7 +8083,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8107,7 +8107,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8116,7 +8116,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Javascript Test > use-style-outside-component 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8143,7 +8143,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8152,7 +8152,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Remove Internal mitosis package 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8168,7 +8168,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8177,7 +8177,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Remove Internal mitosis package 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8196,7 +8196,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8205,7 +8205,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -8271,7 +8271,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -8280,7 +8280,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > AdvancedRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8349,7 +8349,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -8358,7 +8358,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8403,7 +8403,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8412,7 +8412,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8443,7 +8443,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -8452,7 +8452,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic 3`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8500,7 +8500,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8509,7 +8509,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic 4`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8543,7 +8543,7 @@ export class MyBasicForShowComponent {
 
 @NgModule({
   declarations: [MyBasicForShowComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForShowComponent],
 })
 export class MyBasicForShowComponentModule {}
@@ -8552,7 +8552,7 @@ export class MyBasicForShowComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8589,7 +8589,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8598,7 +8598,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Context 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8638,7 +8638,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -8647,7 +8647,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8680,7 +8680,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -8689,7 +8689,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic OnMount Update 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8725,7 +8725,7 @@ export class MyBasicOnMountUpdateComponent {
 
 @NgModule({
   declarations: [MyBasicOnMountUpdateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnMountUpdateComponent],
 })
 export class MyBasicOnMountUpdateComponentModule {}
@@ -8734,7 +8734,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -8760,7 +8760,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -8769,7 +8769,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Outputs 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8798,7 +8798,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -8807,7 +8807,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -8833,7 +8833,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -8842,7 +8842,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Basic Outputs Meta 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8871,7 +8871,7 @@ export class MyBasicOutputsComponent {
 
 @NgModule({
   declarations: [MyBasicOutputsComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOutputsComponent],
 })
 export class MyBasicOutputsComponentModule {}
@@ -8880,7 +8880,7 @@ export class MyBasicOutputsComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -8894,7 +8894,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8903,7 +8903,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicAttribute 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -8920,7 +8920,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -8929,7 +8929,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -8968,7 +8968,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -8977,7 +8977,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicBooleanAttribute 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9019,7 +9019,7 @@ export class MyBooleanAttribute {
 
 @NgModule({
   declarations: [MyBooleanAttribute],
-  imports: [BrowserModule, MyBooleanAttributeComponentModule],
+  imports: [CommonModule, MyBooleanAttributeComponentModule],
   exports: [MyBooleanAttribute],
 })
 export class MyBooleanAttributeModule {}
@@ -9028,7 +9028,7 @@ export class MyBooleanAttributeModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9058,7 +9058,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -9070,7 +9070,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicChildComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9103,7 +9103,7 @@ export class MyBasicChildComponent {
 @NgModule({
   declarations: [MyBasicChildComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     MyBasicComponentModule,
     MyBasicOnMountUpdateComponentModule,
   ],
@@ -9115,7 +9115,7 @@ export class MyBasicChildComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9150,7 +9150,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -9159,7 +9159,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicFor 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9197,7 +9197,7 @@ export class MyBasicForComponent {
 
 @NgModule({
   declarations: [MyBasicForComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForComponent],
 })
 export class MyBasicForComponentModule {}
@@ -9206,7 +9206,7 @@ export class MyBasicForComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -9268,7 +9268,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -9277,7 +9277,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9342,7 +9342,7 @@ export class MyBasicRefComponent {
 
 @NgModule({
   declarations: [MyBasicRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefComponent],
 })
 export class MyBasicRefComponentModule {}
@@ -9351,7 +9351,7 @@ export class MyBasicRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9379,7 +9379,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -9388,7 +9388,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRefAssignment 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9419,7 +9419,7 @@ export class MyBasicRefAssignmentComponent {
 
 @NgModule({
   declarations: [MyBasicRefAssignmentComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicRefAssignmentComponent],
 })
 export class MyBasicRefAssignmentComponentModule {}
@@ -9428,7 +9428,7 @@ export class MyBasicRefAssignmentComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -9471,7 +9471,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -9480,7 +9480,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > BasicRefPrevious 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9526,7 +9526,7 @@ export class MyPreviousComponent {
 
 @NgModule({
   declarations: [MyPreviousComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyPreviousComponent],
 })
 export class MyPreviousComponentModule {}
@@ -9535,7 +9535,7 @@ export class MyPreviousComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -9574,7 +9574,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -9583,7 +9583,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > Button 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9625,7 +9625,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -9634,7 +9634,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -9710,7 +9710,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -9719,7 +9719,7 @@ export class ColumnModule {}
 
 exports[`Angular > jsx > Typescript Test > Columns 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9798,7 +9798,7 @@ export class Column {
 
 @NgModule({
   declarations: [Column],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Column],
 })
 export class ColumnModule {}
@@ -9807,7 +9807,7 @@ export class ColumnModule {}
 
 exports[`Angular > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -9836,7 +9836,7 @@ export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -9845,7 +9845,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > ContentSlotHtml 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9871,13 +9871,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class ContentSlotCode {}
 
 @NgModule({
   declarations: [ContentSlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [ContentSlotCode],
 })
 export class ContentSlotCodeModule {}
@@ -9886,7 +9886,7 @@ export class ContentSlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -9914,7 +9914,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -9923,7 +9923,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > ContentSlotJSX 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9954,7 +9954,7 @@ export class ContentSlotJsxCode {}
 
 @NgModule({
   declarations: [ContentSlotJsxCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ContentSlotJsxCode],
 })
 export class ContentSlotJsxCodeModule {}
@@ -9963,7 +9963,7 @@ export class ContentSlotJsxCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -10039,7 +10039,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -10048,7 +10048,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > CustomCode 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -10127,7 +10127,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -10136,7 +10136,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -10212,7 +10212,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -10221,7 +10221,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > Embed 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -10300,7 +10300,7 @@ export class CustomCode {
 
 @NgModule({
   declarations: [CustomCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [CustomCode],
 })
 export class CustomCodeModule {}
@@ -10309,7 +10309,7 @@ export class CustomCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -10654,7 +10654,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -10663,7 +10663,7 @@ export class FormComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Form 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11011,7 +11011,7 @@ export class FormComponent {
 
 @NgModule({
   declarations: [FormComponent],
-  imports: [BrowserModule, BuilderBlockComponentModule, BuilderBlocksModule],
+  imports: [CommonModule, BuilderBlockComponentModule, BuilderBlocksModule],
   exports: [FormComponent],
 })
 export class FormComponentModule {}
@@ -11020,7 +11020,7 @@ export class FormComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 
@@ -11137,7 +11137,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -11146,7 +11146,7 @@ export class ImageModule {}
 
 exports[`Angular > jsx > Typescript Test > Image 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11266,7 +11266,7 @@ export class Image {
 
 @NgModule({
   declarations: [Image],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Image],
 })
 export class ImageModule {}
@@ -11275,7 +11275,7 @@ export class ImageModule {}
 
 exports[`Angular > jsx > Typescript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -11298,7 +11298,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -11307,7 +11307,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Image State 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11333,7 +11333,7 @@ export class ImgStateComponent {
 
 @NgModule({
   declarations: [ImgStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgStateComponent],
 })
 export class ImgStateComponentModule {}
@@ -11342,7 +11342,7 @@ export class ImgStateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11389,7 +11389,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -11398,7 +11398,7 @@ export class ImgComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Img 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11448,7 +11448,7 @@ export class ImgComponent {
 
 @NgModule({
   declarations: [ImgComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ImgComponent],
 })
 export class ImgComponentModule {}
@@ -11457,7 +11457,7 @@ export class ImgComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11499,7 +11499,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -11508,7 +11508,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Input 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11553,7 +11553,7 @@ export class FormInputComponent {
 
 @NgModule({
   declarations: [FormInputComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
@@ -11562,7 +11562,7 @@ export class FormInputComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11587,7 +11587,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -11596,7 +11596,7 @@ export class RawTextModule {}
 
 exports[`Angular > jsx > Typescript Test > RawText 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11624,7 +11624,7 @@ export class RawText {
 
 @NgModule({
   declarations: [RawText],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RawText],
 })
 export class RawTextModule {}
@@ -11633,7 +11633,7 @@ export class RawTextModule {}
 
 exports[`Angular > jsx > Typescript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11662,7 +11662,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -11671,7 +11671,7 @@ export class SectionComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11706,7 +11706,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -11715,7 +11715,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Section 3`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11747,7 +11747,7 @@ export class SectionComponent {
 
 @NgModule({
   declarations: [SectionComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionComponent],
 })
 export class SectionComponentModule {}
@@ -11756,7 +11756,7 @@ export class SectionComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Section 4`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11794,7 +11794,7 @@ export class SectionStateComponent {
 
 @NgModule({
   declarations: [SectionStateComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SectionStateComponent],
 })
 export class SectionStateComponentModule {}
@@ -11803,7 +11803,7 @@ export class SectionStateComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -11847,7 +11847,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -11856,7 +11856,7 @@ export class SelectComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > Select 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11903,7 +11903,7 @@ export class SelectComponent {
 
 @NgModule({
   declarations: [SelectComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SelectComponent],
 })
 export class SelectComponentModule {}
@@ -11912,7 +11912,7 @@ export class SelectComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -11934,7 +11934,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -11943,7 +11943,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotDefault 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11962,13 +11962,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -11977,7 +11977,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -12001,7 +12001,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12010,7 +12010,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotHtml 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12031,13 +12031,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, ContentSlotCode, Slot],
+  imports: [CommonModule, ContentSlotCode],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule, SlotModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12046,7 +12046,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -12068,7 +12068,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12077,7 +12077,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotJsx 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12102,7 +12102,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, ContentSlotCodeModule],
+  imports: [CommonModule, ContentSlotCodeModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12111,7 +12111,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -12135,7 +12135,7 @@ export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12144,7 +12144,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > SlotNamed 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12165,13 +12165,13 @@ type Props = {
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class SlotCode {}
 
 @NgModule({
   declarations: [SlotCode],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [SlotCode],
 })
 export class SlotCodeModule {}
@@ -12180,7 +12180,7 @@ export class SlotCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -12290,7 +12290,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -12299,7 +12299,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular > jsx > Typescript Test > Stamped.io 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12412,7 +12412,7 @@ export class SmileReviews {
 
 @NgModule({
   declarations: [SmileReviews],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SmileReviews],
 })
 export class SmileReviewsModule {}
@@ -12421,7 +12421,7 @@ export class SmileReviewsModule {}
 
 exports[`Angular > jsx > Typescript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -12443,7 +12443,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -12452,7 +12452,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > Submit 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12477,7 +12477,7 @@ export class SubmitButton {
 
 @NgModule({
   declarations: [SubmitButton],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [SubmitButton],
 })
 export class SubmitButtonModule {}
@@ -12486,7 +12486,7 @@ export class SubmitButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -12521,7 +12521,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -12530,7 +12530,7 @@ export class TextModule {}
 
 exports[`Angular > jsx > Typescript Test > Text 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12568,7 +12568,7 @@ export class Text {
 
 @NgModule({
   declarations: [Text],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Text],
 })
 export class TextModule {}
@@ -12577,7 +12577,7 @@ export class TextModule {}
 
 exports[`Angular > jsx > Typescript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -12610,7 +12610,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -12619,7 +12619,7 @@ export class TextareaModule {}
 
 exports[`Angular > jsx > Typescript Test > Textarea 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12655,7 +12655,7 @@ export class Textarea {
 
 @NgModule({
   declarations: [Textarea],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Textarea],
 })
 export class TextareaModule {}
@@ -12664,7 +12664,7 @@ export class TextareaModule {}
 
 exports[`Angular > jsx > Typescript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -12732,7 +12732,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -12741,7 +12741,7 @@ export class VideoModule {}
 
 exports[`Angular > jsx > Typescript Test > Video 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12812,7 +12812,7 @@ export class Video {
 
 @NgModule({
   declarations: [Video],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Video],
 })
 export class VideoModule {}
@@ -12821,7 +12821,7 @@ export class VideoModule {}
 
 exports[`Angular > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -12843,7 +12843,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -12852,7 +12852,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > arrowFunctionInUseStore 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12877,7 +12877,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -12886,7 +12886,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -12920,7 +12920,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -12929,7 +12929,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicForwardRef 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -12966,7 +12966,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -12975,7 +12975,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13009,7 +13009,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -13018,7 +13018,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicForwardRefMetadata 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13055,7 +13055,7 @@ export class MyBasicForwardRefComponent {
 
 @NgModule({
   declarations: [MyBasicForwardRefComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicForwardRefComponent],
 })
 export class MyBasicForwardRefComponentModule {}
@@ -13064,7 +13064,7 @@ export class MyBasicForwardRefComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13098,7 +13098,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -13107,7 +13107,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > basicOnUpdateReturn 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13144,7 +13144,7 @@ export class MyBasicOnUpdateReturnComponent {
 
 @NgModule({
   declarations: [MyBasicOnUpdateReturnComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicOnUpdateReturnComponent],
 })
 export class MyBasicOnUpdateReturnComponentModule {}
@@ -13153,7 +13153,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13176,7 +13176,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13185,7 +13185,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > class + ClassName + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13211,7 +13211,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13220,7 +13220,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13243,7 +13243,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13252,7 +13252,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > class + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13278,7 +13278,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13287,7 +13287,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13310,7 +13310,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13319,7 +13319,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > className + css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13345,7 +13345,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13354,7 +13354,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13379,7 +13379,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -13388,7 +13388,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > className 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13416,7 +13416,7 @@ export class ClassNameCode {
 
 @NgModule({
   declarations: [ClassNameCode],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ClassNameCode],
 })
 export class ClassNameCodeModule {}
@@ -13425,7 +13425,7 @@ export class ClassNameCodeModule {}
 
 exports[`Angular > jsx > Typescript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -13453,7 +13453,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13462,7 +13462,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > classState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13493,7 +13493,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -13502,7 +13502,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -13529,7 +13529,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -13538,7 +13538,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular > jsx > Typescript Test > componentWithContext 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13568,7 +13568,7 @@ export class ComponentWithContext {
 
 @NgModule({
   declarations: [ComponentWithContext],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithContext],
 })
 export class ComponentWithContextModule {}
@@ -13577,7 +13577,7 @@ export class ComponentWithContextModule {}
 
 exports[`Angular > jsx > Typescript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -13594,7 +13594,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -13603,7 +13603,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > contentState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13625,7 +13625,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -13634,7 +13634,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -13687,7 +13687,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -13696,7 +13696,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13752,7 +13752,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -13761,7 +13761,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 
@@ -13812,7 +13812,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -13821,7 +13821,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultPropsOutsideComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13875,7 +13875,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -13884,7 +13884,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -13910,7 +13910,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -13919,7 +13919,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular > jsx > Typescript Test > defaultValsWithTypes 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -13948,7 +13948,7 @@ export class ComponentWithTypes {
 
 @NgModule({
   declarations: [ComponentWithTypes],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [ComponentWithTypes],
 })
 export class ComponentWithTypesModule {}
@@ -13957,7 +13957,7 @@ export class ComponentWithTypesModule {}
 
 exports[`Angular > jsx > Typescript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -13977,7 +13977,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -13986,7 +13986,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > expressionState 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14009,7 +14009,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -14018,7 +14018,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -14049,7 +14049,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -14058,7 +14058,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > import types 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14092,7 +14092,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlockModule],
+  imports: [CommonModule, RenderBlockModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -14101,7 +14101,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14115,7 +14115,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -14124,7 +14124,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > importRaw 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14141,7 +14141,7 @@ export class MyImportComponent {}
 
 @NgModule({
   declarations: [MyImportComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyImportComponent],
 })
 export class MyImportComponentModule {}
@@ -14150,7 +14150,7 @@ export class MyImportComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14169,7 +14169,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -14178,7 +14178,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleOnUpdate 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14200,7 +14200,7 @@ export class MultipleOnUpdate {
 
 @NgModule({
   declarations: [MultipleOnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdate],
 })
 export class MultipleOnUpdateModule {}
@@ -14209,7 +14209,7 @@ export class MultipleOnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14241,7 +14241,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -14250,7 +14250,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleOnUpdateWithDeps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14285,7 +14285,7 @@ export class MultipleOnUpdateWithDeps {
 
 @NgModule({
   declarations: [MultipleOnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MultipleOnUpdateWithDeps],
 })
 export class MultipleOnUpdateWithDepsModule {}
@@ -14294,7 +14294,7 @@ export class MultipleOnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14312,7 +14312,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -14321,7 +14321,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > multipleSpreads 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14342,7 +14342,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -14351,7 +14351,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -14377,7 +14377,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -14386,7 +14386,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Typescript Test > nestedShow 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14415,7 +14415,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -14424,7 +14424,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Typescript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14457,7 +14457,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -14466,7 +14466,7 @@ export class NestedStylesModule {}
 
 exports[`Angular > jsx > Typescript Test > nestedStyles 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14502,7 +14502,7 @@ export class NestedStyles {}
 
 @NgModule({
   declarations: [NestedStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedStyles],
 })
 export class NestedStylesModule {}
@@ -14511,7 +14511,7 @@ export class NestedStylesModule {}
 
 exports[`Angular > jsx > Typescript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14533,7 +14533,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -14542,7 +14542,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Typescript Test > onInit & onMount 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14567,7 +14567,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -14576,7 +14576,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Typescript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -14607,7 +14607,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -14616,7 +14616,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Typescript Test > onInit 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14650,7 +14650,7 @@ export class OnInit {
 
 @NgModule({
   declarations: [OnInit],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnInit],
 })
 export class OnInitModule {}
@@ -14659,7 +14659,7 @@ export class OnInitModule {}
 
 exports[`Angular > jsx > Typescript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14681,7 +14681,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -14690,7 +14690,7 @@ export class CompModule {}
 
 exports[`Angular > jsx > Typescript Test > onMount 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14715,7 +14715,7 @@ export class Comp {
 
 @NgModule({
   declarations: [Comp],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Comp],
 })
 export class CompModule {}
@@ -14724,7 +14724,7 @@ export class CompModule {}
 
 exports[`Angular > jsx > Typescript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14742,7 +14742,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -14751,7 +14751,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > onUpdate 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14772,7 +14772,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -14781,7 +14781,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -14813,7 +14813,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -14822,7 +14822,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Typescript Test > onUpdateWithDeps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14857,7 +14857,7 @@ export class OnUpdateWithDeps {
 
 @NgModule({
   declarations: [OnUpdateWithDeps],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdateWithDeps],
 })
 export class OnUpdateWithDepsModule {}
@@ -14866,7 +14866,7 @@ export class OnUpdateWithDepsModule {}
 
 exports[`Angular > jsx > Typescript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14890,7 +14890,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -14899,7 +14899,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > outputEventBinding 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -14926,7 +14926,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -14935,7 +14935,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -14965,7 +14965,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -14974,7 +14974,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > preserveExportOrLocalStatement 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15007,7 +15007,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15016,7 +15016,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15045,7 +15045,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15054,7 +15054,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > preserveTyping 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15086,7 +15086,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15095,7 +15095,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15122,7 +15122,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15131,7 +15131,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsDestructure 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15161,7 +15161,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15170,7 +15170,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15191,7 +15191,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15200,7 +15200,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsInterface 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15224,7 +15224,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15233,7 +15233,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15254,7 +15254,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15263,7 +15263,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > propsType 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15287,7 +15287,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15296,7 +15296,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -15324,7 +15324,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -15333,7 +15333,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > referencingFunInsideHook 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15364,7 +15364,7 @@ export class OnUpdate {
 
 @NgModule({
   declarations: [OnUpdate],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [OnUpdate],
 })
 export class OnUpdateModule {}
@@ -15373,7 +15373,7 @@ export class OnUpdateModule {}
 
 exports[`Angular > jsx > Typescript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15424,7 +15424,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -15433,7 +15433,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > renderContentExample 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15489,7 +15489,7 @@ export class RenderContent {
 
 @NgModule({
   declarations: [RenderContent],
-  imports: [BrowserModule, RenderBlocksModule],
+  imports: [CommonModule, RenderBlocksModule],
   exports: [RenderContent],
 })
 export class RenderContentModule {}
@@ -15498,7 +15498,7 @@ export class RenderContentModule {}
 
 exports[`Angular > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15537,7 +15537,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -15546,7 +15546,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > rootFragmentMultiNode 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15588,7 +15588,7 @@ export class Button {
 
 @NgModule({
   declarations: [Button],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [Button],
 })
 export class ButtonModule {}
@@ -15597,7 +15597,7 @@ export class ButtonModule {}
 
 exports[`Angular > jsx > Typescript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15619,7 +15619,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -15628,7 +15628,7 @@ export class RenderStylesModule {}
 
 exports[`Angular > jsx > Typescript Test > rootShow 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15653,7 +15653,7 @@ export class RenderStyles {
 
 @NgModule({
   declarations: [RenderStyles],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [RenderStyles],
 })
 export class RenderStylesModule {}
@@ -15662,7 +15662,7 @@ export class RenderStylesModule {}
 
 exports[`Angular > jsx > Typescript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15684,7 +15684,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -15693,7 +15693,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > self-referencing component 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15718,7 +15718,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -15727,7 +15727,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15753,7 +15753,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -15762,7 +15762,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > self-referencing component with children 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15791,7 +15791,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, MyComponentModule],
+  imports: [CommonModule, MyComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -15800,7 +15800,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15826,7 +15826,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -15835,7 +15835,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Typescript Test > showWithFor 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15864,7 +15864,7 @@ export class NestedShow {
 
 @NgModule({
   declarations: [NestedShow],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [NestedShow],
 })
 export class NestedShowModule {}
@@ -15873,7 +15873,7 @@ export class NestedShowModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -15887,7 +15887,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15896,7 +15896,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadAttrs 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15913,7 +15913,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15922,7 +15922,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -15938,7 +15938,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15947,7 +15947,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadNestedProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -15966,7 +15966,7 @@ export class MyBasicComponent {
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15975,7 +15975,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -15989,7 +15989,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -15998,7 +15998,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > spreadProps 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16015,7 +16015,7 @@ export class MyBasicComponent {}
 
 @NgModule({
   declarations: [MyBasicComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyBasicComponent],
 })
 export class MyBasicComponentModule {}
@@ -16024,7 +16024,7 @@ export class MyBasicComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16038,7 +16038,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -16047,7 +16047,7 @@ export class SubComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > subComponent 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16066,7 +16066,7 @@ export class SubComponent {}
 
 @NgModule({
   declarations: [SubComponent],
-  imports: [BrowserModule, FooModule],
+  imports: [CommonModule, FooModule],
   exports: [SubComponent],
 })
 export class SubComponentModule {}
@@ -16075,7 +16075,7 @@ export class SubComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -16098,7 +16098,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -16107,7 +16107,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular > jsx > Typescript Test > typeDependency 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16133,7 +16133,7 @@ export class TypeDependency {
 
 @NgModule({
   declarations: [TypeDependency],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [TypeDependency],
 })
 export class TypeDependencyModule {}
@@ -16142,7 +16142,7 @@ export class TypeDependencyModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16166,7 +16166,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16175,7 +16175,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16202,7 +16202,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16211,7 +16211,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16238,7 +16238,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16247,7 +16247,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style-and-css 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16277,7 +16277,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16286,7 +16286,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16310,7 +16310,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16319,7 +16319,7 @@ export class MyComponentModule {}
 
 exports[`Angular > jsx > Typescript Test > use-style-outside-component 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16346,7 +16346,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16355,7 +16355,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16375,7 +16375,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16384,7 +16384,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16407,7 +16407,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16416,7 +16416,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16480,7 +16480,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16489,7 +16489,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > bindGroup 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16556,7 +16556,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16565,7 +16565,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16581,7 +16581,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16590,7 +16590,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > bindProperty 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16609,7 +16609,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16618,7 +16618,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -16640,7 +16640,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16649,7 +16649,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > classDirective 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16674,7 +16674,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16683,7 +16683,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16701,7 +16701,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16710,7 +16710,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > context 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16731,7 +16731,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16740,7 +16740,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16760,7 +16760,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16769,7 +16769,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > each 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16792,7 +16792,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16801,7 +16801,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16823,7 +16823,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16832,7 +16832,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > eventHandlers 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16857,7 +16857,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16866,7 +16866,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16882,7 +16882,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16891,7 +16891,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > html 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16910,7 +16910,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16919,7 +16919,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -16940,7 +16940,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16949,7 +16949,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > ifElse 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -16973,7 +16973,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -16982,7 +16982,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17002,7 +17002,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17011,7 +17011,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > imports 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17028,7 +17028,7 @@ import Button from \\"./Button\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Button, Slot],
+  imports: [CommonModule, Button],
 })
 export class MyComponent {
   disabled = false;
@@ -17036,7 +17036,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17045,7 +17045,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17071,7 +17071,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17080,7 +17080,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > lifecycleHooks 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17109,7 +17109,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17118,7 +17118,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17141,7 +17141,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17150,7 +17150,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > reactive 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17176,7 +17176,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17185,7 +17185,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17215,7 +17215,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17224,7 +17224,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > reactiveWithFn 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17257,7 +17257,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17266,7 +17266,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17283,7 +17283,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17292,7 +17292,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > slots 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17306,13 +17306,13 @@ import { CommonModule } from \\"@angular/common\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17321,7 +17321,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17347,7 +17347,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17356,7 +17356,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > style 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17385,7 +17385,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17394,7 +17394,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17416,7 +17416,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17425,7 +17425,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Javascript Test > textExpressions 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17450,7 +17450,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17459,7 +17459,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17479,7 +17479,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17488,7 +17488,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17511,7 +17511,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17520,7 +17520,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17584,7 +17584,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17593,7 +17593,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > bindGroup 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17660,7 +17660,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17669,7 +17669,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17685,7 +17685,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17694,7 +17694,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > bindProperty 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17713,7 +17713,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17722,7 +17722,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
@@ -17744,7 +17744,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17753,7 +17753,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > classDirective 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17778,7 +17778,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17787,7 +17787,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17805,7 +17805,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17814,7 +17814,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > context 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17835,7 +17835,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17844,7 +17844,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17864,7 +17864,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17873,7 +17873,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > each 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17896,7 +17896,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17905,7 +17905,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17927,7 +17927,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17936,7 +17936,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > eventHandlers 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -17961,7 +17961,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17970,7 +17970,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -17986,7 +17986,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -17995,7 +17995,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > html 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18014,7 +18014,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18023,7 +18023,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18044,7 +18044,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18053,7 +18053,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > ifElse 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18077,7 +18077,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18086,7 +18086,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18106,7 +18106,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18115,7 +18115,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > imports 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18132,7 +18132,7 @@ import Button from \\"./Button\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Button, Slot],
+  imports: [CommonModule, Button],
 })
 export class MyComponent {
   disabled = false;
@@ -18140,7 +18140,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, ButtonModule, SlotModule],
+  imports: [CommonModule, ButtonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18149,7 +18149,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18175,7 +18175,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18184,7 +18184,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > lifecycleHooks 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18213,7 +18213,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18222,7 +18222,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18245,7 +18245,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18254,7 +18254,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > reactive 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18280,7 +18280,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18289,7 +18289,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18319,7 +18319,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18328,7 +18328,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > reactiveWithFn 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18361,7 +18361,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18370,7 +18370,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18387,7 +18387,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18396,7 +18396,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > slots 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18410,13 +18410,13 @@ import { CommonModule } from \\"@angular/common\\";
     </div>
   \`,
   standalone: true,
-  imports: [CommonModule, Slot],
+  imports: [CommonModule],
 })
 export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule, SlotModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18425,7 +18425,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18451,7 +18451,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18460,7 +18460,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > style 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18489,7 +18489,7 @@ export class MyComponent {}
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18498,7 +18498,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 
@@ -18520,7 +18520,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}
@@ -18529,7 +18529,7 @@ export class MyComponentModule {}
 
 exports[`Angular > svelte > Typescript Test > textExpressions 2`] = `
 "import { NgModule } from \\"@angular/core\\";
-import { BrowserModule } from \\"@angular/platform-browser\\";
+import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -18554,7 +18554,7 @@ export class MyComponent {
 
 @NgModule({
   declarations: [MyComponent],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}

--- a/packages/core/src/generators/angular.ts
+++ b/packages/core/src/generators/angular.ts
@@ -39,7 +39,7 @@ import { MitosisComponent } from '..';
 import { mergeOptions } from '../helpers/merge-options';
 import { CODE_PROCESSOR_PLUGIN } from '../helpers/plugins/process-code';
 
-const BUILT_IN_COMPONENTS = new Set(['Show', 'For', 'Fragment']);
+const BUILT_IN_COMPONENTS = new Set(['Show', 'For', 'Fragment', 'Slot']);
 
 export interface ToAngularOptions extends BaseTranspilerOptions {
   standalone?: boolean;
@@ -90,13 +90,13 @@ const generateNgModule = (
   bootstrapMapper: Function | null | undefined,
 ): string => {
   return `import { NgModule } from "@angular/core";
-import { BrowserModule } from "@angular/platform-browser";
+import { CommonModule } from "@angular/common";
 
 ${content}
 
 @NgModule({
   declarations: [${name}],
-  imports: [BrowserModule${
+  imports: [CommonModule${
     componentsUsed.length ? ', ' + componentsUsed.map((comp) => `${comp}Module`).join(', ') : ''
   }],
   exports: [${name}],


### PR DESCRIPTION
#953 

Remove Browser Module in favor of Common. Add Slot to whitelist as suggested by @samijaber 

Browser Module causes too many issues and while it works for stand alone packages, it ultimately fails when in an app.
Slot added to built-in component white list.
