### PR TITLE
support the for attribute in qwik generator

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -1486,7 +1486,7 @@ export const MyBasicRefComponent = component$((props) => {
             onBlur$={(event) => state.onBlur()}
             onChange$={(event) => (state.name = event.target.value)}
           />
-          <label htmlFor=\\"cars\\" ref={inputNoArgRef}>
+          <label for=\\"cars\\" ref={inputNoArgRef}>
             Choose a car:
           </label>
           <select name=\\"cars\\" id=\\"cars\\">
@@ -4481,7 +4481,7 @@ export const MyBasicRefComponent = component$((props: Props) => {
             onBlur$={(event) => state.onBlur()}
             onChange$={(event) => (state.name = event.target.value)}
           />
-          <label htmlFor=\\"cars\\" ref={inputNoArgRef}>
+          <label for=\\"cars\\" ref={inputNoArgRef}>
             Choose a car:
           </label>
           <select name=\\"cars\\" id=\\"cars\\">

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -364,7 +364,6 @@ export class SrcBuilder {
     function emitJsxProp(key: string, value: any) {
       if (value) {
         if (key === 'innerHTML') key = 'dangerouslySetInnerHTML';
-        if (key === 'for') key = 'htmlFor';
         if (key === 'dataSet') return; // ignore
         if (self.isJSX) {
           self.emit(' ', key, '=');


### PR DESCRIPTION
## Description

Update qwik generator to properly allow `for` attributes instead of forcing them to be `htmlFor`. Fixes #1047 