### PR TITLE
Added list of all compilable languages in --help

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,6 @@ OPTIONS
                 - builder
                 - customElement
                 - html
-                - json
                 - liquid
                 - lit
                 - marko

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,26 +23,32 @@ EXAMPLES
 OPTIONS
 	--to=<format>, -t=<format>
 		Specify output format. <format> can be one of:
-		
-		- reactNative
-		- solid
-		- vue
-		- react
-		- template
-		- html
-		- customElement
-		- mitosis
-		- builder
-		- swift
-		- svelte
-		- liquid
-		- angular
+		- alpine
+                - angular
+                - builder
+                - customElement
+                - html
+                - json
+                - liquid
+                - lit
+                - marko
+                - mitosis
+                - preact
+                - qwik
+                - react
+                - reactNative
+                - rsc
+                - solid
+                - stencil
+                - svelte
+                - swift
+                - template
+                 - vue
 	--from=<format>, -f=<format>
-		Specify input format. <format> can be one of:
-		
-		- mitosis
+		Specify input format. <format> can be one of:	
+                - liquid
 		- builder
-		- liquid
+		- mitosis
 	--list, -l
 		List available output formats.
 	--config=<file>, -c=<file>

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -4,6 +4,7 @@ import {
   GeneratorOptions,
   MitosisComponent,
   parseJsx,
+  parseSvelte,
   Plugin,
   Target,
   targets,
@@ -126,6 +127,9 @@ const command: GluegunCommand = {
           case 'builder':
             json = builderContentToMitosisComponent(JSON.parse(data!));
             break;
+          case 'svelte':            
+            console.warning("Please note that compilation from Svelte is EXPERIMENTAL. Please report bugs in the Mitosis issues.");
+            json = parseSvelte("placeholder" /*TO-DO: test sveltosis in cli*/)
 
           default:
             print.error(`${from_} is not a valid input type`);

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -129,7 +129,7 @@ const command: GluegunCommand = {
             break;
           case 'svelte':            
             console.warning("Please note that compilation from Svelte is EXPERIMENTAL. Please report bugs in the Mitosis issues.");
-            json = parseSvelte("placeholder" /*TO-DO: test sveltosis in cli*/)
+            json = parseSvelte(data!)
 
           default:
             print.error(`${from_} is not a valid input type`);

--- a/packages/core/src/parsers/svelte/index.ts
+++ b/packages/core/src/parsers/svelte/index.ts
@@ -71,3 +71,4 @@ export const parseSvelte = async function (
   const componentName = path.split('/').pop()?.split('.')[0] ?? 'MyComponent';
   return mapAstToMitosisJson(ast, componentName, string_, usesTypescript);
 };
+export {parseSvelte, mapAstToMitosisJson}


### PR DESCRIPTION
I added some entries to the old --to / -t, as it was uncomplete. I also changed the list of --to and --from into alphabetical order because it's super annoying otherwise.
