### PR TITLE
Use Nullish check for default props

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -429,7 +429,7 @@ const DEFAULT_VALUES = {
   color: 'blue',
 };
 export default function MyComponent(props) {
-  return <div>{props.color || DEFAULT_VALUES.color}</div>;
+  return <div>{props.color ?? DEFAULT_VALUES.color}</div>;
 }
 ```
 
@@ -440,7 +440,7 @@ const DEFAULT_VALUES = {
   color: 'blue',
 };
 export default function MyComponent(props) {
-  return <div>{props.color || DEFAULT_VALUES.color}</div>;
+  return <div>{props.color ?? DEFAULT_VALUES.color}</div>;
 }
 ```
 


### PR DESCRIPTION


## Description

It seems to be more make sense to use the Nullish check here, to avoid rendering the right-hand value when the `prop` is a falsy value e.g. `0`, `false` or `''`
