### PR TITLE
Add JS comment type hint for `mitosis.config.js` to `README`

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,7 +48,7 @@ npm install @builder.io/mitosis-cli @builder.io/mitosis
 ### Setup `mitosis.config.js`
 
 ```js
-/** @type {import('@builder.io/mitosis/dist/src/types/config')} */
+/** @type {import('@builder.io/mitosis').MitosisConfig} */
 module.exports = {
   files: 'src/**',
   targets: ['vue3', 'solid', 'svelte', 'react'],

--- a/README.MD
+++ b/README.MD
@@ -48,6 +48,7 @@ npm install @builder.io/mitosis-cli @builder.io/mitosis
 ### Setup `mitosis.config.js`
 
 ```js
+/** @type {import('@builder.io/mitosis/dist/src/types/config')} */
 module.exports = {
   files: 'src/**',
   targets: ['vue3', 'solid', 'svelte', 'react'],


### PR DESCRIPTION
## Description

Since there is no support yet for a TypeScript config file, JS comment type hint can help a lot. This PR adds type hint to `README`.

