### PR TITLE
fix: css pseudo classes and selectors

### DIFF
--- a/packages/cli/src/helpers/get-mitosis-config.ts
+++ b/packages/cli/src/helpers/get-mitosis-config.ts
@@ -1,17 +1,31 @@
+import { MitosisConfig } from '@builder.io/mitosis';
 import fs from 'fs';
 import { resolve } from 'path';
-import { MitosisConfig } from '@builder.io/mitosis';
 
 /**
  * @param relPath { string } the relative path from pwd to config-file
  */
 export function getMitosisConfig(relPath?: string): MitosisConfig | null {
-  const path = resolve(process.cwd(), relPath || 'mitosis.config');
-  if (fs.existsSync(path + '.js')) {
-    const module = require(path + '.js');
-    return module?.default || module || null;
-  } else if (fs.existsSync(path + '.cjs')) {
-    const module = require(path + '.cjs');
+  if (!relPath) {
+    const path = resolve(process.cwd(), 'mitosis.config');
+
+    if (fs.existsSync(path + '.js')) {
+      const module = require(path + '.js');
+      return module?.default || module || null;
+    }
+
+    if (fs.existsSync(path + '.cjs')) {
+      const module = require(path + '.cjs');
+      return module?.default || module || null;
+    }
+
+    return null;
+  }
+
+  const path = resolve(process.cwd(), relPath);
+
+  if (fs.existsSync(path)) {
+    const module = require(path);
     return module?.default || module || null;
   }
 

--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -1815,8 +1815,14 @@ exports[`Alpine.js > jsx > Javascript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 <div class=\\"div\\" x-data=\\"nestedStyles()\\">Hello world</div>
@@ -4316,8 +4322,14 @@ exports[`Alpine.js > jsx > Typescript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 <div class=\\"div\\" x-data=\\"nestedStyles()\\">Hello world</div>

--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -1824,6 +1824,9 @@ exports[`Alpine.js > jsx > Javascript Test > nestedStyles 1`] = `
   .div .nested-selector:hover {
     display: block;
   }
+  .div.nested-selector:active {
+    display: inline-block;
+  }
 </style>
 <div class=\\"div\\" x-data=\\"nestedStyles()\\">Hello world</div>
 <script>
@@ -4330,6 +4333,9 @@ exports[`Alpine.js > jsx > Typescript Test > nestedStyles 1`] = `
   }
   .div .nested-selector:hover {
     display: block;
+  }
+  .div.nested-selector:active {
+    display: inline-block;
   }
 </style>
 <div class=\\"div\\" x-data=\\"nestedStyles()\\">Hello world</div>

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -2830,6 +2830,9 @@ import { Component } from \\"@angular/core\\";
       .div .nested-selector:hover {
         display: block;
       }
+      .div.nested-selector:active {
+        display: inline-block;
+      }
     \`,
   ],
 })
@@ -7157,6 +7160,9 @@ import { Component } from \\"@angular/core\\";
       }
       .div .nested-selector:hover {
         display: block;
+      }
+      .div.nested-selector:active {
+        display: inline-block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -2821,8 +2821,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],
@@ -7143,8 +7149,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -2881,8 +2881,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],
@@ -7296,8 +7302,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -2890,6 +2890,9 @@ import { Component } from \\"@angular/core\\";
       .div .nested-selector:hover {
         display: block;
       }
+      .div.nested-selector:active {
+        display: inline-block;
+      }
     \`,
   ],
 })
@@ -7310,6 +7313,9 @@ import { Component } from \\"@angular/core\\";
       }
       .div .nested-selector:hover {
         display: block;
+      }
+      .div.nested-selector:active {
+        display: inline-block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -5794,8 +5794,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],
@@ -5838,8 +5844,14 @@ import { CommonModule } from \\"@angular/common\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],
@@ -14700,8 +14712,14 @@ import { Component } from \\"@angular/core\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],
@@ -14744,8 +14762,14 @@ import { CommonModule } from \\"@angular/common\\";
       .div:hover {
         display: flex;
       }
+      .div:active {
+        display: inline;
+      }
       .div .nested-selector {
         display: grid;
+      }
+      .div .nested-selector:hover {
+        display: block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -5803,6 +5803,9 @@ import { Component } from \\"@angular/core\\";
       .div .nested-selector:hover {
         display: block;
       }
+      .div.nested-selector:active {
+        display: inline-block;
+      }
     \`,
   ],
 })
@@ -5852,6 +5855,9 @@ import { CommonModule } from \\"@angular/common\\";
       }
       .div .nested-selector:hover {
         display: block;
+      }
+      .div.nested-selector:active {
+        display: inline-block;
       }
     \`,
   ],
@@ -14721,6 +14727,9 @@ import { Component } from \\"@angular/core\\";
       .div .nested-selector:hover {
         display: block;
       }
+      .div.nested-selector:active {
+        display: inline-block;
+      }
     \`,
   ],
 })
@@ -14770,6 +14779,9 @@ import { CommonModule } from \\"@angular/common\\";
       }
       .div .nested-selector:hover {
         display: block;
+      }
+      .div.nested-selector:active {
+        display: inline-block;
       }
     \`,
   ],

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -4156,6 +4156,9 @@ exports[`Html > jsx > Javascript Test > nestedStyles 1`] = `
   .div .nested-selector:hover {
     display: block;
   }
+  .div.nested-selector:active {
+    display: inline-block;
+  }
 </style>
 "
 `;
@@ -9938,6 +9941,9 @@ exports[`Html > jsx > Typescript Test > nestedStyles 1`] = `
   }
   .div .nested-selector:hover {
     display: block;
+  }
+  .div.nested-selector:active {
+    display: inline-block;
   }
 </style>
 "

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -4147,8 +4147,14 @@ exports[`Html > jsx > Javascript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 "
@@ -9924,8 +9930,14 @@ exports[`Html > jsx > Typescript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 "

--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -623,6 +623,9 @@ exports[`Liquid > jsx > Javascript Test > nestedStyles 1`] = `
   .div .nested-selector:hover {
     display: block;
   }
+  .div.nested-selector:active {
+    display: inline-block;
+  }
 </style>
 "
 `;
@@ -1460,6 +1463,9 @@ exports[`Liquid > jsx > Typescript Test > nestedStyles 1`] = `
   }
   .div .nested-selector:hover {
     display: block;
+  }
+  .div.nested-selector:active {
+    display: inline-block;
   }
 </style>
 "

--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -614,8 +614,14 @@ exports[`Liquid > jsx > Javascript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 "
@@ -1446,8 +1452,14 @@ exports[`Liquid > jsx > Typescript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>
 "

--- a/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
@@ -2763,8 +2763,14 @@ export default class NestedStyles extends LitElement {
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>
           <div>Hello world</div>
@@ -6964,8 +6970,14 @@ export default class NestedStyles extends LitElement {
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>
           <div>Hello world</div>

--- a/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
@@ -2772,6 +2772,9 @@ export default class NestedStyles extends LitElement {
 .div .nested-selector:hover {
   display: block;
 }
+.div.nested-selector:active {
+  display: inline-block;
+}
 </style>
           <div>Hello world</div>
 
@@ -6978,6 +6981,9 @@ export default class NestedStyles extends LitElement {
 }
 .div .nested-selector:hover {
   display: block;
+}
+.div.nested-selector:active {
+  display: inline-block;
 }
 </style>
           <div>Hello world</div>

--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -1682,30 +1682,33 @@ exports[`Marko > jsx > Javascript Test > nestedStyles 1`] = `
 "class {}
 
 style { 
-  .div-37d76664 {
+  .div-8f6e8a44 {
     display: flex;
     --bar: red;
     color: var(--bar);
   }
   @media (max-width: env(--mobile)) {
-    .div-37d76664 {
+    .div-8f6e8a44 {
       display: block;
     }
   }
-  .div-37d76664:hover {
+  .div-8f6e8a44:hover {
     display: flex;
   }
-  .div-37d76664:active {
+  .div-8f6e8a44:active {
     display: inline;
   }
-  .div-37d76664 .nested-selector {
+  .div-8f6e8a44 .nested-selector {
     display: grid;
   }
-  .div-37d76664 .nested-selector:hover {
+  .div-8f6e8a44 .nested-selector:hover {
     display: block;
   }
+  .div-8f6e8a44.nested-selector:active {
+    display: inline-block;
+  }
 }
-<div class=\\"div-37d76664\\">Hello world</div>"
+<div class=\\"div-8f6e8a44\\">Hello world</div>"
 `;
 
 exports[`Marko > jsx > Javascript Test > onInit & onMount 1`] = `
@@ -3931,30 +3934,33 @@ exports[`Marko > jsx > Typescript Test > nestedStyles 1`] = `
 "class {}
 
 style { 
-  .div-37d76664 {
+  .div-8f6e8a44 {
     display: flex;
     --bar: red;
     color: var(--bar);
   }
   @media (max-width: env(--mobile)) {
-    .div-37d76664 {
+    .div-8f6e8a44 {
       display: block;
     }
   }
-  .div-37d76664:hover {
+  .div-8f6e8a44:hover {
     display: flex;
   }
-  .div-37d76664:active {
+  .div-8f6e8a44:active {
     display: inline;
   }
-  .div-37d76664 .nested-selector {
+  .div-8f6e8a44 .nested-selector {
     display: grid;
   }
-  .div-37d76664 .nested-selector:hover {
+  .div-8f6e8a44 .nested-selector:hover {
     display: block;
   }
+  .div-8f6e8a44.nested-selector:active {
+    display: inline-block;
+  }
 }
-<div class=\\"div-37d76664\\">Hello world</div>"
+<div class=\\"div-8f6e8a44\\">Hello world</div>"
 `;
 
 exports[`Marko > jsx > Typescript Test > onInit & onMount 1`] = `

--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -1682,24 +1682,30 @@ exports[`Marko > jsx > Javascript Test > nestedStyles 1`] = `
 "class {}
 
 style { 
-  .div-6e6ae19d {
+  .div-37d76664 {
     display: flex;
     --bar: red;
     color: var(--bar);
   }
   @media (max-width: env(--mobile)) {
-    .div-6e6ae19d {
+    .div-37d76664 {
       display: block;
     }
   }
-  .div-6e6ae19d:hover {
+  .div-37d76664:hover {
     display: flex;
   }
-  .div-6e6ae19d .nested-selector {
+  .div-37d76664:active {
+    display: inline;
+  }
+  .div-37d76664 .nested-selector {
     display: grid;
   }
+  .div-37d76664 .nested-selector:hover {
+    display: block;
+  }
 }
-<div class=\\"div-6e6ae19d\\">Hello world</div>"
+<div class=\\"div-37d76664\\">Hello world</div>"
 `;
 
 exports[`Marko > jsx > Javascript Test > onInit & onMount 1`] = `
@@ -3925,24 +3931,30 @@ exports[`Marko > jsx > Typescript Test > nestedStyles 1`] = `
 "class {}
 
 style { 
-  .div-6e6ae19d {
+  .div-37d76664 {
     display: flex;
     --bar: red;
     color: var(--bar);
   }
   @media (max-width: env(--mobile)) {
-    .div-6e6ae19d {
+    .div-37d76664 {
       display: block;
     }
   }
-  .div-6e6ae19d:hover {
+  .div-37d76664:hover {
     display: flex;
   }
-  .div-6e6ae19d .nested-selector {
+  .div-37d76664:active {
+    display: inline;
+  }
+  .div-37d76664 .nested-selector {
     display: grid;
   }
+  .div-37d76664 .nested-selector:hover {
+    display: block;
+  }
 }
-<div class=\\"div-6e6ae19d\\">Hello world</div>"
+<div class=\\"div-37d76664\\">Hello world</div>"
 `;
 
 exports[`Marko > jsx > Typescript Test > onInit & onMount 1`] = `

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -8385,8 +8385,14 @@ exports[`Parse JSX > Javascript > nestedStyles 1`] = `
   '&:hover': {
     display: 'flex'
   },
+  ':active': {
+    display: 'inline'
+  },
   '.nested-selector': {
     display: 'grid'
+  },
+  '.nested-selector:hover': {
+    display: 'block'
   }
 }",
           "type": "single",
@@ -20220,8 +20226,14 @@ exports[`Parse JSX > Typescript > nestedStyles 1`] = `
   '&:hover': {
     display: 'flex'
   },
+  ':active': {
+    display: 'inline'
+  },
   '.nested-selector': {
     display: 'grid'
+  },
+  '.nested-selector:hover': {
+    display: 'block'
   }
 }",
           "type": "single",

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -8393,6 +8393,9 @@ exports[`Parse JSX > Javascript > nestedStyles 1`] = `
   },
   '.nested-selector:hover': {
     display: 'block'
+  },
+  '&.nested-selector:active': {
+    display: 'inline-block'
   }
 }",
           "type": "single",
@@ -20234,6 +20237,9 @@ exports[`Parse JSX > Typescript > nestedStyles 1`] = `
   },
   '.nested-selector:hover': {
     display: 'block'
+  },
+  '&.nested-selector:active': {
+    display: 'inline-block'
   }
 }",
           "type": "single",

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -2203,8 +2203,14 @@ function NestedStyles(props) {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </Fragment>
@@ -5615,8 +5621,14 @@ function NestedStyles(props: any) {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </Fragment>

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -2212,6 +2212,9 @@ function NestedStyles(props) {
         .div .nested-selector:hover {
           display: block;
         }
+        .div.nested-selector:active {
+          display: inline-block;
+        }
       \`}</style>
     </Fragment>
   );
@@ -5629,6 +5632,9 @@ function NestedStyles(props: any) {
         }
         .div .nested-selector:hover {
           display: block;
+        }
+        .div.nested-selector:active {
+          display: inline-block;
         }
       \`}</style>
     </Fragment>

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -3859,8 +3859,14 @@ export const STYLES = \`
 .div-NestedStyles:hover {
   display: flex;
 }
+.div-NestedStyles:active {
+  display: inline;
+}
 .div-NestedStyles .nested-selector {
   display: grid;
+}
+.div-NestedStyles .nested-selector:hover {
+  display: block;
 }
 \`;
 "
@@ -7082,8 +7088,14 @@ export const STYLES = \`
 .div-NestedStyles:hover {
   display: flex;
 }
+.div-NestedStyles:active {
+  display: inline;
+}
 .div-NestedStyles .nested-selector {
   display: grid;
+}
+.div-NestedStyles .nested-selector:hover {
+  display: block;
 }
 \`;
 "

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -3868,6 +3868,9 @@ export const STYLES = \`
 .div-NestedStyles .nested-selector:hover {
   display: block;
 }
+.div-NestedStyles.nested-selector:active {
+  display: inline-block;
+}
 \`;
 "
 `;
@@ -7096,6 +7099,9 @@ export const STYLES = \`
 }
 .div-NestedStyles .nested-selector:hover {
   display: block;
+}
+.div-NestedStyles.nested-selector:active {
+  display: inline-block;
 }
 \`;
 "

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -2526,7 +2526,9 @@ const styles = StyleSheet.create({
     \\"--bar\\": \\"red\\",
     color: \\"var(--bar)\\",
     \\"&:hover\\": { display: \\"flex\\" },
+    \\":active\\": { display: \\"inline\\" },
     \\".nested-selector\\": { display: \\"grid\\" },
+    \\".nested-selector:hover\\": { display: \\"block\\" },
   },
 });
 
@@ -6448,7 +6450,9 @@ const styles = StyleSheet.create({
     \\"--bar\\": \\"red\\",
     color: \\"var(--bar)\\",
     \\"&:hover\\": { display: \\"flex\\" },
+    \\":active\\": { display: \\"inline\\" },
     \\".nested-selector\\": { display: \\"grid\\" },
+    \\".nested-selector:hover\\": { display: \\"block\\" },
   },
 });
 

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -2529,6 +2529,7 @@ const styles = StyleSheet.create({
     \\":active\\": { display: \\"inline\\" },
     \\".nested-selector\\": { display: \\"grid\\" },
     \\".nested-selector:hover\\": { display: \\"block\\" },
+    \\"&.nested-selector:active\\": { display: \\"inline-block\\" },
   },
 });
 
@@ -6453,6 +6454,7 @@ const styles = StyleSheet.create({
     \\":active\\": { display: \\"inline\\" },
     \\".nested-selector\\": { display: \\"grid\\" },
     \\".nested-selector:hover\\": { display: \\"block\\" },
+    \\"&.nested-selector:active\\": { display: \\"inline-block\\" },
   },
 });
 

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -2152,6 +2152,9 @@ function NestedStyles(props) {
         .div .nested-selector:hover {
           display: block;
         }
+        .div.nested-selector:active {
+          display: inline-block;
+        }
       \`}</style>
     </>
   );
@@ -5480,6 +5483,9 @@ function NestedStyles(props: any) {
         }
         .div .nested-selector:hover {
           display: block;
+        }
+        .div.nested-selector:active {
+          display: inline-block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -2143,8 +2143,14 @@ function NestedStyles(props) {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>
@@ -5466,8 +5472,14 @@ function NestedStyles(props: any) {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -1957,15 +1957,19 @@ function NestedStyles(props) {
 
   return (
     <>
-      <div className=\\"div-4f697875\\">Hello world</div>
-      <style>{\`.div-4f697875 {
+      <div className=\\"div-936a9b34\\">Hello world</div>
+      <style>{\`.div-936a9b34 {
   display: flex;
   --bar: red;
   color: var(--bar);
-}@media (max-width: env(--mobile)) { .div-4f697875 {   display: block; } }.div-4f697875:hover {
+}@media (max-width: env(--mobile)) { .div-936a9b34 {   display: block; } }.div-936a9b34:hover {
   display: flex;
-}.div-4f697875 .nested-selector {
+}.div-936a9b34:active {
+  display: inline;
+}.div-936a9b34 .nested-selector {
   display: grid;
+}.div-936a9b34 .nested-selector:hover {
+  display: block;
 }\`}</style>
     </>
   );
@@ -5113,15 +5117,19 @@ function NestedStyles(props: any) {
 
   return (
     <>
-      <div className=\\"div-4f697875\\">Hello world</div>
-      <style>{\`.div-4f697875 {
+      <div className=\\"div-936a9b34\\">Hello world</div>
+      <style>{\`.div-936a9b34 {
   display: flex;
   --bar: red;
   color: var(--bar);
-}@media (max-width: env(--mobile)) { .div-4f697875 {   display: block; } }.div-4f697875:hover {
+}@media (max-width: env(--mobile)) { .div-936a9b34 {   display: block; } }.div-936a9b34:hover {
   display: flex;
-}.div-4f697875 .nested-selector {
+}.div-936a9b34:active {
+  display: inline;
+}.div-936a9b34 .nested-selector {
   display: grid;
+}.div-936a9b34 .nested-selector:hover {
+  display: block;
 }\`}</style>
     </>
   );

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -1957,19 +1957,21 @@ function NestedStyles(props) {
 
   return (
     <>
-      <div className=\\"div-936a9b34\\">Hello world</div>
-      <style>{\`.div-936a9b34 {
+      <div className=\\"div-1322de04\\">Hello world</div>
+      <style>{\`.div-1322de04 {
   display: flex;
   --bar: red;
   color: var(--bar);
-}@media (max-width: env(--mobile)) { .div-936a9b34 {   display: block; } }.div-936a9b34:hover {
+}@media (max-width: env(--mobile)) { .div-1322de04 {   display: block; } }.div-1322de04:hover {
   display: flex;
-}.div-936a9b34:active {
+}.div-1322de04:active {
   display: inline;
-}.div-936a9b34 .nested-selector {
+}.div-1322de04 .nested-selector {
   display: grid;
-}.div-936a9b34 .nested-selector:hover {
+}.div-1322de04 .nested-selector:hover {
   display: block;
+}.div-1322de04.nested-selector:active {
+  display: inline-block;
 }\`}</style>
     </>
   );
@@ -5117,19 +5119,21 @@ function NestedStyles(props: any) {
 
   return (
     <>
-      <div className=\\"div-936a9b34\\">Hello world</div>
-      <style>{\`.div-936a9b34 {
+      <div className=\\"div-1322de04\\">Hello world</div>
+      <style>{\`.div-1322de04 {
   display: flex;
   --bar: red;
   color: var(--bar);
-}@media (max-width: env(--mobile)) { .div-936a9b34 {   display: block; } }.div-936a9b34:hover {
+}@media (max-width: env(--mobile)) { .div-1322de04 {   display: block; } }.div-1322de04:hover {
   display: flex;
-}.div-936a9b34:active {
+}.div-1322de04:active {
   display: inline;
-}.div-936a9b34 .nested-selector {
+}.div-1322de04 .nested-selector {
   display: grid;
-}.div-936a9b34 .nested-selector:hover {
+}.div-1322de04 .nested-selector:hover {
   display: block;
+}.div-1322de04.nested-selector:active {
+  display: inline-block;
 }\`}</style>
     </>
   );

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -4327,6 +4327,9 @@ function NestedStyles(props) {
         \\".nested-selector:hover\\": {
           display: \\"block\\",
         },
+        \\"&.nested-selector:active\\": {
+          display: \\"inline-block\\",
+        },
       })}
     >
       Hello world
@@ -4344,29 +4347,32 @@ exports[`Solid > jsx > Javascript Test > nestedStyles 2`] = `
 function NestedStyles(props) {
   return (
     <>
-      <div class=\\"div-37d76664\\">Hello world</div>
+      <div class=\\"div-8f6e8a44\\">Hello world</div>
       <style jsx>{\`
-        .div-37d76664 {
+        .div-8f6e8a44 {
           display: flex;
           --bar: red;
           color: var(--bar);
         }
         @media (max-width: env(--mobile)) {
-          .div-37d76664 {
+          .div-8f6e8a44 {
             display: block;
           }
         }
-        .div-37d76664:hover {
+        .div-8f6e8a44:hover {
           display: flex;
         }
-        .div-37d76664:active {
+        .div-8f6e8a44:active {
           display: inline;
         }
-        .div-37d76664 .nested-selector {
+        .div-8f6e8a44 .nested-selector {
           display: grid;
         }
-        .div-37d76664 .nested-selector:hover {
+        .div-8f6e8a44 .nested-selector:hover {
           display: block;
+        }
+        .div-8f6e8a44.nested-selector:active {
+          display: inline-block;
         }
       \`}</style>
     </>
@@ -10951,6 +10957,9 @@ function NestedStyles(props: any) {
         \\".nested-selector:hover\\": {
           display: \\"block\\",
         },
+        \\"&.nested-selector:active\\": {
+          display: \\"inline-block\\",
+        },
       })}
     >
       Hello world
@@ -10968,29 +10977,32 @@ exports[`Solid > jsx > Typescript Test > nestedStyles 2`] = `
 function NestedStyles(props: any) {
   return (
     <>
-      <div class=\\"div-37d76664\\">Hello world</div>
+      <div class=\\"div-8f6e8a44\\">Hello world</div>
       <style jsx>{\`
-        .div-37d76664 {
+        .div-8f6e8a44 {
           display: flex;
           --bar: red;
           color: var(--bar);
         }
         @media (max-width: env(--mobile)) {
-          .div-37d76664 {
+          .div-8f6e8a44 {
             display: block;
           }
         }
-        .div-37d76664:hover {
+        .div-8f6e8a44:hover {
           display: flex;
         }
-        .div-37d76664:active {
+        .div-8f6e8a44:active {
           display: inline;
         }
-        .div-37d76664 .nested-selector {
+        .div-8f6e8a44 .nested-selector {
           display: grid;
         }
-        .div-37d76664 .nested-selector:hover {
+        .div-8f6e8a44 .nested-selector:hover {
           display: block;
+        }
+        .div-8f6e8a44.nested-selector:active {
+          display: inline-block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -4318,8 +4318,14 @@ function NestedStyles(props) {
         \\"&:hover\\": {
           display: \\"flex\\",
         },
+        \\":active\\": {
+          display: \\"inline\\",
+        },
         \\".nested-selector\\": {
           display: \\"grid\\",
+        },
+        \\".nested-selector:hover\\": {
+          display: \\"block\\",
         },
       })}
     >
@@ -4338,23 +4344,29 @@ exports[`Solid > jsx > Javascript Test > nestedStyles 2`] = `
 function NestedStyles(props) {
   return (
     <>
-      <div class=\\"div-6e6ae19d\\">Hello world</div>
+      <div class=\\"div-37d76664\\">Hello world</div>
       <style jsx>{\`
-        .div-6e6ae19d {
+        .div-37d76664 {
           display: flex;
           --bar: red;
           color: var(--bar);
         }
         @media (max-width: env(--mobile)) {
-          .div-6e6ae19d {
+          .div-37d76664 {
             display: block;
           }
         }
-        .div-6e6ae19d:hover {
+        .div-37d76664:hover {
           display: flex;
         }
-        .div-6e6ae19d .nested-selector {
+        .div-37d76664:active {
+          display: inline;
+        }
+        .div-37d76664 .nested-selector {
           display: grid;
+        }
+        .div-37d76664 .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>
@@ -10930,8 +10942,14 @@ function NestedStyles(props: any) {
         \\"&:hover\\": {
           display: \\"flex\\",
         },
+        \\":active\\": {
+          display: \\"inline\\",
+        },
         \\".nested-selector\\": {
           display: \\"grid\\",
+        },
+        \\".nested-selector:hover\\": {
+          display: \\"block\\",
         },
       })}
     >
@@ -10950,23 +10968,29 @@ exports[`Solid > jsx > Typescript Test > nestedStyles 2`] = `
 function NestedStyles(props: any) {
   return (
     <>
-      <div class=\\"div-6e6ae19d\\">Hello world</div>
+      <div class=\\"div-37d76664\\">Hello world</div>
       <style jsx>{\`
-        .div-6e6ae19d {
+        .div-37d76664 {
           display: flex;
           --bar: red;
           color: var(--bar);
         }
         @media (max-width: env(--mobile)) {
-          .div-6e6ae19d {
+          .div-37d76664 {
             display: block;
           }
         }
-        .div-6e6ae19d:hover {
+        .div-37d76664:hover {
           display: flex;
         }
-        .div-6e6ae19d .nested-selector {
+        .div-37d76664:active {
+          display: inline;
+        }
+        .div-37d76664 .nested-selector {
           display: grid;
+        }
+        .div-37d76664 .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2209,8 +2209,14 @@ exports[`Stencil > jsx > Javascript Test > nestedStyles 1`] = `
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
 \`,
 })
@@ -5075,8 +5081,14 @@ exports[`Stencil > jsx > Typescript Test > nestedStyles 1`] = `
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
 \`,
 })

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2218,6 +2218,9 @@ exports[`Stencil > jsx > Javascript Test > nestedStyles 1`] = `
         .div .nested-selector:hover {
           display: block;
         }
+        .div.nested-selector:active {
+          display: inline-block;
+        }
 \`,
 })
 export default class NestedStyles {
@@ -5089,6 +5092,9 @@ exports[`Stencil > jsx > Typescript Test > nestedStyles 1`] = `
         }
         .div .nested-selector:hover {
           display: block;
+        }
+        .div.nested-selector:active {
+          display: inline-block;
         }
 \`,
 })

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1862,8 +1862,14 @@ exports[`Svelte > jsx > Javascript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>"
 `;
@@ -4793,8 +4799,14 @@ exports[`Svelte > jsx > Typescript Test > nestedStyles 1`] = `
   .div:hover {
     display: flex;
   }
+  .div:active {
+    display: inline;
+  }
   .div .nested-selector {
     display: grid;
+  }
+  .div .nested-selector:hover {
+    display: block;
   }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1871,6 +1871,9 @@ exports[`Svelte > jsx > Javascript Test > nestedStyles 1`] = `
   .div .nested-selector:hover {
     display: block;
   }
+  .div.nested-selector:active {
+    display: inline-block;
+  }
 </style>"
 `;
 
@@ -4807,6 +4810,9 @@ exports[`Svelte > jsx > Typescript Test > nestedStyles 1`] = `
   }
   .div .nested-selector:hover {
     display: block;
+  }
+  .div.nested-selector:active {
+    display: inline-block;
   }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -2179,6 +2179,9 @@ function NestedStyles(props) {
         .view .nested-selector:hover {
           display: block;
         }
+        .view.nested-selector:active {
+          display: inline-block;
+        }
       \`}</style>
     </>
   );
@@ -5584,6 +5587,9 @@ function NestedStyles(props: any) {
         }
         .view .nested-selector:hover {
           display: block;
+        }
+        .view.nested-selector:active {
+          display: inline-block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -2170,8 +2170,14 @@ function NestedStyles(props) {
         .view:hover {
           display: flex;
         }
+        .view:active {
+          display: inline;
+        }
         .view .nested-selector {
           display: grid;
+        }
+        .view .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>
@@ -5570,8 +5576,14 @@ function NestedStyles(props: any) {
         .view:hover {
           display: flex;
         }
+        .view:active {
+          display: inline;
+        }
         .view .nested-selector {
           display: grid;
+        }
+        .view .nested-selector:hover {
+          display: block;
         }
       \`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -2065,8 +2065,14 @@ exports[`Vue > jsx > Javascript Test > nestedStyles 1`] = `
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>"
 `;
@@ -5082,8 +5088,14 @@ exports[`Vue > jsx > Typescript Test > nestedStyles 1`] = `
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -2074,6 +2074,9 @@ exports[`Vue > jsx > Javascript Test > nestedStyles 1`] = `
 .div .nested-selector:hover {
   display: block;
 }
+.div.nested-selector:active {
+  display: inline-block;
+}
 </style>"
 `;
 
@@ -5096,6 +5099,9 @@ exports[`Vue > jsx > Typescript Test > nestedStyles 1`] = `
 }
 .div .nested-selector:hover {
   display: block;
+}
+.div.nested-selector:active {
+  display: inline-block;
 }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -2346,8 +2346,14 @@ export default {
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>"
 `;
@@ -5835,8 +5841,14 @@ export default {
 .div:hover {
   display: flex;
 }
+.div:active {
+  display: inline;
+}
 .div .nested-selector {
   display: grid;
+}
+.div .nested-selector:hover {
+  display: block;
 }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -2355,6 +2355,9 @@ export default {
 .div .nested-selector:hover {
   display: block;
 }
+.div.nested-selector:active {
+  display: inline-block;
+}
 </style>"
 `;
 
@@ -5849,6 +5852,9 @@ export default {
 }
 .div .nested-selector:hover {
   display: block;
+}
+.div.nested-selector:active {
+  display: inline-block;
 }
 </style>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -9228,6 +9228,9 @@ class NestedStyles extends HTMLElement {
         .div .nested-selector:hover {
           display: block;
         }
+        .div.nested-selector:active {
+          display: inline-block;
+        }
       </style>\`;
     this.pendingUpdate = true;
 
@@ -21766,6 +21769,9 @@ class NestedStyles extends HTMLElement {
         }
         .div .nested-selector:hover {
           display: block;
+        }
+        .div.nested-selector:active {
+          display: inline-block;
         }
       </style>\`;
     this.pendingUpdate = true;

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -9219,8 +9219,14 @@ class NestedStyles extends HTMLElement {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       </style>\`;
     this.pendingUpdate = true;
@@ -21752,8 +21758,14 @@ class NestedStyles extends HTMLElement {
         .div:hover {
           display: flex;
         }
+        .div:active {
+          display: inline;
+        }
         .div .nested-selector {
           display: grid;
+        }
+        .div .nested-selector:hover {
+          display: block;
         }
       </style>\`;
     this.pendingUpdate = true;

--- a/packages/core/src/__tests__/data/nested-styles.raw.tsx
+++ b/packages/core/src/__tests__/data/nested-styles.raw.tsx
@@ -11,8 +11,14 @@ export default function NestedStyles() {
         '&:hover': {
           display: 'flex',
         },
+        ':active': {
+          display: 'inline',
+        },
         '.nested-selector': {
           display: 'grid',
+        },
+        '.nested-selector:hover': {
+          display: 'block',
         },
       }}
     >

--- a/packages/core/src/__tests__/data/nested-styles.raw.tsx
+++ b/packages/core/src/__tests__/data/nested-styles.raw.tsx
@@ -20,6 +20,9 @@ export default function NestedStyles() {
         '.nested-selector:hover': {
           display: 'block',
         },
+        '&.nested-selector:active': {
+          display: 'inline-block',
+        },
       }}
     >
       Hello world

--- a/packages/core/src/helpers/styles/collect-css.ts
+++ b/packages/core/src/helpers/styles/collect-css.ts
@@ -1,8 +1,9 @@
+import hash from 'object-hash';
 import traverse from 'traverse';
 import { MitosisComponent } from '../../types/mitosis-component';
+import { MitosisNode } from '../../types/mitosis-node';
 import { dashCase } from '../dash-case';
 import { isMitosisNode } from '../is-mitosis-node';
-import hash from 'object-hash';
 import {
   ClassStyleMap,
   getNestedSelectors,
@@ -11,7 +12,6 @@ import {
   parseCssObject,
   styleMapToCss,
 } from './helpers';
-import { MitosisNode } from '../../types/mitosis-node';
 
 type CollectStyleOptions = {
   prefix?: string;
@@ -91,16 +91,27 @@ const classStyleMapToCss = (map: ClassStyleMap): string => {
   for (const key in map) {
     const styles = getStylesOnly(map[key]);
     str += `.${key} {\n${styleMapToCss(styles)}\n}`;
+
     const nestedSelectors = getNestedSelectors(map[key]);
     for (const nestedSelector in nestedSelectors) {
       const value = nestedSelectors[nestedSelector] as any;
+
       if (nestedSelector.startsWith('@')) {
         str += `${nestedSelector} { .${key} { ${styleMapToCss(value)} } }`;
       } else {
-        const useSelector = nestedSelector.includes('&')
-          ? nestedSelector.replace(/&/g, `.${key}`)
-          : `.${key} ${nestedSelector}`;
-        str += `${useSelector} {\n${styleMapToCss(value)}\n}`;
+        const getSelector = (nestedSelector: string) => {
+          if (nestedSelector.startsWith(':')) {
+            return `.${key}${nestedSelector}`;
+          }
+
+          if (nestedSelector.includes('&')) {
+            return nestedSelector.replace(/&/g, `.${key}`);
+          }
+
+          return `.${key} ${nestedSelector}`;
+        };
+
+        str += `${getSelector(nestedSelector)} {\n${styleMapToCss(value)}\n}`;
       }
     }
   }


### PR DESCRIPTION
## Description

This PR fixes the unnecessary whitespace added to the output CSS when not using `&` for pseudo-classes and selectors.

Closes #1125