### PR TITLE
fix: allow stencil to output ts files when typescript flag is on

### DIFF
--- a/packages/cli/src/build/helpers/extensions.ts
+++ b/packages/cli/src/build/helpers/extensions.ts
@@ -28,6 +28,8 @@ export const getFileExtensionForTarget = ({
       return '.ts';
     case 'lit':
       return '.ts';
+    case 'stencil':
+      return isTs ? '.ts' : '.js';
 
     // all JSX frameworks
     case 'solid':


### PR DESCRIPTION
## Description

I was adding stencil to the list of support for my library and noticed that it only outputs js files even if the typescript flag is explicitly true.

