### PR TITLE
fix: add missing  svg attribute xmlns

### DIFF
--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -1566,6 +1566,7 @@ export declare namespace JSX {
       FitToViewBoxSVGAttributes,
       ZoomAndPanSVGAttributes,
       Pick<PresentationSVGAttributes, 'display' | 'visibility'> {
+    xmlns?: string;
     version?: string;
     'base-profile'?: string;
     x?: number | string;


### PR DESCRIPTION
## Description

Add a short description of:
- what changes you made:  add missing  svg attribute `xmlns`
