### PR TITLE
fix: Sveltosis behaviour on inputs

### DIFF
--- a/packages/core/src/parsers/svelte/html/element.ts
+++ b/packages/core/src/parsers/svelte/html/element.ts
@@ -207,7 +207,8 @@ export function parseElement(json: SveltosisComponent, node: TemplateNode) {
 
           if (name !== 'ref' && name !== 'group' && name !== 'this') {
             const onChangeCode = `${binding} = event.target.value`;
-            mitosisNode.bindings['onChange'] = createSingleBinding({
+            const binding = ['input', 'textarea'].indexOf(mitosisNode.name) > -1 ? 'onInput' : 'onChange';
+            mitosisNode.bindings[binding] = createSingleBinding({
               code: onChangeCode,
               arguments: ['event'],
             });


### PR DESCRIPTION
The goal is to make sure inputs and textarea are binded onInput instead of onChange (which is triggered on blur) so that it is more inline with the Svelte rendering
