### PR TITLE
fix: add stencil to list of jsx/tsx targets

### DIFF
--- a/packages/cli/src/build/helpers/extensions.ts
+++ b/packages/cli/src/build/helpers/extensions.ts
@@ -35,6 +35,7 @@ export const getFileExtensionForTarget = ({
     case 'react':
     case 'reactNative':
     case 'rsc':
+    case 'stencil':
       switch (type) {
         case 'import':
           // we can't have `.jsx`/`.tsx` extensions in the import paths, so we stick with implicit file extensions.


### PR DESCRIPTION
I was adding stencil to the list of support for my library and noticed that it only outputs js files even if the typescript flag is explicitly true.