### PR TITLE
Update gotchas.md

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -405,7 +405,7 @@ ignored by the compiler.
 _Mitosis input_
 
 ```typescript
-export default function MyComponent(props) {
+export default function MyComponent({ color = 'blue' }) {
   return <div>{color}</div>;
 }
 ```
@@ -413,7 +413,7 @@ export default function MyComponent(props) {
 _Mitosis output_
 
 ```typescript
-export default function MyComponent({ color = 'blue' }) {
+export default function MyComponent(props) {
   return <div>{color}</div>;
 }
 ```


### PR DESCRIPTION
## Description

- The Mitosis Input and Output code snippet of the gotcha [Can't set default props value with destructuring](https://github.com/Ryukemeister/mitosis/blob/main/docs/gotchas.md#cant-set-default-props-value-with-destructuring) seems to be in the reverse order after trying it in the mitosis fiddle [here](https://mitosis.builder.io/?outputTab=E4UwhgxgLkA%3D&code=FDCmA8AcHsCcBcAEATUAzAhgVwDZLVgHYDG8AltIYgLICeAwtALYyGiHwAUA3osdDjiIAvIgDkAIxxZQYxAF8AlIm7BEiWKHhZYVADzIyANwB83foNjy9AekOmA3MHlA) 