### PR TITLE
Remove padding from output menu

### DIFF
--- a/packages/fiddle/src/components/Fiddle/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle/Fiddle.tsx
@@ -915,7 +915,6 @@ export default function Fiddle() {
               css={{
                 display: 'flex',
                 alignItems: 'center',
-                padding: 5,
                 flexShrink: 0,
                 height: 40,
                 borderBottom: `1px solid ${colors.contrast}`,


### PR DESCRIPTION
## Description

Remove unnecessary padding from the fiddle output menu

Before:
![image](https://user-images.githubusercontent.com/11877796/212521440-002a577a-56a5-4891-9c76-a05d4cfe1b8a.png)

After:
![image](https://user-images.githubusercontent.com/11877796/212521397-cece225a-e82a-45fa-a259-34ac0c40f09f.png)


