### PR TITLE
Fix: use TS option in Fiddle JSX

### DIFF
--- a/packages/fiddle/src/components/Fiddle/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle/Fiddle.tsx
@@ -302,7 +302,9 @@ export default function Fiddle() {
             break;
           case 'jsx':
           default:
-            json = parseJsx(state.code);
+            json = parseJsx(state.code, {
+              typescript: state.options.typescript === 'true',
+            });
             break;
         }
 

--- a/packages/fiddle/src/components/Fiddle/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle/Fiddle.tsx
@@ -296,6 +296,10 @@ export default function Fiddle() {
 
         const { parseSvelte, parseJsx } = await mitosisCore();
 
+        const commonOptions: { typescript: boolean } = {
+          typescript: state.options.typescript === 'true',
+        };
+
         switch (state.inputTab) {
           case 'svelte':
             json = await parseSvelte(state.code);
@@ -303,15 +307,10 @@ export default function Fiddle() {
           case 'jsx':
           default:
             json = parseJsx(state.code, {
-              typescript: state.options.typescript === 'true',
+              typescript: commonOptions.typescript,
             });
             break;
         }
-
-        const commonOptions: { typescript: boolean } = {
-          typescript: state.options.typescript === 'true',
-        };
-
         const generateOptions = () => {
           switch (state.outputTab) {
             case 'alpine':


### PR DESCRIPTION
## Description

- We were not generating TS code properly in the Fiddle. Need to reuse `typescript` state option in the `parseJsx` fn
- Test with `/?outputTab=FYZw9gdkA%3D%3D%3D&code=PTAEAsBdIBwZwFwgOYEtLgK4CMB0BjAewFtgAhTVAGwBMBTAJwEkB5YY9QuVOYbKwtnYBDVADtgMYfgDWw5HV5EGdYHAb5gAfS2RFkODuA1hkYXwGylhKpmJi4uBsIDuuAwA8AUF9TEYhAyQoADeoJhwdADKkIF0ADSgAGKBoAC%2BoABmDCSgAOQAAtiUtIy4qITsnNxweQDcPpAAnjB0oADCNnZioAC8oV6goERieqMIoMJiTQ1DIKAAKiwAIiwTTP5UdMR0o6AYPKAu4LugcJgwAUFZqTRNYsIc%2BB1RUaBUUzRwg0eoNBgAfgmYjs2EYDTSDS8dA8V2C4j0DEy0janVs9gACjl4AMhkR0Q4gR0uvYANoAXShczAS1W602212wQOcCOJx650ugWCmVu90eqGe7Ve70%2B3yGcCk%2BDoRJBxDBDFmoHmtLWoA2MC2Oz2LLZp05cJuDFAdweTxebw%2BYi%2BPzgZlkaO6cAAgpAiXkzPw6JA8qAAD75YiCah0X0BvJiOgAN0Y9R%2BKpWao1WqZ%2B3Ah2O%2Bouht5xtNAqFIqtNqGKhjDEijvscAA6uyYtIZHQaETsIQbHQphCfDDDfRkZgqDzMGJ8JAKj0q2IABQwbGIYkErGEeAASlxw0IDmCdtMbX6EWisRU05CPyGCkgU7g09XEynFI3Q1L3swDB6c5XjnxTv9AYpSpDGk8TnqAl4AOKYNAjBRKgABedC3sCoKME%2Bz4qJAb49M0rSEJkoCfvAuCSiifS9P0EYoQwvoAgR87EVKbR%2BgGAAMoATAATCxgHpCBz5gd6NZ%2FBg07iPQHjIfKjDrme%2FF4ludqbgSrL9Luei4Je163jxL6Ye%2BoDTj%2B1akmJMLkqAABkFlKU6JnWmZuAuMJ4DrsxoAAIwsWxYBGQ4uBbGIyAYDxwGgZpJJiO0cC1s5EyifZEmgHKCrrr0AB8aHyduNnVveEWPqpZjqeFynaaBWWKcgUGIrBCF9GcRV0Bp3qQdBDC1Yhq46Zu2XnNgkDOGOQn%2FOA9XTlVbUdaAABUBm%2BY4AVBaNAC0HmruuPkRQtuxLd1GFYaAAAG%2BDCFQ%2BDTgAJCEalNZew0iaZHirmkACkoCrVdfUDdIkD3eAaQwE9h0hXx6RdT4ukHdOoEADw0KgUblcMHzRb0ABExTUPQDDLfNaNI%2FgqMhLJclDPDkofE0Ex5JkWweHkoOk7TMLLKgKhjhO1O%2BQzSNDKdqDIGITB6MQC55HaGH4OAPOk0MVDiHQAASdAC1A1NiIExCnTLsuFDs8PCAZWseMtTkjRMACcVuA6ueQTCTstZHTrPs%2BOW7UzkLg66ToWO3rzaoIb07G6bsWgAAbAAzBbNt25lcnMx4Lt0Bz7v5J7y1lowkTe3Jvt52koFpUjMMpManZS70ISEd%2BW1pMXjshIZEWJI9qUZdDjtDHDCPI8IqMYyU2O4xFaPDETYSJ%2BBnvU%2B5vppPXvNySEvkEFuYyQBkISPYXXegDDxgIw3svPSXwBl8f3eH1Gx%2Fg4XQA%3D%3D`

