### PR TITLE
fix: jsx recursive type

### DIFF
--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -1079,7 +1079,6 @@ export declare namespace JSX {
 
   interface ShapeElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,
-      ShapeElementSVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | 'color'


### PR DESCRIPTION
## Description

It seems like the ShapeElementSVGAttributes type erroneously depends on itself, causing a TypeScript warning.

