### PR TITLE
fix(vue): add classStringToObject types if typescript

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -3406,8 +3406,8 @@ const cls = computed(() => {
 function show() {
   useSlots().content ? 1 : \\"\\";
 }
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -3492,8 +3492,8 @@ function findAndRunScripts() {
     }
   }
 }
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -3578,8 +3578,8 @@ function findAndRunScripts() {
     }
   }
 }
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -4016,8 +4016,8 @@ function isBrowser() {
     typeof window !== \\"undefined\\" && window.navigator.product != \\"ReactNative\\"
   );
 }
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -4141,8 +4141,8 @@ export interface RawTextProps {
 
 const props = defineProps<RawTextProps>();
 
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -4395,8 +4395,8 @@ function kebabCaseValue() {
 function snakeCaseValue() {
   return snakeCase(\\"testThis\\");
 }
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -4738,8 +4738,8 @@ type Props = {
 
 const bindings = ref(\\"a binding\\");
 
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -4767,8 +4767,8 @@ const styleState = ref({
   color: \\"red\\",
 });
 
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }
@@ -6369,8 +6369,8 @@ import { ref } from \\"vue\\";
 const props = withDefaults(defineProps<undefined>(), { disabled: undefined });
 const focus = ref(true);
 
-function _classStringToObject(str) {
-  const obj = {};
+function _classStringToObject(str: string) {
+  const obj: Record<string, boolean> = {};
   if (typeof str !== \\"string\\") {
     return obj;
   }

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -4122,8 +4122,8 @@ export default defineComponent({
     show() {
       this.$slots.content ? 1 : \\"\\";
     },
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -4214,8 +4214,8 @@ export default defineComponent({
         }
       }
     },
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -4306,8 +4306,8 @@ export default defineComponent({
         }
       }
     },
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -4782,8 +4782,8 @@ export default defineComponent({
         window.navigator.product != \\"ReactNative\\"
       );
     },
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -4944,8 +4944,8 @@ export default defineComponent({
   props: [\\"attributes\\", \\"text\\"],
 
   methods: {
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -5247,8 +5247,8 @@ export default defineComponent({
     snakeCaseValue() {
       return snakeCase(\\"testThis\\");
     },
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -5688,8 +5688,8 @@ export default defineComponent({
   },
 
   methods: {
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -5727,8 +5727,8 @@ export default defineComponent({
   },
 
   methods: {
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }
@@ -7703,8 +7703,8 @@ export default defineComponent({
   },
 
   methods: {
-    _classStringToObject(str) {
-      const obj = {};
+    _classStringToObject(str: string) {
+      const obj: Record<string, boolean> = {};
       if (typeof str !== \\"string\\") {
         return obj;
       }

--- a/packages/core/src/generators/vue/compositionApi.ts
+++ b/packages/core/src/generators/vue/compositionApi.ts
@@ -17,10 +17,11 @@ const getCompositionPropDefinition = ({
   component: MitosisComponent;
   props: string[];
 }) => {
+  const isTs = options.typescript
   let str = 'const props = ';
 
   if (component.defaultProps) {
-    const generic = options.typescript ? `<${component.propsTypeRef}>` : '';
+    const generic = isTs ? `<${component.propsTypeRef}>` : '';
     const defalutPropsString = props
       .map((prop) => {
         const value = component.defaultProps!.hasOwnProperty(prop)
@@ -30,7 +31,7 @@ const getCompositionPropDefinition = ({
       })
       .join(',');
     str += `withDefaults(defineProps${generic}(), {${defalutPropsString}})`;
-  } else if (options.typescript && component.propsTypeRef && component.propsTypeRef !== 'any') {
+  } else if (isTs && component.propsTypeRef && component.propsTypeRef !== 'any') {
     str += `defineProps<${component.propsTypeRef}>()`;
   } else {
     str += `defineProps(${json5.stringify(props)})`;
@@ -46,13 +47,14 @@ export function generateCompositionApiScript(
   onUpdateWithDeps: extendedHook[],
   onUpdateWithoutDeps: extendedHook[],
 ) {
+  const isTs = options.typescript
   let refs = getStateObjectStringFromComponent(component, {
     data: true,
     functions: false,
     getters: false,
     format: 'variables',
     valueMapper: (code, _, typeParameter) =>
-      options.typescript && typeParameter ? `ref<${typeParameter}>(${code})` : `ref(${code})`,
+      isTs && typeParameter ? `ref<${typeParameter}>(${code})` : `ref(${code})`,
     keyPrefix: 'const',
   });
 
@@ -64,8 +66,8 @@ export function generateCompositionApiScript(
   });
 
   if (template.includes('_classStringToObject')) {
-    methods += ` function _classStringToObject(str) {
-      const obj = {};
+    methods += ` function _classStringToObject(str${isTs ? ': string' : ''}) {
+      const obj${isTs ? ': Record<string, boolean>' : ''} = {};
       if (typeof str !== 'string') { return obj }
       const classNames = str.trim().split(/\\s+/);
       for (const name of classNames) {
@@ -98,7 +100,7 @@ export function generateCompositionApiScript(
 
     ${Object.keys(component.refs)
       ?.map((key) => {
-        if (options.typescript) {
+        if (isTs) {
           return `const ${key} = ref<${component.refs[key].typeParameter}>()`;
         } else {
           return `const ${key} = ref(null)`;

--- a/packages/core/src/generators/vue/compositionApi.ts
+++ b/packages/core/src/generators/vue/compositionApi.ts
@@ -17,7 +17,7 @@ const getCompositionPropDefinition = ({
   component: MitosisComponent;
   props: string[];
 }) => {
-  const isTs = options.typescript
+  const isTs = options.typescript;
   let str = 'const props = ';
 
   if (component.defaultProps) {
@@ -47,7 +47,7 @@ export function generateCompositionApiScript(
   onUpdateWithDeps: extendedHook[],
   onUpdateWithoutDeps: extendedHook[],
 ) {
-  const isTs = options.typescript
+  const isTs = options.typescript;
   let refs = getStateObjectStringFromComponent(component, {
     data: true,
     functions: false,

--- a/packages/core/src/generators/vue/optionsApi.ts
+++ b/packages/core/src/generators/vue/optionsApi.ts
@@ -75,6 +75,7 @@ export function generateOptionsApiScript(
   const { exports: localExports } = component;
   const localVarAsData: string[] = [];
   const localVarAsFunc: string[] = [];
+  const isTs = options.typescript
   if (localExports) {
     Object.keys(localExports).forEach((key) => {
       if (localExports[key].usedInLocal) {
@@ -120,8 +121,8 @@ export function generateOptionsApiScript(
   if (includeClassMapHelper) {
     functionsString = functionsString.replace(
       /}\s*$/,
-      `_classStringToObject(str) {
-        const obj = {};
+      `_classStringToObject(str${isTs ? ': string' : ''}) {
+        const obj${isTs ? ': Record<string, boolean>' : ''} = {};
         if (typeof str !== 'string') { return obj }
         const classNames = str.trim().split(/\\s+/);
         for (const name of classNames) {

--- a/packages/core/src/generators/vue/optionsApi.ts
+++ b/packages/core/src/generators/vue/optionsApi.ts
@@ -75,7 +75,7 @@ export function generateOptionsApiScript(
   const { exports: localExports } = component;
   const localVarAsData: string[] = [];
   const localVarAsFunc: string[] = [];
-  const isTs = options.typescript
+  const isTs = options.typescript;
   if (localExports) {
     Object.keys(localExports).forEach((key) => {
       if (localExports[key].usedInLocal) {


### PR DESCRIPTION
## Description

Add a short description of:
- what changes you made,   add classStringToObject types for better ts check.


js
```js
_classStringToObject(str) {
  const obj = {};
  if (typeof str !== "string") {
    return obj;
  }
  const classNames = str.trim().split(/\s+/);
  for (const name of classNames) {
    obj[name] = true;
  }
  return obj;
},
```

ts

```ts
_classStringToObject(str: string) {
  const obj: Record<string, boolean> = {};
  if (typeof str !== "string") {
    return obj;
  }
  const classNames = str.trim().split(/\s+/);
  for (const name of classNames) {
    obj[name] = true;
  }
  return obj;
},
```