### PR TITLE
add fill property to useSvgAttributes to fix typing

### DIFF
--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -1652,6 +1652,7 @@ export declare namespace JSX {
     y?: number | string;
     width?: number | string;
     height?: number | string;
+    fill?: number | string;
   }
 
   interface ViewSVGAttributes<T>


### PR DESCRIPTION
## Description

added the property fill to the UseSVGAttributes interface to fix the issue #838 
