### PR TITLE
Split Preact Rendering to Dedicated Renderer

### DIFF
--- a/packages/cli/src/build/helpers/context.ts
+++ b/packages/cli/src/build/helpers/context.ts
@@ -8,6 +8,7 @@ import {
   MitosisConfig,
   parseContext,
   Target,
+  contextToPreact,
 } from '@builder.io/mitosis';
 import { readFile } from 'fs-extra';
 import { upperFirst, camelCase, last } from 'lodash';
@@ -37,8 +38,11 @@ export const generateContextFile = async ({
         return contextToVue(options.options[target])({ context });
       case 'solid':
         return contextToSolid()({ context });
-      case 'react':
       case 'preact':
+        return contextToPreact({ typescript: checkShouldOutputTypeScript({ options, target }) })({
+          context,
+        });
+      case 'react':
       case 'reactNative':
         return contextToReact({ typescript: checkShouldOutputTypeScript({ options, target }) })({
           context,

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -612,6 +612,12 @@ function ContentSlotJsxCode(props) {
   );
 }
 
+ContentSlotJsxCode.defaultProps = {
+  content: \\"\\",
+  slotReference: undefined,
+  slotContent: \\"{props.content}\\",
+};
+
 export default ContentSlotJsxCode;
 "
 `;
@@ -1298,6 +1304,10 @@ function SlotCode(props) {
   return <div>{props.children}</div>;
 }
 
+SlotCode.defaultProps = {
+  children: <div className=\\"default-slot\\">Default content</div>,
+};
+
 export default SlotCode;
 "
 `;
@@ -1351,6 +1361,8 @@ function SlotCode(props) {
     </div>
   );
 }
+
+SlotCode.defaultProps = { slotLeft: \\"Default left\\", children: \\"Default Child\\" };
 
 export default SlotCode;
 "
@@ -1943,6 +1955,15 @@ function Button(props) {
   );
 }
 
+Button.defaultProps = {
+  text: \\"default text\\",
+  link: \\"https://builder.io/\\",
+  openLinkInNewTab: false,
+  onClick: () => {
+    console.log(\\"hi\\");
+  },
+};
+
 export default Button;
 "
 `;
@@ -1980,6 +2001,13 @@ function Button(props) {
     </div>
   );
 }
+
+Button.defaultProps = {
+  text: \\"default text\\",
+  link: \\"https://builder.io/\\",
+  openLinkInNewTab: false,
+  onClick: () => {},
+};
 
 export default Button;
 "
@@ -3773,6 +3801,12 @@ function ContentSlotJsxCode(props: Props) {
   );
 }
 
+ContentSlotJsxCode.defaultProps = {
+  content: \\"\\",
+  slotReference: undefined,
+  slotContent: \\"{props.content}\\",
+};
+
 export default ContentSlotJsxCode;
 "
 `;
@@ -4571,6 +4605,10 @@ function SlotCode(props: Props) {
   return <div>{props.children}</div>;
 }
 
+SlotCode.defaultProps = {
+  children: <div className=\\"default-slot\\">Default content</div>,
+};
+
 export default SlotCode;
 "
 `;
@@ -4636,6 +4674,8 @@ function SlotCode(props: Props) {
     </div>
   );
 }
+
+SlotCode.defaultProps = { slotLeft: \\"Default left\\", children: \\"Default Child\\" };
 
 export default SlotCode;
 "
@@ -5310,6 +5350,15 @@ function Button(props: ButtonProps) {
   );
 }
 
+Button.defaultProps = {
+  text: \\"default text\\",
+  link: \\"https://builder.io/\\",
+  openLinkInNewTab: false,
+  onClick: () => {
+    console.log(\\"hi\\");
+  },
+};
+
 export default Button;
 "
 `;
@@ -5355,6 +5404,13 @@ function Button(props: ButtonProps) {
     </div>
   );
 }
+
+Button.defaultProps = {
+  text: \\"default text\\",
+  link: \\"https://builder.io/\\",
+  openLinkInNewTab: false,
+  onClick: () => {},
+};
 
 export default Button;
 "
@@ -6689,6 +6745,8 @@ function MyComponent(props) {
   );
 }
 
+MyComponent.defaultProps = {};
+
 export default MyComponent;
 "
 `;
@@ -6928,6 +6986,11 @@ function MyComponent(props) {
   );
 }
 
+MyComponent.defaultProps = {
+  children: \\"default\\",
+  slotTest: <div>default</div>,
+};
+
 export default MyComponent;
 "
 `;
@@ -7106,6 +7169,8 @@ function MyComponent(props: any) {
     />
   );
 }
+
+MyComponent.defaultProps = {};
 
 export default MyComponent;
 "
@@ -7345,6 +7410,11 @@ function MyComponent(props: any) {
     </div>
   );
 }
+
+MyComponent.defaultProps = {
+  children: \\"default\\",
+  slotTest: <div>default</div>,
+};
 
 export default MyComponent;
 "

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -612,12 +612,6 @@ function ContentSlotJsxCode(props) {
   );
 }
 
-ContentSlotJsxCode.defaultProps = {
-  content: \\"\\",
-  slotReference: undefined,
-  slotContent: \\"{props.content}\\",
-};
-
 export default ContentSlotJsxCode;
 "
 `;
@@ -1304,10 +1298,6 @@ function SlotCode(props) {
   return <div>{props.children}</div>;
 }
 
-SlotCode.defaultProps = {
-  children: <div className=\\"default-slot\\">Default content</div>,
-};
-
 export default SlotCode;
 "
 `;
@@ -1361,8 +1351,6 @@ function SlotCode(props) {
     </div>
   );
 }
-
-SlotCode.defaultProps = { slotLeft: \\"Default left\\", children: \\"Default Child\\" };
 
 export default SlotCode;
 "
@@ -1608,31 +1596,29 @@ export default MyComponent;
 exports[`Preact > jsx > Javascript Test > basicForwardRef 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
-import { useState, forwardRef } from \\"preact/hooks\\";
+import { useState } from \\"preact/hooks\\";
 
-const MyBasicForwardRefComponent = forwardRef(
-  function MyBasicForwardRefComponent(props, inputRef) {
-    const [name, setName] = useState(() => \\"PatrickJS\\");
+function MyBasicForwardRefComponent(props) {
+  const [name, setName] = useState(() => \\"PatrickJS\\");
 
-    return (
-      <Fragment>
-        <div>
-          <input
-            className=\\"input\\"
-            ref={inputRef}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <style jsx>{\`
-          .input {
-            color: red;
-          }
-        \`}</style>
-      </Fragment>
-    );
-  }
-);
+  return (
+    <Fragment>
+      <div>
+        <input
+          className=\\"input\\"
+          ref={props.inputRef}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+      <style jsx>{\`
+        .input {
+          color: red;
+        }
+      \`}</style>
+    </Fragment>
+  );
+}
 
 export default MyBasicForwardRefComponent;
 "
@@ -1641,31 +1627,29 @@ export default MyBasicForwardRefComponent;
 exports[`Preact > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
-import { useState, forwardRef } from \\"preact/hooks\\";
+import { useState } from \\"preact/hooks\\";
 
-const MyBasicForwardRefComponent = forwardRef(
-  function MyBasicForwardRefComponent(props, inputRef) {
-    const [name, setName] = useState(() => \\"PatrickJS\\");
+function MyBasicForwardRefComponent(props) {
+  const [name, setName] = useState(() => \\"PatrickJS\\");
 
-    return (
-      <Fragment>
-        <div>
-          <input
-            className=\\"input\\"
-            ref={inputRef}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <style jsx>{\`
-          .input {
-            color: red;
-          }
-        \`}</style>
-      </Fragment>
-    );
-  }
-);
+  return (
+    <Fragment>
+      <div>
+        <input
+          className=\\"input\\"
+          ref={props.inputRef}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+      <style jsx>{\`
+        .input {
+          color: red;
+        }
+      \`}</style>
+    </Fragment>
+  );
+}
 
 export default MyBasicForwardRefComponent;
 "
@@ -1959,15 +1943,6 @@ function Button(props) {
   );
 }
 
-Button.defaultProps = {
-  text: \\"default text\\",
-  link: \\"https://builder.io/\\",
-  openLinkInNewTab: false,
-  onClick: () => {
-    console.log(\\"hi\\");
-  },
-};
-
 export default Button;
 "
 `;
@@ -2005,13 +1980,6 @@ function Button(props) {
     </div>
   );
 }
-
-Button.defaultProps = {
-  text: \\"default text\\",
-  link: \\"https://builder.io/\\",
-  openLinkInNewTab: false,
-  onClick: () => {},
-};
 
 export default Button;
 "
@@ -2491,8 +2459,8 @@ function RenderBlock(props) {
     if (!ref) {
       // TODO: Public doc page with more info about this message
       console.warn(\`
-          Could not find a registered component named \\"\${componentName}\\".
-          If you registered it, is the file that registered it imported by the file that needs to render it?\`);
+       Could not find a registered component named \\"\${componentName}\\". 
+       If you registered it, is the file that registered it imported by the file that needs to render it?\`);
       return undefined;
     } else {
       return ref;
@@ -3141,7 +3109,6 @@ exports[`Preact > jsx > Typescript Test > AdvancedRef 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
-
 export interface Props {
   showInput: boolean;
 }
@@ -3209,7 +3176,6 @@ exports[`Preact > jsx > Typescript Test > Basic 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 export interface MyBasicComponentProps {
   id: string;
 }
@@ -3296,7 +3262,6 @@ exports[`Preact > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
-
 export interface Props {
   hi: string;
   bye: string;
@@ -3477,7 +3442,6 @@ exports[`Preact > jsx > Typescript Test > BasicRef 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
-
 export interface Props {
   showInput: boolean;
 }
@@ -3541,7 +3505,6 @@ exports[`Preact > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useRef } from \\"preact/hooks\\";
-
 export interface Props {
   showInput: boolean;
 }
@@ -3569,7 +3532,6 @@ exports[`Preact > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
-
 export interface Props {
   showInput: boolean;
 }
@@ -3766,7 +3728,6 @@ exports[`Preact > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 type Props = {
   [key: string]: string | JSX.Element;
 };
@@ -3812,12 +3773,6 @@ function ContentSlotJsxCode(props: Props) {
   );
 }
 
-ContentSlotJsxCode.defaultProps = {
-  content: \\"\\",
-  slotReference: undefined,
-  slotContent: \\"{props.content}\\",
-};
-
 export default ContentSlotJsxCode;
 "
 `;
@@ -3826,7 +3781,6 @@ exports[`Preact > jsx > Typescript Test > CustomCode 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
-
 export interface CustomCodeProps {
   code: string;
   replaceNodes?: boolean;
@@ -3903,7 +3857,6 @@ exports[`Preact > jsx > Typescript Test > Embed 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
-
 export interface CustomCodeProps {
   code: string;
   replaceNodes?: boolean;
@@ -3980,7 +3933,6 @@ exports[`Preact > jsx > Typescript Test > Form 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
-
 export interface FormProps {
   attributes?: any;
   name?: string;
@@ -4287,7 +4239,6 @@ exports[`Preact > jsx > Typescript Test > Image 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
-
 // TODO: AMP Support?
 export interface ImageProps {
   _class?: string;
@@ -4620,10 +4571,6 @@ function SlotCode(props: Props) {
   return <div>{props.children}</div>;
 }
 
-SlotCode.defaultProps = {
-  children: <div className=\\"default-slot\\">Default content</div>,
-};
-
 export default SlotCode;
 "
 `;
@@ -4690,8 +4637,6 @@ function SlotCode(props: Props) {
   );
 }
 
-SlotCode.defaultProps = { slotLeft: \\"Default left\\", children: \\"Default Child\\" };
-
 export default SlotCode;
 "
 `;
@@ -4700,7 +4645,6 @@ exports[`Preact > jsx > Typescript Test > Stamped.io 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
-
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
@@ -4836,7 +4780,6 @@ exports[`Preact > jsx > Typescript Test > Text 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 export interface TextProps {
   attributes?: any;
   rtlMode: boolean;
@@ -4989,36 +4932,33 @@ export default MyComponent;
 exports[`Preact > jsx > Typescript Test > basicForwardRef 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
-import { useState, forwardRef } from \\"preact/hooks\\";
-
+import { useState } from \\"preact/hooks\\";
 export interface Props {
   showInput: boolean;
   inputRef: HTMLInputElement;
 }
 
-const MyBasicForwardRefComponent = forwardRef<Props[\\"inputRef\\"]>(
-  function MyBasicForwardRefComponent(props: Props, inputRef) {
-    const [name, setName] = useState(() => \\"PatrickJS\\");
+function MyBasicForwardRefComponent(props: Props) {
+  const [name, setName] = useState(() => \\"PatrickJS\\");
 
-    return (
-      <Fragment>
-        <div>
-          <input
-            className=\\"input\\"
-            ref={inputRef}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <style jsx>{\`
-          .input {
-            color: red;
-          }
-        \`}</style>
-      </Fragment>
-    );
-  }
-);
+  return (
+    <Fragment>
+      <div>
+        <input
+          className=\\"input\\"
+          ref={props.inputRef}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+      <style jsx>{\`
+        .input {
+          color: red;
+        }
+      \`}</style>
+    </Fragment>
+  );
+}
 
 export default MyBasicForwardRefComponent;
 "
@@ -5027,36 +4967,33 @@ export default MyBasicForwardRefComponent;
 exports[`Preact > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
-import { useState, forwardRef } from \\"preact/hooks\\";
-
+import { useState } from \\"preact/hooks\\";
 export interface Props {
   showInput: boolean;
   inputRef: HTMLInputElement;
 }
 
-const MyBasicForwardRefComponent = forwardRef<Props[\\"inputRef\\"]>(
-  function MyBasicForwardRefComponent(props: Props, inputRef) {
-    const [name, setName] = useState(() => \\"PatrickJS\\");
+function MyBasicForwardRefComponent(props: Props) {
+  const [name, setName] = useState(() => \\"PatrickJS\\");
 
-    return (
-      <Fragment>
-        <div>
-          <input
-            className=\\"input\\"
-            ref={inputRef}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <style jsx>{\`
-          .input {
-            color: red;
-          }
-        \`}</style>
-      </Fragment>
-    );
-  }
-);
+  return (
+    <Fragment>
+      <div>
+        <input
+          className=\\"input\\"
+          ref={props.inputRef}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+      <style jsx>{\`
+        .input {
+          color: red;
+        }
+      \`}</style>
+    </Fragment>
+  );
+}
 
 export default MyBasicForwardRefComponent;
 "
@@ -5172,7 +5109,6 @@ exports[`Preact > jsx > Typescript Test > className 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 type Props = {
   [key: string]: string | JSX.Element;
   slotTesting: JSX.Element;
@@ -5229,7 +5165,6 @@ exports[`Preact > jsx > Typescript Test > componentWithContext 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
-
 export interface ComponentWithContextProps {
   content: string;
 }
@@ -5269,7 +5204,6 @@ exports[`Preact > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
-
 export interface ComponentWithContextProps {
   content: string;
 }
@@ -5376,15 +5310,6 @@ function Button(props: ButtonProps) {
   );
 }
 
-Button.defaultProps = {
-  text: \\"default text\\",
-  link: \\"https://builder.io/\\",
-  openLinkInNewTab: false,
-  onClick: () => {
-    console.log(\\"hi\\");
-  },
-};
-
 export default Button;
 "
 `;
@@ -5430,13 +5355,6 @@ function Button(props: ButtonProps) {
     </div>
   );
 }
-
-Button.defaultProps = {
-  text: \\"default text\\",
-  link: \\"https://builder.io/\\",
-  openLinkInNewTab: false,
-  onClick: () => {},
-};
 
 export default Button;
 "
@@ -5690,7 +5608,6 @@ exports[`Preact > jsx > Typescript Test > onInit 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
-
 type Props = {
   name: string;
 };
@@ -5763,7 +5680,6 @@ exports[`Preact > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
-
 type Props = {
   size: string;
 };
@@ -5846,7 +5762,6 @@ exports[`Preact > jsx > Typescript Test > propsDestructure 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 type Props = {
   children: any;
   type: string;
@@ -5945,7 +5860,6 @@ exports[`Preact > jsx > Typescript Test > renderBlock 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
-
 export type RenderBlockProps = {
   block: BuilderBlock;
   context: BuilderContextInterface;
@@ -5991,8 +5905,8 @@ function RenderBlock(props: RenderBlockProps) {
     if (!ref) {
       // TODO: Public doc page with more info about this message
       console.warn(\`
-          Could not find a registered component named \\"\${componentName}\\".
-          If you registered it, is the file that registered it imported by the file that needs to render it?\`);
+       Could not find a registered component named \\"\${componentName}\\". 
+       If you registered it, is the file that registered it imported by the file that needs to render it?\`);
       return undefined;
     } else {
       return ref;
@@ -6225,7 +6139,6 @@ exports[`Preact > jsx > Typescript Test > renderContentExample 1`] = `
 "/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext, useEffect } from \\"preact/hooks\\";
-
 type Props = {
   customComponents: string[];
   content: {
@@ -6776,8 +6689,6 @@ function MyComponent(props) {
   );
 }
 
-MyComponent.defaultProps = {};
-
 export default MyComponent;
 "
 `;
@@ -7017,11 +6928,6 @@ function MyComponent(props) {
   );
 }
 
-MyComponent.defaultProps = {
-  children: \\"default\\",
-  slotTest: <div>default</div>,
-};
-
 export default MyComponent;
 "
 `;
@@ -7200,8 +7106,6 @@ function MyComponent(props: any) {
     />
   );
 }
-
-MyComponent.defaultProps = {};
 
 export default MyComponent;
 "
@@ -7441,11 +7345,6 @@ function MyComponent(props: any) {
     </div>
   );
 }
-
-MyComponent.defaultProps = {
-  children: \\"default\\",
-  slotTest: <div>default</div>,
-};
 
 export default MyComponent;
 "

--- a/packages/core/src/__tests__/preact.test.ts
+++ b/packages/core/src/__tests__/preact.test.ts
@@ -1,10 +1,10 @@
-import { componentToReact } from '../generators/react';
+import { componentToPreact } from '../generators/preact';
 import { runTestsForTarget } from './test-generator';
 
 describe('Preact', () => {
   runTestsForTarget({
-    options: { preact: true },
-    target: 'react',
-    generator: componentToReact,
+    options: {},
+    target: 'preact',
+    generator: componentToPreact,
   });
 });

--- a/packages/core/src/__tests__/test-generator.ts
+++ b/packages/core/src/__tests__/test-generator.ts
@@ -296,6 +296,18 @@ const JSX_TESTS_FOR_TARGET: Partial<Record<Target, Tests[]>> = {
     ON_UPDATE_RETURN,
     // FOR_SHOW_TESTS,
   ],
+  preact: [
+    CONTEXT_TEST,
+    BASIC_TESTS,
+    SLOTS_TESTS,
+    SHOW_TESTS,
+    FORWARD_REF_TESTS,
+    MULTI_ON_UPDATE_TESTS,
+    FORM_BLOCK_TESTS,
+    ADVANCED_REF,
+    ON_UPDATE_RETURN,
+    // FOR_SHOW_TESTS,
+  ],
   rsc: [
     CONTEXT_TEST,
     BASIC_TESTS,

--- a/packages/core/src/generators/context/preact.ts
+++ b/packages/core/src/generators/context/preact.ts
@@ -1,0 +1,36 @@
+import { format } from 'prettier/standalone';
+import { stringifyContextValue } from '../../helpers/get-state-object-string';
+import { MitosisContext } from '../../types/mitosis-context';
+
+type ContextToPreactOptions = {
+  format?: boolean;
+  typescript?: boolean;
+};
+
+export const contextToPreact =
+  (options: ContextToPreactOptions = { typescript: false }) =>
+  ({ context }: { context: MitosisContext }): string => {
+    let str = `
+  import { createContext } from 'preact';
+
+  export default createContext${options.typescript ? '<any>' : ''}(${stringifyContextValue(
+      context.value,
+    )})
+  `;
+
+    if (options.format !== false) {
+      try {
+        str = format(str, {
+          parser: 'typescript',
+          plugins: [
+            require('prettier/parser-typescript'), // To support running in browsers
+          ],
+        });
+      } catch (err) {
+        console.error('Format error for file:', str);
+        throw err;
+      }
+    }
+
+    return str;
+  };

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -14,8 +14,8 @@ import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 import { checkHasState } from '../helpers/state';
 import { isRootTextNode } from '../helpers/is-root-text-node';
-import {getNodeMappers, REACT_BINDING_MAPPERS} from "./react/blocks";
-import {closeFrag, getFragment, openFrag} from "./react/helpers";
+import { getNodeMappers, REACT_BINDING_MAPPERS } from './react/blocks';
+import { closeFrag, getFragment, openFrag } from './react/helpers';
 
 export interface ToMitosisOptions extends BaseTranspilerOptions {
   format: 'react' | 'legacy';
@@ -38,11 +38,11 @@ export const blockToMitosis = (
     ...toMitosisOptions,
   };
   if (options.format === 'react') {
-    const REACT_NODE_MAPPERS = getNodeMappers({
+    const REACT_NODE_MAPPERS = getNodeMappers(REACT_BINDING_MAPPERS, {
       getFragment,
       openFrag,
-      closeFrag
-    })
+      closeFrag,
+    });
 
     return blockToReact(
       json,
@@ -55,7 +55,7 @@ export const blockToMitosis = (
       },
       component,
       REACT_NODE_MAPPERS,
-      REACT_BINDING_MAPPERS
+      REACT_BINDING_MAPPERS,
     );
   }
 

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -14,6 +14,8 @@ import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 import { checkHasState } from '../helpers/state';
 import { isRootTextNode } from '../helpers/is-root-text-node';
+import {getNodeMappers} from "./react/blocks";
+import {closeFrag, getFragment, openFrag} from "./react/helpers";
 
 export interface ToMitosisOptions extends BaseTranspilerOptions {
   format: 'react' | 'legacy';
@@ -36,6 +38,12 @@ export const blockToMitosis = (
     ...toMitosisOptions,
   };
   if (options.format === 'react') {
+    const REACT_NODE_MAPPERS = getNodeMappers({
+      getFragment,
+      openFrag,
+      closeFrag
+    })
+
     return blockToReact(
       json,
       {
@@ -46,6 +54,7 @@ export const blockToMitosis = (
         prettier: options.prettier,
       },
       component,
+      REACT_NODE_MAPPERS
     );
   }
 

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -14,7 +14,7 @@ import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
 import { blockToReact, componentToReact } from './react';
 import { checkHasState } from '../helpers/state';
 import { isRootTextNode } from '../helpers/is-root-text-node';
-import {getNodeMappers} from "./react/blocks";
+import {getNodeMappers, REACT_BINDING_MAPPERS} from "./react/blocks";
 import {closeFrag, getFragment, openFrag} from "./react/helpers";
 
 export interface ToMitosisOptions extends BaseTranspilerOptions {
@@ -54,7 +54,8 @@ export const blockToMitosis = (
         prettier: options.prettier,
       },
       component,
-      REACT_NODE_MAPPERS
+      REACT_NODE_MAPPERS,
+      REACT_BINDING_MAPPERS
     );
   }
 

--- a/packages/core/src/generators/preact.ts
+++ b/packages/core/src/generators/preact.ts
@@ -34,6 +34,7 @@ import { renderPreComponent } from '../helpers/render-imports';
 import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings';
 import { getFrameworkImports } from './react/imports';
 import { format } from 'prettier/standalone';
+import {getNodeMappers} from "./react/blocks";
 
 export const openFrag = () => getFragment('open');
 export const closeFrag = () => getFragment('close');
@@ -105,6 +106,12 @@ export const componentToPreact: TranspilerGenerator<Partial<ToPreactOptions>> =
     }
     return str;
   };
+
+const PREACT_NODE_MAPPERS = getNodeMappers({
+  getFragment,
+  openFrag,
+  closeFrag
+})
 
 const _componentToPreact = (
   json: MitosisComponent,
@@ -182,7 +189,7 @@ const _componentToPreact = (
 
     return (
       ${wrap ? openFrag() : ''}
-      ${json.children.map((item) => blockToReact(item, _options, json, [])).join('\n')}
+      ${json.children.map((item) => blockToReact(item, _options, json, PREACT_NODE_MAPPERS, [])).join('\n')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/preact.ts
+++ b/packages/core/src/generators/preact.ts
@@ -34,8 +34,8 @@ import { renderPreComponent } from '../helpers/render-imports';
 import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings';
 import { getFrameworkImports } from './react/imports';
 import { format } from 'prettier/standalone';
-import {ATTTRIBUTE_MAPPERS, BindingMapper, getNodeMappers} from "./react/blocks";
-import {getPropsDefinition} from "./react/props";
+import { ATTTRIBUTE_MAPPERS, BindingMapper, getNodeMappers } from './react/blocks';
+import { getPropsDefinition } from './react/props';
 
 export const openFrag = () => getFragment('open');
 export const closeFrag = () => getFragment('close');
@@ -45,14 +45,13 @@ export function getFragment(type: 'open' | 'close') {
 
 // TODO: Maybe in the future allow defining `string | function` as values
 const PREACT_BINDING_MAPPERS: {
-  [key: string]: BindingMapper
+  [key: string]: BindingMapper;
 } = {
   innerHTML(_key, value) {
     return ['dangerouslySetInnerHTML', `{__html: ${value.replace(/\s+/g, ' ')}}`];
   },
   ...ATTTRIBUTE_MAPPERS,
 };
-
 
 export interface ToPreactOptions extends BaseTranspilerOptions {
   stylesType: 'styled-jsx' | 'style-tag';
@@ -122,8 +121,8 @@ export const componentToPreact: TranspilerGenerator<Partial<ToPreactOptions>> =
 const PREACT_NODE_MAPPERS = getNodeMappers(PREACT_BINDING_MAPPERS, {
   getFragment,
   openFrag,
-  closeFrag
-})
+  closeFrag,
+});
 
 const _componentToPreact = (
   json: MitosisComponent,
@@ -201,7 +200,11 @@ const _componentToPreact = (
 
     return (
       ${wrap ? openFrag() : ''}
-      ${json.children.map((item) => blockToReact(item, _options, json, PREACT_NODE_MAPPERS, PREACT_BINDING_MAPPERS, [])).join('\n')}
+      ${json.children
+        .map((item) =>
+          blockToReact(item, _options, json, PREACT_NODE_MAPPERS, PREACT_BINDING_MAPPERS, []),
+        )
+        .join('\n')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/preact.ts
+++ b/packages/core/src/generators/preact.ts
@@ -1,0 +1,218 @@
+import { fastClone } from '../helpers/fast-clone';
+import { blockToReact, ToReactOptions } from './react';
+import { BaseTranspilerOptions, TranspilerGenerator } from '../types/transpiler';
+import { mergeOptions } from '../helpers/merge-options';
+import { MitosisComponent } from '@builder.io/mitosis';
+import { processHttpRequests } from '../helpers/process-http-requests';
+import { handleMissingState } from '../helpers/handle-missing-state';
+import { processTagReferences } from '../helpers/process-tag-references';
+import { provideContext } from './react/context';
+import { hasCss } from '../helpers/styles/helpers';
+import { gettersToFunctions } from '../helpers/getters-to-functions';
+import {
+  getContextString,
+  getHooksCode,
+  getRefsString,
+  getUseStateCode,
+  updateStateSetters,
+} from './react/state';
+import { mapRefs } from '../helpers/map-refs';
+import { checkHasState } from '../helpers/state';
+import {
+  runPostCodePlugins,
+  runPostJsonPlugins,
+  runPreCodePlugins,
+  runPreJsonPlugins,
+} from '../modules/plugins';
+import { collectCss } from '../helpers/styles/collect-css';
+import hash from 'hash-sum';
+import { stripMetaProperties } from '../helpers/strip-meta-properties';
+import { isRootSpecialNode, processBinding, wrapInFragment } from './react/helpers';
+import { isRootTextNode } from '../helpers/is-root-text-node';
+import dedent from 'dedent';
+import { renderPreComponent } from '../helpers/render-imports';
+import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings';
+import { getFrameworkImports } from './react/imports';
+import { format } from 'prettier/standalone';
+
+export const openFrag = () => getFragment('open');
+export const closeFrag = () => getFragment('close');
+export function getFragment(type: 'open' | 'close') {
+  return type === 'open' ? `<Fragment>` : `</Fragment>`;
+}
+
+export interface ToPreactOptions extends BaseTranspilerOptions {
+  stylesType: 'styled-jsx' | 'style-tag';
+  format?: 'lite' | 'safe';
+}
+
+const getInitCode = (
+  json: MitosisComponent,
+  options: Parameters<typeof processBinding>[1],
+): string => {
+  return processBinding(json.hooks.init?.code || '', options);
+};
+
+const DEFAULT_OPTIONS: ToPreactOptions = {
+  stylesType: 'styled-jsx',
+};
+
+// TODO: import target components when they are required
+const getDefaultImport = (json: MitosisComponent, options: ToPreactOptions): string => {
+  return `
+  /** @jsx h */
+  import { h, Fragment } from 'preact';
+  `;
+};
+
+export const componentToPreact: TranspilerGenerator<Partial<ToPreactOptions>> =
+  (preactOptions = {}) =>
+  ({ component, path }) => {
+    let json = fastClone(component);
+    const options: ToPreactOptions = mergeOptions(DEFAULT_OPTIONS, preactOptions);
+
+    if (options.plugins) {
+      json = runPreJsonPlugins(json, options.plugins);
+    }
+
+    let str = _componentToPreact(json, options);
+
+    str +=
+      '\n\n\n' +
+      json.subComponents.map((item) => _componentToPreact(item, options, true)).join('\n\n\n');
+
+    if (options.plugins) {
+      str = runPreCodePlugins(str, options.plugins);
+    }
+    if (options.prettier !== false) {
+      try {
+        str = format(str, {
+          parser: 'typescript',
+          plugins: [
+            require('prettier/parser-typescript'), // To support running in browsers
+            require('prettier/parser-postcss'),
+          ],
+        })
+          // Remove spaces between imports
+          .replace(/;\n\nimport\s/g, ';\nimport ');
+      } catch (err) {
+        console.error('Format error for file:');
+        throw err;
+      }
+    }
+    if (options.plugins) {
+      str = runPostCodePlugins(str, options.plugins);
+    }
+    return str;
+  };
+
+const _componentToPreact = (
+  json: MitosisComponent,
+  options: ToPreactOptions,
+  isSubComponent = false,
+) => {
+  processHttpRequests(json);
+  handleMissingState(json);
+  processTagReferences(json);
+  const _options = {
+    ...options,
+    contextType: 'context',
+    stateType: 'useState',
+    type: 'dom',
+  } as Omit<ToReactOptions, keyof ToPreactOptions> & ToPreactOptions;
+  const contextStr = provideContext(json, _options);
+  const componentHasStyles = hasCss(json);
+  gettersToFunctions(json);
+  updateStateSetters(json, _options);
+
+  if (!json.name) {
+    json.name = 'MyComponent';
+  }
+
+  // const domRefs = getRefs(json);
+  const allRefs = Object.keys(json.refs);
+  mapRefs(json, (refName) => `${refName}.current`);
+
+  let hasState = checkHasState(json);
+
+  const useStateCode = getUseStateCode(json, _options);
+  if (options.plugins) {
+    json = runPostJsonPlugins(json, options.plugins);
+  }
+
+  const css =
+    options.stylesType === 'styled-jsx'
+      ? collectCss(json)
+      : options.stylesType === 'style-tag'
+      ? collectCss(json, {
+          prefix: hash(json),
+        })
+      : null;
+
+  if (options.format !== 'lite') {
+    stripMetaProperties(json);
+  }
+
+  const preactLibImports = getFrameworkImports(json, {
+    allRefs,
+    useStateCode,
+  });
+
+  const wrap =
+    wrapInFragment(json) ||
+    isRootTextNode(json) ||
+    (componentHasStyles &&
+      (options.stylesType === 'styled-jsx' || options.stylesType === 'style-tag')) ||
+    isRootSpecialNode(json);
+
+  const [hasStateArgument, refsString] = getRefsString(json, allRefs, _options);
+
+  const propType = json.propsTypeRef || 'any';
+  const componentArgs = `props${options.typescript ? `:${propType}` : ''}`;
+
+  const componentBody = dedent`
+    ${hasStateArgument ? '' : refsString}
+    ${hasState ? useStateCode : ''}
+    ${hasStateArgument ? refsString : ''}
+    ${getContextString(json, _options)}
+    ${getInitCode(json, _options)}
+    ${contextStr || ''}
+
+    ${getHooksCode(json, _options)}
+
+    return (
+      ${wrap ? openFrag() : ''}
+      ${json.children.map((item) => blockToReact(item, _options, json, [])).join('\n')}
+      ${
+        componentHasStyles && options.stylesType === 'styled-jsx'
+          ? `<style jsx>{\`${css}\`}</style>`
+          : componentHasStyles && options.stylesType === 'style-tag'
+          ? `<style>{\`${css}\`}</style>`
+          : ''
+      }
+      ${wrap ? closeFrag() : ''}
+    );
+  `;
+
+  const str = dedent`
+  ${getDefaultImport(json, options)}
+  ${
+    preactLibImports.size
+      ? `import { ${Array.from(preactLibImports).join(', ')} } from 'preact/hooks'`
+      : ''
+  }
+    ${json.types && options.typescript ? json.types.join('\n') : ''}
+    ${renderPreComponent({
+      component: json,
+      target: 'preact',
+    })}
+    function ${json.name}(${componentArgs}) {
+    ${componentBody}
+  }
+
+    ${isSubComponent ? '' : `export default ${json.name};`}
+
+  `;
+
+  return stripNewlinesInStrings(str);
+};

--- a/packages/core/src/generators/preact.ts
+++ b/packages/core/src/generators/preact.ts
@@ -35,6 +35,7 @@ import { stripNewlinesInStrings } from '../helpers/replace-new-lines-in-strings'
 import { getFrameworkImports } from './react/imports';
 import { format } from 'prettier/standalone';
 import {ATTTRIBUTE_MAPPERS, BindingMapper, getNodeMappers} from "./react/blocks";
+import {getPropsDefinition} from "./react/props";
 
 export const openFrag = () => getFragment('open');
 export const closeFrag = () => getFragment('close');
@@ -227,6 +228,9 @@ const _componentToPreact = (
     function ${json.name}(${componentArgs}) {
     ${componentBody}
   }
+
+    ${getPropsDefinition({ json })}
+
 
     ${isSubComponent ? '' : `export default ${json.name};`}
 

--- a/packages/core/src/generators/react/blocks.ts
+++ b/packages/core/src/generators/react/blocks.ts
@@ -87,9 +87,9 @@ const NODE_MAPPERS: {
   },
   Fragment(json, options, component) {
     const wrap = wrapInFragment(json);
-    return `${wrap ? getFragment('open', options) : ''}${json.children
+    return `${wrap ? getFragment('open') : ''}${json.children
       .map((item) => blockToReact(item, options, component))
-      .join('\n')}${wrap ? getFragment('close', options) : ''}`;
+      .join('\n')}${wrap ? getFragment('close') : ''}`;
   },
   For(_json, options, component) {
     const json = _json as ForNode;
@@ -99,10 +99,10 @@ const NODE_MAPPERS: {
       json.bindings.each?.code as string,
       options,
     )}?.map((${forArguments}) => (
-      ${wrap ? openFrag(options) : ''}${json.children
+      ${wrap ? openFrag() : ''}${json.children
       .filter(filterEmptyTextNodes)
       .map((item) => blockToReact(item, options, component))
-      .join('\n')}${wrap ? closeFrag(options) : ''}
+      .join('\n')}${wrap ? closeFrag() : ''}
     ))}`;
   },
   Show(json, options, component) {
@@ -111,16 +111,16 @@ const NODE_MAPPERS: {
       json.meta.else &&
       (wrapInFragment(json.meta.else as any) || checkIsForNode(json.meta.else as any));
     return `{${processBinding(json.bindings.when?.code as string, options)} ? (
-      ${wrap ? openFrag(options) : ''}${json.children
+      ${wrap ? openFrag() : ''}${json.children
       .filter(filterEmptyTextNodes)
       .map((item) => blockToReact(item, options, component))
-      .join('\n')}${wrap ? closeFrag(options) : ''}
+      .join('\n')}${wrap ? closeFrag() : ''}
     ) : ${
       !json.meta.else
         ? 'null'
-        : (wrapElse ? openFrag(options) : '') +
+        : (wrapElse ? openFrag() : '') +
           blockToReact(json.meta.else as any, options, component) +
-          (wrapElse ? closeFrag(options) : '')
+          (wrapElse ? closeFrag() : '')
     }}`;
   },
 };

--- a/packages/core/src/generators/react/blocks.ts
+++ b/packages/core/src/generators/react/blocks.ts
@@ -30,7 +30,7 @@ export const getNodeMappers = (bindingMappers: Record<string, BindingMapper>, fn
       component: MitosisComponent,
       parentSlots?: any[],
     ) => string;
-  } = ({
+  } = {
     Slot(json, options, component, parentSlots) {
       const slotName = json.bindings.name?.code || json.properties.name;
 
@@ -63,7 +63,7 @@ export const getNodeMappers = (bindingMappers: Record<string, BindingMapper>, fn
         const key = Object.keys(json.bindings).find(Boolean);
         if (key && parentSlots) {
           const propKey = camelCase('Slot' + key[0].toUpperCase() + key.substring(1));
-          parentSlots.push({key: propKey, value: json.bindings[key]?.code});
+          parentSlots.push({ key: propKey, value: json.bindings[key]?.code });
           return '';
         }
 
@@ -130,11 +130,11 @@ export const getNodeMappers = (bindingMappers: Record<string, BindingMapper>, fn
         !json.meta.else
           ? 'null'
           : (wrapElse ? fns.openFrag() : '') +
-          blockToReact(json.meta.else as any, options, component, MAPPERS, bindingMappers) +
-          (wrapElse ? fns.closeFrag() : '')
+            blockToReact(json.meta.else as any, options, component, MAPPERS, bindingMappers) +
+            (wrapElse ? fns.closeFrag() : '')
       }}`;
     },
-  });
+  };
   return MAPPERS;
 };
 
@@ -147,7 +147,7 @@ export const ATTTRIBUTE_MAPPERS: { [key: string]: string } = {
 
 // TODO: Maybe in the future allow defining `string | function` as values
 export const REACT_BINDING_MAPPERS: {
-  [key: string]: BindingMapper
+  [key: string]: BindingMapper;
 } = {
   ref(ref, value, options) {
     const regexp = /(.+)?props\.(.+)( |\)|;|\()?$/m;
@@ -276,7 +276,9 @@ export const blockToReact = (
   let childrenNodes = '';
   if (json.children) {
     childrenNodes = json.children
-      .map((item) => blockToReact(item, options, component, nodeMappers, bindingMappers, needsToRenderSlots))
+      .map((item) =>
+        blockToReact(item, options, component, nodeMappers, bindingMappers, needsToRenderSlots),
+      )
       .join('\n');
   }
   if (needsToRenderSlots.length) {

--- a/packages/core/src/generators/react/context.ts
+++ b/packages/core/src/generators/react/context.ts
@@ -1,0 +1,54 @@
+import { contextPropDrillingKey, MitosisComponent, ToReactOptions } from '@builder.io/mitosis';
+import { stringifyContextValue } from '../../helpers/get-state-object-string';
+import { createMitosisNode } from '../../helpers/create-mitosis-node';
+import { createSingleBinding } from '../../helpers/bindings';
+
+export function provideContext(
+  json: MitosisComponent,
+  options: Pick<ToReactOptions, 'contextType'>,
+): string | void {
+  if (options.contextType === 'prop-drill') {
+    let str = '';
+    for (const key in json.context.set) {
+      const { name, ref, value } = json.context.set[key];
+      if (value) {
+        str += `
+          ${contextPropDrillingKey}.${name} = ${stringifyContextValue(value)};
+        `;
+      }
+      // TODO: support refs. I'm not sure what those are so unclear how to support them
+    }
+    return str;
+  } else {
+    for (const key in json.context.set) {
+      const { name, ref, value } = json.context.set[key];
+      if (value) {
+        json.children = [
+          createMitosisNode({
+            name: `${name}.Provider`,
+            children: json.children,
+            ...(value && {
+              bindings: {
+                value: createSingleBinding({
+                  code: stringifyContextValue(value),
+                }),
+              },
+            }),
+          }),
+        ];
+      } else if (ref) {
+        json.children = [
+          createMitosisNode({
+            name: 'Context.Provider',
+            children: json.children,
+            ...(ref && {
+              bindings: {
+                value: createSingleBinding({ code: ref }),
+              },
+            }),
+          }),
+        ];
+      }
+    }
+  }
+}

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -32,14 +32,21 @@ import {
   getUseStateCode,
   updateStateSetters,
 } from './state';
-import { closeFrag, isRootSpecialNode, openFrag, processBinding, wrapInFragment } from './helpers';
+import { closeFrag, getFragment, isRootSpecialNode, openFrag, processBinding, wrapInFragment } from './helpers';
 import hash from 'hash-sum';
-import { blockToReact } from './blocks';
+import {blockToReact, getNodeMappers} from './blocks';
 import { mergeOptions } from '../../helpers/merge-options';
 import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strings';
 import { isRootTextNode } from '../../helpers/is-root-text-node';
 import { provideContext } from './context';
 import { getFrameworkImports } from './imports';
+
+const REACT_NODE_MAPPERS = getNodeMappers({
+  getFragment,
+  openFrag,
+  closeFrag
+})
+
 
 export const contextPropDrillingKey = '_context';
 
@@ -253,7 +260,7 @@ const _componentToReact = (
 
     return (
       ${wrap ? openFrag() : ''}
-      ${json.children.map((item) => blockToReact(item, options, json, [])).join('\n')}
+      ${json.children.map((item) => blockToReact(item, options, json, REACT_NODE_MAPPERS, [])).join('\n')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -40,6 +40,7 @@ import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strin
 import { isRootTextNode } from '../../helpers/is-root-text-node';
 import { provideContext } from './context';
 import { getFrameworkImports } from './imports';
+import {getPropsDefinition} from "./props";
 
 const REACT_NODE_MAPPERS = getNodeMappers(REACT_BINDING_MAPPERS, {
   getFragment,
@@ -118,19 +119,6 @@ const getDefaultImport = (json: MitosisComponent, options: ToReactOptions): stri
   }
 
   return "import * as React from 'react';";
-};
-
-const getPropsDefinition = ({ json }: { json: MitosisComponent }) => {
-  if (!json.defaultProps) return '';
-  const defaultPropsString = Object.keys(json.defaultProps)
-    .map((prop) => {
-      const value = json.defaultProps!.hasOwnProperty(prop)
-        ? json.defaultProps![prop]?.code
-        : 'undefined';
-      return `${prop}: ${value}`;
-    })
-    .join(',');
-  return `${json.name}.defaultProps = {${defaultPropsString}};`;
 };
 
 const _componentToReact = (

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -32,22 +32,28 @@ import {
   getUseStateCode,
   updateStateSetters,
 } from './state';
-import { closeFrag, getFragment, isRootSpecialNode, openFrag, processBinding, wrapInFragment } from './helpers';
+import {
+  closeFrag,
+  getFragment,
+  isRootSpecialNode,
+  openFrag,
+  processBinding,
+  wrapInFragment,
+} from './helpers';
 import hash from 'hash-sum';
-import {blockToReact, getNodeMappers, REACT_BINDING_MAPPERS} from './blocks';
+import { blockToReact, getNodeMappers, REACT_BINDING_MAPPERS } from './blocks';
 import { mergeOptions } from '../../helpers/merge-options';
 import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strings';
 import { isRootTextNode } from '../../helpers/is-root-text-node';
 import { provideContext } from './context';
 import { getFrameworkImports } from './imports';
-import {getPropsDefinition} from "./props";
+import { getPropsDefinition } from './props';
 
 const REACT_NODE_MAPPERS = getNodeMappers(REACT_BINDING_MAPPERS, {
   getFragment,
   openFrag,
-  closeFrag
-})
-
+  closeFrag,
+});
 
 export const contextPropDrillingKey = '_context';
 
@@ -248,7 +254,11 @@ const _componentToReact = (
 
     return (
       ${wrap ? openFrag() : ''}
-      ${json.children.map((item) => blockToReact(item, options, json, REACT_NODE_MAPPERS, REACT_BINDING_MAPPERS, [])).join('\n')}
+      ${json.children
+        .map((item) =>
+          blockToReact(item, options, json, REACT_NODE_MAPPERS, REACT_BINDING_MAPPERS, []),
+        )
+        .join('\n')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -34,14 +34,14 @@ import {
 } from './state';
 import { closeFrag, getFragment, isRootSpecialNode, openFrag, processBinding, wrapInFragment } from './helpers';
 import hash from 'hash-sum';
-import {blockToReact, getNodeMappers} from './blocks';
+import {blockToReact, getNodeMappers, REACT_BINDING_MAPPERS} from './blocks';
 import { mergeOptions } from '../../helpers/merge-options';
 import { stripNewlinesInStrings } from '../../helpers/replace-new-lines-in-strings';
 import { isRootTextNode } from '../../helpers/is-root-text-node';
 import { provideContext } from './context';
 import { getFrameworkImports } from './imports';
 
-const REACT_NODE_MAPPERS = getNodeMappers({
+const REACT_NODE_MAPPERS = getNodeMappers(REACT_BINDING_MAPPERS, {
   getFragment,
   openFrag,
   closeFrag
@@ -260,7 +260,7 @@ const _componentToReact = (
 
     return (
       ${wrap ? openFrag() : ''}
-      ${json.children.map((item) => blockToReact(item, options, json, REACT_NODE_MAPPERS, [])).join('\n')}
+      ${json.children.map((item) => blockToReact(item, options, json, REACT_NODE_MAPPERS, REACT_BINDING_MAPPERS, [])).join('\n')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/react/helpers.ts
+++ b/packages/core/src/generators/react/helpers.ts
@@ -4,7 +4,7 @@ import { stripStateAndPropsRefs } from '../../helpers/strip-state-and-props-refs
 
 import { ToReactOptions } from './types';
 
-export const processBinding = (str: string, options: ToReactOptions) => {
+export const processBinding = (str: string, options: Pick<ToReactOptions, 'stateType'>) => {
   if (options.stateType !== 'useState') {
     return str;
   }
@@ -15,10 +15,16 @@ export const processBinding = (str: string, options: ToReactOptions) => {
   });
 };
 
-export const openFrag = (options: ToReactOptions) => getFragment('open', options);
-export const closeFrag = (options: ToReactOptions) => getFragment('close', options);
-export function getFragment(type: 'open' | 'close', options: ToReactOptions) {
-  const tagName = options.preact ? 'Fragment' : '';
-  return type === 'open' ? `<${tagName}>` : `</${tagName}>`;
+export const openFrag = () => getFragment('open');
+export const closeFrag = () => getFragment('close');
+export function getFragment(type: 'open' | 'close') {
+  return type === 'open' ? `<>` : `</>`;
 }
 export const wrapInFragment = (json: MitosisComponent | MitosisNode) => json.children.length !== 1;
+
+/**
+ * If the root Mitosis component only has 1 child, and it is a `Show`/`For` node, then we need to wrap it in a fragment.
+ * Otherwise, we end up with invalid React render code.
+ */
+export const isRootSpecialNode = (json: MitosisComponent) =>
+  json.children.length === 1 && ['Show', 'For'].includes(json.children[0].name);

--- a/packages/core/src/generators/react/imports.ts
+++ b/packages/core/src/generators/react/imports.ts
@@ -1,0 +1,40 @@
+import { hasContext } from '../helpers/context';
+import { MitosisComponent } from '@builder.io/mitosis';
+
+export type ReactExports =
+  | 'useState'
+  | 'useRef'
+  | 'useCallback'
+  | 'useEffect'
+  | 'useContext'
+  | 'forwardRef';
+
+interface getImportsGeneratorMeta {
+  useStateCode: string;
+  allRefs: string[];
+  dontUseContext?: boolean;
+}
+
+export function getFrameworkImports(json: MitosisComponent, meta: getImportsGeneratorMeta) {
+  const frameworkLibImports: Set<ReactExports> = new Set();
+  if (meta.useStateCode.includes('useState')) {
+    frameworkLibImports.add('useState');
+  }
+  if (hasContext(json) && !meta.dontUseContext) {
+    frameworkLibImports.add('useContext');
+  }
+  if (meta.allRefs.length) {
+    frameworkLibImports.add('useRef');
+  }
+
+  if (
+    json.hooks.onMount?.code ||
+    json.hooks.onUnMount?.code ||
+    json.hooks.onUpdate?.length ||
+    json.hooks.onInit?.code
+  ) {
+    frameworkLibImports.add('useEffect');
+  }
+
+  return frameworkLibImports;
+}

--- a/packages/core/src/generators/react/props.ts
+++ b/packages/core/src/generators/react/props.ts
@@ -1,0 +1,14 @@
+import {MitosisComponent} from "@builder.io/mitosis";
+
+export const getPropsDefinition = ({ json }: { json: MitosisComponent }) => {
+  if (!json.defaultProps) return '';
+  const defaultPropsString = Object.keys(json.defaultProps)
+    .map((prop) => {
+      const value = json.defaultProps!.hasOwnProperty(prop)
+        ? json.defaultProps![prop]?.code
+        : 'undefined';
+      return `${prop}: ${value}`;
+    })
+    .join(',');
+  return `${json.name}.defaultProps = {${defaultPropsString}};`;
+};

--- a/packages/core/src/generators/react/props.ts
+++ b/packages/core/src/generators/react/props.ts
@@ -1,4 +1,4 @@
-import {MitosisComponent} from "@builder.io/mitosis";
+import { MitosisComponent } from '@builder.io/mitosis';
 
 export const getPropsDefinition = ({ json }: { json: MitosisComponent }) => {
   if (!json.defaultProps) return '';

--- a/packages/core/src/generators/react/types.ts
+++ b/packages/core/src/generators/react/types.ts
@@ -5,7 +5,6 @@ export interface ToReactOptions extends BaseTranspilerOptions {
   stateType: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder' | 'variables';
   format?: 'lite' | 'safe';
   type: 'dom' | 'native' | 'taro';
-  preact?: boolean;
   forwardRef?: string;
   experimental?: any;
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export * from './generators/svelte';
 export * from './generators/stencil';
 export * from './generators/marko';
 export * from './generators/mitosis';
+export * from './generators/preact';
 export * from './generators/template';
 export * from './generators/swift-ui';
 export * from './generators/lit';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export * from './parsers/context';
 export * from './generators/vue';
 export * from './generators/alpine';
 export * from './generators/angular';
+export * from './generators/context/preact';
 export * from './generators/context/react';
 export * from './generators/context/qwik';
 export * from './generators/context/rsc';

--- a/packages/core/src/targets.ts
+++ b/packages/core/src/targets.ts
@@ -9,7 +9,7 @@ import { componentToAlpine as alpine } from './generators/alpine';
 import { componentToMitosis as mitosis } from './generators/mitosis';
 import { componentToLiquid as liquid } from './generators/liquid';
 import { componentToReact as react } from './generators/react';
-import { componentToPreact as preact } from './generators/react';
+import { componentToPreact as preact } from './generators/preact';
 import { componentToReactNative as reactNative } from './generators/react-native';
 import { componentToSolid as solid } from './generators/solid';
 import { componentToSvelte as svelte } from './generators/svelte';


### PR DESCRIPTION
> First, let me start by apologizing: I generally try to avoid opening large PRs that shift code and functionality after discussing them with the authors first. This PR started with me playing with the codebase to see how viable it was and ended up with me playing with the codebase to learn it.
> 
> Should this work not align with the Mitosis project goals, I'd understand and wouldn't hold it against the project to throw away this work.

BLUF: **This PR splits Preact into its own generator and fixes two bugs along the way** (1163, 1160)

After looking through Mitosis' Preact support, I found a few issues, namely:

- https://github.com/BuilderIO/mitosis/issues/1163
- https://github.com/BuilderIO/mitosis/issues/1160
- https://github.com/BuilderIO/mitosis/issues/1155 (Fixed in another PR)

In addition to the bugs, there appear to be properties that are unintentionally added to the Preact generator options:

- https://github.com/BuilderIO/mitosis/issues/1161

And an opportunity to add a few options/properties that primarily/only apply to Preact over React:

- https://github.com/BuilderIO/mitosis/issues/1158
- https://github.com/BuilderIO/mitosis/issues/1164

After thinking through all of these issues, I realized that Preact should not be a strict derivative of React's generator but rather own its own generation code and simply share much of its logic from React.

This PR:

- Splits up the generator code from Preact
- Fixes an issue with createContext not importing the right path
- Fixes issues with properties that don't really exist in Preact (but do for React)