### PR TITLE
Add api option to compile command

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -62,6 +62,7 @@ const command: GluegunCommand = {
       stylesType: opts.styles,
       stateType: opts.state,
       type: opts.type,
+      api: opts.api,
       cssNamespace: opts.cssNamespace,
     } as any as Partial<{ [K in AllGeneratorOptionKeys]: any }>;
 


### PR DESCRIPTION
Vue needs the option called "api" to be able to choose between composition and options apis


