### PR TITLE
fix: no config file found for Mitosis

### DIFF
--- a/packages/cli/src/helpers/get-mitosis-config.ts
+++ b/packages/cli/src/helpers/get-mitosis-config.ts
@@ -1,17 +1,31 @@
+import { MitosisConfig } from '@builder.io/mitosis';
 import fs from 'fs';
 import { resolve } from 'path';
-import { MitosisConfig } from '@builder.io/mitosis';
 
 /**
  * @param relPath { string } the relative path from pwd to config-file
  */
 export function getMitosisConfig(relPath?: string): MitosisConfig | null {
-  const path = resolve(process.cwd(), relPath || 'mitosis.config');
-  if (fs.existsSync(path + '.js')) {
-    const module = require(path + '.js');
-    return module?.default || module || null;
-  } else if (fs.existsSync(path + '.cjs')) {
-    const module = require(path + '.cjs');
+  if (!relPath) {
+    const path = resolve(process.cwd(), 'mitosis.config');
+
+    if (fs.existsSync(path + '.js')) {
+      const module = require(path + '.js');
+      return module?.default || module || null;
+    }
+
+    if (fs.existsSync(path + '.cjs')) {
+      const module = require(path + '.cjs');
+      return module?.default || module || null;
+    }
+
+    return null;
+  }
+
+  const path = resolve(process.cwd(), relPath);
+
+  if (fs.existsSync(path)) {
+    const module = require(path);
     return module?.default || module || null;
   }
 


### PR DESCRIPTION
## Description

Add a short description of:
When passing a custom config file, either with `js` or `cjs` extension, to the CLI, the "No config file found for Mitosis" was shown.

This is a fix, that preserves the original approach with the additional edge case of a custom config file handled properly.

NOTE: The imports were automatically organized by `vs-code` with `organizeImports` function.

