### PR TITLE
Fix: if root is a text node it needs to be wrapped in a fragment for JSX outputs

### DIFF
--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -13,6 +13,7 @@ import { MitosisComponent } from '../types/mitosis-component';
 import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 import { checkHasState } from '../helpers/state';
+import { isRootTextNode } from 'src/helpers/is-root-text-node';
 
 export interface ToMitosisOptions extends BaseTranspilerOptions {
   format: 'react' | 'legacy';
@@ -156,7 +157,7 @@ export const componentToMitosis: TranspilerGenerator<Partial<ToMitosisOptions>> 
       return `${refName}${domRefs.has(refName) ? `.current` : ''}`;
     });
 
-    const addWrapper = json.children.length !== 1;
+    const addWrapper = json.children.length !== 1 || isRootTextNode(json);
 
     const components = Array.from(getComponents(json));
 

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -13,7 +13,7 @@ import { MitosisComponent } from '../types/mitosis-component';
 import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 import { checkHasState } from '../helpers/state';
-import { isRootTextNode } from 'src/helpers/is-root-text-node';
+import { isRootTextNode } from '../helpers/is-root-text-node';
 
 export interface ToMitosisOptions extends BaseTranspilerOptions {
   format: 'react' | 'legacy';

--- a/packages/core/src/generators/qwik/jsx.ts
+++ b/packages/core/src/generators/qwik/jsx.ts
@@ -30,7 +30,9 @@ export function renderJSXNodes(
     if (children.length == 0) return;
     if (root) this.emit('(');
     const needsFragment =
-      root && (children.length > 1 || (children.length && isInlinedDirective(children[0])));
+      root &&
+      (children.length > 1 ||
+        (children.length && (isInlinedDirective(children[0]) || isTextNode(children[0]))));
     file.import(file.qwikModule, 'h');
     const fragmentSymbol = file.import(file.qwikModule, 'Fragment');
     if (needsFragment) {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -38,7 +38,7 @@ import { createSingleBinding } from '../../helpers/bindings';
 import { blockToReact } from './blocks';
 import { mergeOptions } from '../../helpers/merge-options';
 import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strings';
-import { isRootTextNode } from 'src/helpers/is-root-text-node';
+import { isRootTextNode } from '../../helpers/is-root-text-node';
 
 export const contextPropDrillingKey = '_context';
 

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -38,13 +38,13 @@ import { createSingleBinding } from '../../helpers/bindings';
 import { blockToReact } from './blocks';
 import { mergeOptions } from '../../helpers/merge-options';
 import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strings';
+import { isRootTextNode } from 'src/helpers/is-root-text-node';
 
 export const contextPropDrillingKey = '_context';
 
 /**
  * If the root Mitosis component only has 1 child, and it is a `Show`/`For` node, then we need to wrap it in a fragment.
  * Otherwise, we end up with invalid React render code.
- *
  */
 const isRootSpecialNode = (json: MitosisComponent) =>
   json.children.length === 1 && ['Show', 'For'].includes(json.children[0].name);
@@ -327,6 +327,7 @@ const _componentToReact = (
 
   const wrap =
     wrapInFragment(json) ||
+    isRootTextNode(json) ||
     (componentHasStyles &&
       (options.stylesType === 'styled-jsx' || options.stylesType === 'style-tag')) ||
     isRootSpecialNode(json);

--- a/packages/core/src/generators/solid/index.ts
+++ b/packages/core/src/generators/solid/index.ts
@@ -32,7 +32,7 @@ import { CODE_PROCESSOR_PLUGIN } from '../../helpers/plugins/process-code';
 import { hasGetContext } from '../helpers/context';
 import { blockToSolid } from './blocks';
 import { createSingleBinding } from '../../helpers/bindings';
-import { isRootTextNode } from 'src/helpers/is-root-text-node';
+import { isRootTextNode } from '../../helpers/is-root-text-node';
 
 // Transform <foo.bar key={value} /> to <Dynamic compnent={foo.bar} key={value} />
 function processDynamicComponents(json: MitosisComponent, options: ToSolidOptions) {

--- a/packages/core/src/generators/solid/index.ts
+++ b/packages/core/src/generators/solid/index.ts
@@ -32,6 +32,7 @@ import { CODE_PROCESSOR_PLUGIN } from '../../helpers/plugins/process-code';
 import { hasGetContext } from '../helpers/context';
 import { blockToSolid } from './blocks';
 import { createSingleBinding } from '../../helpers/bindings';
+import { isRootTextNode } from 'src/helpers/is-root-text-node';
 
 // Transform <foo.bar key={value} /> to <Dynamic compnent={foo.bar} key={value} />
 function processDynamicComponents(json: MitosisComponent, options: ToSolidOptions) {
@@ -121,7 +122,9 @@ export const componentToSolid: TranspilerGenerator<Partial<ToSolidOptions>> =
     addProviderComponents(json, options);
     const componentHasStyles = hasCss(json);
     const addWrapper =
-      json.children.filter(filterEmptyTextNodes).length !== 1 || options.stylesType === 'style-tag';
+      json.children.filter(filterEmptyTextNodes).length !== 1 ||
+      options.stylesType === 'style-tag' ||
+      isRootTextNode(json);
 
     // we need to run this before we run the code processor plugin, so the dynamic component variables are transformed
     const foundDynamicComponents = processDynamicComponents(json, options);

--- a/packages/core/src/helpers/is-root-text-node.ts
+++ b/packages/core/src/helpers/is-root-text-node.ts
@@ -1,0 +1,11 @@
+import { MitosisNode } from '../types/mitosis-node';
+import { MitosisComponent } from '../types/mitosis-component';
+
+export function isRootTextNode(json: MitosisComponent) {
+  const firstChild = json.children[0];
+  return Boolean(firstChild && isTextNode(firstChild));
+}
+
+export function isTextNode(node: MitosisNode) {
+  return Boolean(node.properties._text || node.bindings._text);
+}


### PR DESCRIPTION
I changed Builder to generate code on a per-selected-block basis. If you select text blocks the code would error out because raw text if rendered at the root needs a fragment around it. This specifically happens only really when created in Builder as Mitosis JSX doesn't let you create root nodes that are text (it's invalid JSX) but builder does allow root text blocks