### PR TITLE
Fix Svelte and Vue named slots

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1211,40 +1211,12 @@ exports[`Svelte > jsx > Javascript Test > SlotHtml 1`] = `
 `;
 
 exports[`Svelte > jsx > Javascript Test > SlotJsx 1`] = `
-"<script >
-  
-  
-
-  
-import ContentSlotCode from './content-slot-jsx.raw';
-
-
-
-
-  
-  
-  
-  
-
-  
-  
-
-  
-
-  
-  
-
-  
-
-  
-
-  
-
-  
+"<script>
+  import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 </script>
 
-<div >
-  <ContentSlotCode  slotTesting={<div>Hello</div>} ></ContentSlotCode>
+<div>
+  <ContentSlotCode><div slot=\\"testing\\">Hello</div></ContentSlotCode>
 </div>"
 `;
 
@@ -3970,49 +3942,18 @@ exports[`Svelte > jsx > Typescript Test > SlotHtml 1`] = `
 `;
 
 exports[`Svelte > jsx > Typescript Test > SlotJsx 1`] = `
-"<script context='module' lang='ts'>
-      type Props = {
-[key: string]: string;
-};
-
-    </script>
-    
-
-    
-<script lang='ts'>
-  
-  
-
-  
-import ContentSlotCode from './content-slot-jsx.raw';
-
-
-
-
-  
-  
-  
-  
-
-  
-  
-
-  
-
-  
-  
-
-  
-
-  
-
-  
-
-  
+"<script context=\\"module\\" lang=\\"ts\\">
+  type Props = {
+    [key: string]: string;
+  };
 </script>
 
-<div >
-  <ContentSlotCode  slotTesting={<div>Hello</div>} ></ContentSlotCode>
+<script lang=\\"ts\\">
+  import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+</script>
+
+<div>
+  <ContentSlotCode><div slot=\\"testing\\">Hello</div></ContentSlotCode>
 </div>"
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -1333,7 +1333,9 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 exports[`Vue > jsx > Javascript Test > SlotJsx 1`] = `
 "<template>
   <div>
-    <content-slot-code :slotTesting=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code
+      ><template #testing><div>Hello</div></template></content-slot-code
+    >
   </div>
 </template>
 
@@ -4251,7 +4253,9 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 exports[`Vue > jsx > Typescript Test > SlotJsx 1`] = `
 "<template>
   <div>
-    <content-slot-code :slotTesting=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code
+      ><template #testing><div>Hello</div></template></content-slot-code
+    >
   </div>
 </template>
 

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1488,7 +1488,9 @@ export default {
 exports[`Vue > jsx > Javascript Test > SlotJsx 1`] = `
 "<template>
   <div>
-    <content-slot-code :slotTesting=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code
+      ><template #testing><div>Hello</div></template></content-slot-code
+    >
   </div>
 </template>
 
@@ -4861,7 +4863,9 @@ export default {
 exports[`Vue > jsx > Typescript Test > SlotJsx 1`] = `
 "<template>
   <div>
-    <content-slot-code :slotTesting=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code
+      ><template #testing><div>Hello</div></template></content-slot-code
+    >
   </div>
 </template>
 

--- a/packages/core/src/generators/vue/blocks.ts
+++ b/packages/core/src/generators/vue/blocks.ts
@@ -295,7 +295,7 @@ const NODE_MAPPERS: {
 const stringifyBinding =
   (node: MitosisNode) =>
   ([key, value]: [string, Binding]) => {
-    if (value.type === 'spread') {
+    if (value.type === 'spread' || isSlotProperty(key)) {
       return ''; // we handle this after
     } else if (key === 'class') {
       return `:class="_classStringToObject(${value?.code})"`;
@@ -418,6 +418,15 @@ export const blockToVue: BlockRenderer = (node, options, scope) => {
   }
 
   str += '>';
+
+  for (const key in node.bindings) {
+    if (isSlotProperty(key)) {
+      str += `<template #${stripSlotPrefix(key).toLowerCase()}>${
+        node.bindings[key]?.code
+      }</template>`;
+    }
+  }
+
   if (node.children) {
     str += node.children.map((item) => blockToVue(item, options)).join('');
   }

--- a/packages/core/src/helpers/slots.ts
+++ b/packages/core/src/helpers/slots.ts
@@ -21,3 +21,14 @@ export function replaceSlotsInString(code: string, mapper: SlotMapper) {
     },
   });
 }
+
+export function addSlotName(code: string, slotAttribute: string) {
+  // If the tag has other attributes, add the "slot" attribute before the first attribute
+  // If the tag has no attributes, add the "slot" attribute after the tag name
+  let splitIndex = code.indexOf('>');
+  const whitespaceIndex = code.indexOf(' ');
+  if (whitespaceIndex > -1 && whitespaceIndex < splitIndex) {
+    splitIndex = whitespaceIndex;
+  }
+  return `${code.slice(0, splitIndex)} ${slotAttribute}${code.slice(splitIndex)}`;
+}


### PR DESCRIPTION
Fixes https://github.com/BuilderIO/mitosis/issues/1097


This implements "named slots" for Svelte and Vue.

Consider this code from the existing "SlotCode":

https://github.com/BuilderIO/mitosis/blob/main/packages/core/src/__tests__/data/blocks/slot-jsx.raw.tsx

```jsx
import ContentSlotCode from './content-slot-jsx.raw';

type Props = { [key: string]: string };

export default function SlotCode(props: Props) {
  return (
    <div>
      <ContentSlotCode slotTesting={<div>Hello</div>} />
    </div>
  );
}
```

Before, this was broken in Svelte and Vue.

Vue (broken):

```vue
<div>
  <content-slot-code :slotTesting="<div>Hello</div>"></content-slot-code>
</div>
```

Svelte (broken):

```vue
<div>
  <ContentSlotCode slotTesting={<div>Hello</div>} ></ContentSlotCode>
</div>
```

After, this is fixed using the respective named slots syntax:

Vue (working, see named slots: https://vuejs.org/guide/components/slots.html#named-slots)

```vue
<div>
  <content-slot-code>
    <template #testing><div>Hello</div></template>
  </content-slot-code>
</div>
```

Svelte (working, see named slots: https://svelte.dev/tutorial/named-slots):

```vue
<div>
  <ContentSlotCode>
    <div slot="testing">Hello</div>
  </ContentSlotCode>
</div>
```
