### PR TITLE
fix: preact context generation imports from proper library

### DIFF
--- a/packages/cli/src/build/helpers/context.ts
+++ b/packages/cli/src/build/helpers/context.ts
@@ -37,8 +37,14 @@ export const generateContextFile = async ({
         return contextToVue(options.options[target])({ context });
       case 'solid':
         return contextToSolid()({ context });
-      case 'react':
       case 'preact':
+        return contextToReact({
+          preact: true,
+          typescript: checkShouldOutputTypeScript({ options, target }),
+        })({
+          context,
+        });
+      case 'react':
       case 'reactNative':
         return contextToReact({ typescript: checkShouldOutputTypeScript({ options, target }) })({
           context,

--- a/packages/core/src/generators/context/react.ts
+++ b/packages/core/src/generators/context/react.ts
@@ -4,14 +4,15 @@ import { MitosisContext } from '../../types/mitosis-context';
 
 type ContextToReactOptions = {
   format?: boolean;
+  preact?: boolean;
   typescript?: boolean;
 };
 
 export const contextToReact =
-  (options: ContextToReactOptions = { typescript: false }) =>
+  (options: ContextToReactOptions = { typescript: false, preact: false }) =>
   ({ context }: { context: MitosisContext }): string => {
     let str = `
-  import { createContext } from 'react';
+  import { createContext } from '${options.preact ? 'preact' : 'react'}';
 
   export default createContext${options.typescript ? '<any>' : ''}(${stringifyContextValue(
       context.value,


### PR DESCRIPTION
## Description

This PR ensures that context generation imports from Preact rather than React in Preact generation

Fixes #1163
