### PR TITLE
fix(core): :bug: Preserve meaningful whitespace

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -21,14 +21,11 @@ exports[`Alpine.js > jsx > Javascript Test > AdvancedRef 1`] = `
 
       <select name=\\"cars\\" id=\\"cars\\">
         <option value=\\"supra\\">GR Supra</option>
-
         <option value=\\"86\\">GR 86</option>
       </select>
     </div>
   </template>
-
   Hello
-
   <span x-html=\\"lowerCaseName()\\"></span>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -60,7 +57,6 @@ exports[`Alpine.js > jsx > Javascript Test > Basic 1`] = `
     x-bind:value=\\"DEFAULT_VALUES.name || name\\"
     x-on:change=\\"name = myEvent.target.value\\"
   />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -88,7 +84,6 @@ exports[`Alpine.js > jsx > Javascript Test > Basic 2`] = `
         x-bind:value=\\"name\\"
         x-on:change=\\"name = $event.target.value + ' and ' + person\\"
       />
-
       Hello
       <span x-html=\\"person\\"></span>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -109,9 +104,7 @@ exports[`Alpine.js > jsx > Javascript Test > Basic 2`] = `
 exports[`Alpine.js > jsx > Javascript Test > Basic Context 1`] = `
 "<div x-data=\\"myBasicComponent()\\">
   <span x-html=\\"myService.method('hello') + name\\"></span>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
-
   <input x-on:change=\\"onChange\\" />
 </div>
 <script>
@@ -205,17 +198,13 @@ exports[`Alpine.js > jsx > Javascript Test > BasicAttribute 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "<div x-data=\\"myBooleanAttribute()\\">
   <span x-html=\\"children\\"></span>
-
   <span x-html=\\"type\\"></span>
-
   <MyBooleanAttributeComponent
     x-bind:toggle=\\"true\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     x-bind:toggle=\\"true\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent x-bind:list=\\"null\\"></MyBooleanAttributeComponent>
 </div>
 <script>
@@ -229,7 +218,6 @@ exports[`Alpine.js > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > BasicChildComponent 1`] = `
 "<div x-data=\\"myBasicChildComponent()\\">
   <MyBasicComponent x-bind:id=\\"dev\\"></MyBasicComponent>
-
   <div>
     <MyBasicOnMountUpdateComponent
       x-bind:hi=\\"name\\"
@@ -256,7 +244,6 @@ exports[`Alpine.js > jsx > Javascript Test > BasicFor 1`] = `
         x-bind:value=\\"name\\"
         x-on:change=\\"name = $event.target.value + ' and ' + person\\"
       />
-
       Hello
       <span x-html=\\"person\\"></span>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -299,14 +286,11 @@ exports[`Alpine.js > jsx > Javascript Test > BasicRef 1`] = `
 
       <select name=\\"cars\\" id=\\"cars\\">
         <option value=\\"supra\\">GR Supra</option>
-
         <option value=\\"86\\">GR 86</option>
       </select>
     </div>
   </template>
-
   Hello
-
   <span x-html=\\"lowerCaseName()\\"></span>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -353,7 +337,6 @@ exports[`Alpine.js > jsx > Javascript Test > BasicRefPrevious 1`] = `
     , before:
     <span x-html=\\"prevCount\\"></span>
   </h1>
-
   <button x-on:click=\\"count += 1\\">Increment</button>
 </div>
 <script>
@@ -383,7 +366,6 @@ exports[`Alpine.js > jsx > Javascript Test > Button 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\">
       <span x-html=\\"text\\"></span>
@@ -424,7 +406,6 @@ exports[`Alpine.js > jsx > Javascript Test > Columns 1`] = `
   <template x-for=\\"column in columns\\">
     <div class=\\"builder-column div-2\\">
       <span x-html=\\"column.content\\"></span>
-
       <span x-html=\\"index\\"></span>
     </div>
   </template>
@@ -461,11 +442,9 @@ exports[`Alpine.js > jsx > Javascript Test > Columns 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "<div x-data=\\"contentSlotCode()\\">
   <slot x-bind:name=\\"slotTesting\\"></slot>
-
   <div>
     <hr />
   </div>
-
   <div>
     <slot></slot>
   </div>
@@ -490,11 +469,9 @@ exports[`Alpine.js > jsx > Javascript Test > ContentSlotJSX 1`] = `
     <template x-if=\\"showContent && slotContent\\">
       <slot name=\\"content\\"><span x-html=\\"content\\"></span></slot>
     </template>
-
     <div>
       <hr />
     </div>
-
     <div><span x-html=\\"children\\"></span></div>
   </div>
 </template>
@@ -691,9 +668,7 @@ exports[`Alpine.js > jsx > Javascript Test > Form 1`] = `
 
   <template x-if=\\"submissionState === 'error' && responseData\\">
     <pre class=\\"builder-form-error-text pre\\">
-          
-<span x-html=\\"JSON.stringify(responseData, null, 2)\\"></span>
-
+          <span x-html=\\"JSON.stringify(responseData, null, 2)\\"></span>
         </pre>
   </template>
 
@@ -962,10 +937,8 @@ exports[`Alpine.js > jsx > Javascript Test > Image 1`] = `
         x-bind:sizes=\\"sizes\\"
       />
     </template>
-
     <source x-bind:srcset=\\"srcset\\" />
   </picture>
-
   <span x-html=\\"children\\"></span>
 </div>
 <script>
@@ -1075,6 +1048,19 @@ exports[`Alpine.js > jsx > Javascript Test > Input 1`] = `
 <script>
   document.addEventListener(\\"alpine:init\\", () => {
     Alpine.data(\\"formInputComponent\\", () => ({}));
+  });
+</script>
+"
+`;
+
+exports[`Alpine.js > jsx > Javascript Test > Literal Space 1`] = `
+"<div x-data=\\"hello()\\">
+  Hello
+  <span x-html=\\"name ?? 'World'\\"></span>
+</div>
+<script>
+  document.addEventListener(\\"alpine:init\\", () => {
+    Alpine.data(\\"hello\\", () => ({}));
   });
 </script>
 "
@@ -1202,9 +1188,7 @@ exports[`Alpine.js > jsx > Javascript Test > SlotJsx 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > SlotNamed 1`] = `
 "<div x-data=\\"slotCode()\\">
   <slot name=\\"top\\"></slot>
-
   <slot name=\\"left\\">Default left</slot>
-
   <slot>Default Child</slot>
 </div>
 <script>
@@ -1242,7 +1226,6 @@ exports[`Alpine.js > jsx > Javascript Test > Stamped.io 1`] = `
 </style>
 <div x-data=\\"smileReviews()\\" x-bind:data-user=\\"name\\">
   <button x-on:click=\\"showReviewPrompt = true\\">Write a review</button>
-
   <template x-if=\\"showReviewPrompt || 'asdf'\\">
     <input placeholder=\\"Email\\" />
 
@@ -1252,7 +1235,6 @@ exports[`Alpine.js > jsx > Javascript Test > Stamped.io 1`] = `
       placeholder=\\"How was your experience?\\"
       class=\\"textarea\\"
     ></textarea>
-
     <button
       class=\\"button\\"
       x-on:click=\\"$event.preventDefault();
@@ -1261,19 +1243,15 @@ showReviewPrompt = false\\"
       Submit
     </button>
   </template>
-
   <template x-for=\\"review in reviews\\">
     <div class=\\"review\\" x-bind:key=\\"review.id\\">
       <img class=\\"img\\" x-bind:src=\\"review.avatar\\" />
-
       <div x-bind:class=\\"showReviewPrompt ? 'bg-primary' : 'bg-secondary'\\">
         <div>
           N:
           <span x-html=\\"index\\"></span>
         </div>
-
         <div><span x-html=\\"review.author\\"></span></div>
-
         <div><span x-html=\\"review.reviewMessage\\"></span></div>
       </div>
     </div>
@@ -1409,11 +1387,9 @@ exports[`Alpine.js > jsx > Javascript Test > basicForNoTagReference 1`] = `
 "<state.TagNameGetter x-data=\\"myBasicForNoTagRefComponent()\\">
   Hello
   <state.tag><span x-html=\\"name\\"></span></state.tag>
-
   <template x-for=\\"action in actions\\">
     <state.TagName>
       <action.icon></action.icon>
-
       <span><span x-html=\\"action.text\\"></span></span>
     </state.TagName>
   </template>
@@ -1624,7 +1600,6 @@ exports[`Alpine.js > jsx > Javascript Test > componentWithContext 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
 "<div x-data=\\"componentWithContext()\\">
   <div><span x-html=\\"foo.value\\"></span></div>
-
   <div>other</div>
 </div>
 <script>
@@ -1656,7 +1631,6 @@ exports[`Alpine.js > jsx > Javascript Test > defaultProps 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\" x-on:click=\\"onClick($event)\\">
       <span x-html=\\"buttonText\\"></span>
@@ -1682,7 +1656,6 @@ exports[`Alpine.js > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = 
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\" x-on:click=\\"onClick($event)\\">
       <span x-html=\\"text\\"></span>
@@ -1972,9 +1945,7 @@ exports[`Alpine.js > jsx > Javascript Test > preserveTyping 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > propsDestructure 1`] = `
 "<div x-data=\\"myBasicComponent()\\">
   <span x-html=\\"children\\"></span>
-
   <span x-html=\\"type\\"></span>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -2042,7 +2013,6 @@ exports[`Alpine.js > jsx > Javascript Test > renderBlock 1`] = `
   <template x-if=\\"isEmptyHtmlElement(tag)\\">
     <state.tag x-bind=\\"attributes\\" x-bind=\\"actions\\"></state.tag>
   </template>
-
   <template x-if=\\"!isEmptyHtmlElement(tag) && repeatItemData\\">
     <template x-for=\\"data in repeatItemData\\">
       <RenderRepeatedBlock
@@ -2052,7 +2022,6 @@ exports[`Alpine.js > jsx > Javascript Test > renderBlock 1`] = `
       ></RenderRepeatedBlock>
     </template>
   </template>
-
   <template x-if=\\"!isEmptyHtmlElement(tag) && !repeatItemData\\">
     <state.tag x-bind=\\"attributes\\" x-bind=\\"actions\\">
       <state.renderComponentTag
@@ -2066,7 +2035,6 @@ exports[`Alpine.js > jsx > Javascript Test > renderBlock 1`] = `
           x-bind:context=\\"childrenContext\\"
         ></RenderBlock>
       </template>
-
       <template x-for=\\"child in childrenWithoutParentComponent\\">
         <BlockStyles
           x-bind:key=\\"'block-style-' + child.id\\"
@@ -2293,7 +2261,6 @@ exports[`Alpine.js > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\">
       <span x-html=\\"text\\"></span>
@@ -2323,7 +2290,6 @@ exports[`Alpine.js > jsx > Javascript Test > rootShow 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > self-referencing component 1`] = `
 "<div x-data=\\"myComponent()\\">
   <span x-html=\\"name\\"></span>
-
   <template x-if=\\"name === 'Batman'\\">
     <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
   </template>
@@ -2339,9 +2305,7 @@ exports[`Alpine.js > jsx > Javascript Test > self-referencing component 1`] = `
 exports[`Alpine.js > jsx > Javascript Test > self-referencing component with children 1`] = `
 "<div x-data=\\"myComponent()\\">
   <span x-html=\\"name\\"></span>
-
   <span x-html=\\"children\\"></span>
-
   <template x-if=\\"name === 'Batman'\\">
     <MyComponent name=\\"Bruce\\">
       <div>Wayne</div>
@@ -2455,13 +2419,11 @@ exports[`Alpine.js > jsx > Javascript Test > svgComponent 1`] = `
   <defs>
     <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
       <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
       <feBlend
         in=\\"SourceGraphic\\"
         in2=\\"BackgroundImageFix\\"
         result=\\"shape\\"
       ></feBlend>
-
       <feGaussianBlur
         result=\\"effect1_foregroundBlur\\"
         x-bind:stdDeviation=\\"7\\"
@@ -2596,14 +2558,11 @@ exports[`Alpine.js > jsx > Typescript Test > AdvancedRef 1`] = `
 
       <select name=\\"cars\\" id=\\"cars\\">
         <option value=\\"supra\\">GR Supra</option>
-
         <option value=\\"86\\">GR 86</option>
       </select>
     </div>
   </template>
-
   Hello
-
   <span x-html=\\"lowerCaseName()\\"></span>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -2635,7 +2594,6 @@ exports[`Alpine.js > jsx > Typescript Test > Basic 1`] = `
     x-bind:value=\\"DEFAULT_VALUES.name || name\\"
     x-on:change=\\"name = myEvent.target.value\\"
   />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -2663,7 +2621,6 @@ exports[`Alpine.js > jsx > Typescript Test > Basic 2`] = `
         x-bind:value=\\"name\\"
         x-on:change=\\"name = $event.target.value + ' and ' + person\\"
       />
-
       Hello
       <span x-html=\\"person\\"></span>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -2684,9 +2641,7 @@ exports[`Alpine.js > jsx > Typescript Test > Basic 2`] = `
 exports[`Alpine.js > jsx > Typescript Test > Basic Context 1`] = `
 "<div x-data=\\"myBasicComponent()\\">
   <span x-html=\\"myService.method('hello') + name\\"></span>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
-
   <input x-on:change=\\"onChange\\" />
 </div>
 <script>
@@ -2780,17 +2735,13 @@ exports[`Alpine.js > jsx > Typescript Test > BasicAttribute 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "<div x-data=\\"myBooleanAttribute()\\">
   <span x-html=\\"children\\"></span>
-
   <span x-html=\\"type\\"></span>
-
   <MyBooleanAttributeComponent
     x-bind:toggle=\\"true\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     x-bind:toggle=\\"true\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent x-bind:list=\\"null\\"></MyBooleanAttributeComponent>
 </div>
 <script>
@@ -2804,7 +2755,6 @@ exports[`Alpine.js > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > BasicChildComponent 1`] = `
 "<div x-data=\\"myBasicChildComponent()\\">
   <MyBasicComponent x-bind:id=\\"dev\\"></MyBasicComponent>
-
   <div>
     <MyBasicOnMountUpdateComponent
       x-bind:hi=\\"name\\"
@@ -2831,7 +2781,6 @@ exports[`Alpine.js > jsx > Typescript Test > BasicFor 1`] = `
         x-bind:value=\\"name\\"
         x-on:change=\\"name = $event.target.value + ' and ' + person\\"
       />
-
       Hello
       <span x-html=\\"person\\"></span>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -2874,14 +2823,11 @@ exports[`Alpine.js > jsx > Typescript Test > BasicRef 1`] = `
 
       <select name=\\"cars\\" id=\\"cars\\">
         <option value=\\"supra\\">GR Supra</option>
-
         <option value=\\"86\\">GR 86</option>
       </select>
     </div>
   </template>
-
   Hello
-
   <span x-html=\\"lowerCaseName()\\"></span>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -2928,7 +2874,6 @@ exports[`Alpine.js > jsx > Typescript Test > BasicRefPrevious 1`] = `
     , before:
     <span x-html=\\"prevCount\\"></span>
   </h1>
-
   <button x-on:click=\\"count += 1\\">Increment</button>
 </div>
 <script>
@@ -2958,7 +2903,6 @@ exports[`Alpine.js > jsx > Typescript Test > Button 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\">
       <span x-html=\\"text\\"></span>
@@ -2999,7 +2943,6 @@ exports[`Alpine.js > jsx > Typescript Test > Columns 1`] = `
   <template x-for=\\"column in columns\\">
     <div class=\\"builder-column div-2\\">
       <span x-html=\\"column.content\\"></span>
-
       <span x-html=\\"index\\"></span>
     </div>
   </template>
@@ -3036,11 +2979,9 @@ exports[`Alpine.js > jsx > Typescript Test > Columns 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "<div x-data=\\"contentSlotCode()\\">
   <slot x-bind:name=\\"slotTesting\\"></slot>
-
   <div>
     <hr />
   </div>
-
   <div>
     <slot></slot>
   </div>
@@ -3065,11 +3006,9 @@ exports[`Alpine.js > jsx > Typescript Test > ContentSlotJSX 1`] = `
     <template x-if=\\"showContent && slotContent\\">
       <slot name=\\"content\\"><span x-html=\\"content\\"></span></slot>
     </template>
-
     <div>
       <hr />
     </div>
-
     <div><span x-html=\\"children\\"></span></div>
   </div>
 </template>
@@ -3266,9 +3205,7 @@ exports[`Alpine.js > jsx > Typescript Test > Form 1`] = `
 
   <template x-if=\\"submissionState === 'error' && responseData\\">
     <pre class=\\"builder-form-error-text pre\\">
-          
-<span x-html=\\"JSON.stringify(responseData, null, 2)\\"></span>
-
+          <span x-html=\\"JSON.stringify(responseData, null, 2)\\"></span>
         </pre>
   </template>
 
@@ -3526,10 +3463,8 @@ exports[`Alpine.js > jsx > Typescript Test > Image 1`] = `
         x-bind:sizes=\\"sizes\\"
       />
     </template>
-
     <source x-bind:srcset=\\"srcset\\" />
   </picture>
-
   <span x-html=\\"children\\"></span>
 </div>
 <script>
@@ -3639,6 +3574,19 @@ exports[`Alpine.js > jsx > Typescript Test > Input 1`] = `
 <script>
   document.addEventListener(\\"alpine:init\\", () => {
     Alpine.data(\\"formInputComponent\\", () => ({}));
+  });
+</script>
+"
+`;
+
+exports[`Alpine.js > jsx > Typescript Test > Literal Space 1`] = `
+"<div x-data=\\"hello()\\">
+  Hello
+  <span x-html=\\"name ?? 'World'\\"></span>
+</div>
+<script>
+  document.addEventListener(\\"alpine:init\\", () => {
+    Alpine.data(\\"hello\\", () => ({}));
   });
 </script>
 "
@@ -3766,9 +3714,7 @@ exports[`Alpine.js > jsx > Typescript Test > SlotJsx 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > SlotNamed 1`] = `
 "<div x-data=\\"slotCode()\\">
   <slot name=\\"top\\"></slot>
-
   <slot name=\\"left\\">Default left</slot>
-
   <slot>Default Child</slot>
 </div>
 <script>
@@ -3806,7 +3752,6 @@ exports[`Alpine.js > jsx > Typescript Test > Stamped.io 1`] = `
 </style>
 <div x-data=\\"smileReviews()\\" x-bind:data-user=\\"name\\">
   <button x-on:click=\\"showReviewPrompt = true\\">Write a review</button>
-
   <template x-if=\\"showReviewPrompt || 'asdf'\\">
     <input placeholder=\\"Email\\" />
 
@@ -3816,7 +3761,6 @@ exports[`Alpine.js > jsx > Typescript Test > Stamped.io 1`] = `
       placeholder=\\"How was your experience?\\"
       class=\\"textarea\\"
     ></textarea>
-
     <button
       class=\\"button\\"
       x-on:click=\\"$event.preventDefault();
@@ -3825,19 +3769,15 @@ showReviewPrompt = false\\"
       Submit
     </button>
   </template>
-
   <template x-for=\\"review in reviews\\">
     <div class=\\"review\\" x-bind:key=\\"review.id\\">
       <img class=\\"img\\" x-bind:src=\\"review.avatar\\" />
-
       <div x-bind:class=\\"showReviewPrompt ? 'bg-primary' : 'bg-secondary'\\">
         <div>
           N:
           <span x-html=\\"index\\"></span>
         </div>
-
         <div><span x-html=\\"review.author\\"></span></div>
-
         <div><span x-html=\\"review.reviewMessage\\"></span></div>
       </div>
     </div>
@@ -3973,11 +3913,9 @@ exports[`Alpine.js > jsx > Typescript Test > basicForNoTagReference 1`] = `
 "<state.TagNameGetter x-data=\\"myBasicForNoTagRefComponent()\\">
   Hello
   <state.tag><span x-html=\\"name\\"></span></state.tag>
-
   <template x-for=\\"action in actions\\">
     <state.TagName>
       <action.icon></action.icon>
-
       <span><span x-html=\\"action.text\\"></span></span>
     </state.TagName>
   </template>
@@ -4188,7 +4126,6 @@ exports[`Alpine.js > jsx > Typescript Test > componentWithContext 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
 "<div x-data=\\"componentWithContext()\\">
   <div><span x-html=\\"foo.value\\"></span></div>
-
   <div>other</div>
 </div>
 <script>
@@ -4220,7 +4157,6 @@ exports[`Alpine.js > jsx > Typescript Test > defaultProps 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\" x-on:click=\\"onClick($event)\\">
       <span x-html=\\"buttonText\\"></span>
@@ -4246,7 +4182,6 @@ exports[`Alpine.js > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = 
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\" x-on:click=\\"onClick($event)\\">
       <span x-html=\\"text\\"></span>
@@ -4536,9 +4471,7 @@ exports[`Alpine.js > jsx > Typescript Test > preserveTyping 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > propsDestructure 1`] = `
 "<div x-data=\\"myBasicComponent()\\">
   <span x-html=\\"children\\"></span>
-
   <span x-html=\\"type\\"></span>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -4606,7 +4539,6 @@ exports[`Alpine.js > jsx > Typescript Test > renderBlock 1`] = `
   <template x-if=\\"isEmptyHtmlElement(tag)\\">
     <state.tag x-bind=\\"attributes\\" x-bind=\\"actions\\"></state.tag>
   </template>
-
   <template x-if=\\"!isEmptyHtmlElement(tag) && repeatItemData\\">
     <template x-for=\\"data in repeatItemData\\">
       <RenderRepeatedBlock
@@ -4616,7 +4548,6 @@ exports[`Alpine.js > jsx > Typescript Test > renderBlock 1`] = `
       ></RenderRepeatedBlock>
     </template>
   </template>
-
   <template x-if=\\"!isEmptyHtmlElement(tag) && !repeatItemData\\">
     <state.tag x-bind=\\"attributes\\" x-bind=\\"actions\\">
       <state.renderComponentTag
@@ -4630,7 +4561,6 @@ exports[`Alpine.js > jsx > Typescript Test > renderBlock 1`] = `
           x-bind:context=\\"childrenContext\\"
         ></RenderBlock>
       </template>
-
       <template x-for=\\"child in childrenWithoutParentComponent\\">
         <BlockStyles
           x-bind:key=\\"'block-style-' + child.id\\"
@@ -4860,7 +4790,6 @@ exports[`Alpine.js > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
       <span x-html=\\"text\\"></span>
     </a>
   </template>
-
   <template x-if=\\"!link\\">
     <button type=\\"button\\" x-bind=\\"attributes\\">
       <span x-html=\\"text\\"></span>
@@ -4890,7 +4819,6 @@ exports[`Alpine.js > jsx > Typescript Test > rootShow 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > self-referencing component 1`] = `
 "<div x-data=\\"myComponent()\\">
   <span x-html=\\"name\\"></span>
-
   <template x-if=\\"name === 'Batman'\\">
     <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
   </template>
@@ -4906,9 +4834,7 @@ exports[`Alpine.js > jsx > Typescript Test > self-referencing component 1`] = `
 exports[`Alpine.js > jsx > Typescript Test > self-referencing component with children 1`] = `
 "<div x-data=\\"myComponent()\\">
   <span x-html=\\"name\\"></span>
-
   <span x-html=\\"children\\"></span>
-
   <template x-if=\\"name === 'Batman'\\">
     <MyComponent name=\\"Bruce\\">
       <div>Wayne</div>
@@ -5022,13 +4948,11 @@ exports[`Alpine.js > jsx > Typescript Test > svgComponent 1`] = `
   <defs>
     <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
       <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
       <feBlend
         in=\\"SourceGraphic\\"
         in2=\\"BackgroundImageFix\\"
         result=\\"shape\\"
       ></feBlend>
-
       <feGaussianBlur
         result=\\"effect1_foregroundBlur\\"
         x-bind:stdDeviation=\\"7\\"
@@ -5129,7 +5053,6 @@ exports[`Alpine.js > jsx > Typescript Test > useTarget 1`] = `
 exports[`Alpine.js > svelte > Javascript Test > basic 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input x-on:change=\\"name = $event.target.value\\" x-bind:value=\\"name\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -5338,7 +5261,6 @@ exports[`Alpine.js > svelte > Javascript Test > lifecycleHooks 1`] = `
 exports[`Alpine.js > svelte > Javascript Test > reactive 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input x-bind:value=\\"name\\" />
-
   Lowercase:
   <span x-html=\\"lowercaseName\\"></span>
 </div>
@@ -5360,7 +5282,6 @@ exports[`Alpine.js > svelte > Javascript Test > reactiveWithFn 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input type=\\"number\\" x-on:change=\\"a = $event.target.value\\" x-bind:value=\\"a\\" />
   <input type=\\"number\\" x-on:change=\\"b = $event.target.value\\" x-bind:value=\\"b\\" />
-
   Result:
   <span x-html=\\"result\\"></span>
 </div>
@@ -5421,12 +5342,9 @@ exports[`Alpine.js > svelte > Javascript Test > style 1`] = `
 exports[`Alpine.js > svelte > Javascript Test > textExpressions 1`] = `
 "<div x-data=\\"myComponent()\\">
   normal:
-
   <span x-html=\\"a + b\\"></span>
   <br />
-
   conditional
-
   <span x-html=\\"a > 2 ? 'hello' : 'bye'\\"></span>
 </div>
 <script>
@@ -5443,7 +5361,6 @@ exports[`Alpine.js > svelte > Javascript Test > textExpressions 1`] = `
 exports[`Alpine.js > svelte > Typescript Test > basic 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input x-on:change=\\"name = $event.target.value\\" x-bind:value=\\"name\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -5652,7 +5569,6 @@ exports[`Alpine.js > svelte > Typescript Test > lifecycleHooks 1`] = `
 exports[`Alpine.js > svelte > Typescript Test > reactive 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input x-bind:value=\\"name\\" />
-
   Lowercase:
   <span x-html=\\"lowercaseName\\"></span>
 </div>
@@ -5674,7 +5590,6 @@ exports[`Alpine.js > svelte > Typescript Test > reactiveWithFn 1`] = `
 "<div x-data=\\"myComponent()\\">
   <input type=\\"number\\" x-on:change=\\"a = $event.target.value\\" x-bind:value=\\"a\\" />
   <input type=\\"number\\" x-on:change=\\"b = $event.target.value\\" x-bind:value=\\"b\\" />
-
   Result:
   <span x-html=\\"result\\"></span>
 </div>
@@ -5735,12 +5650,9 @@ exports[`Alpine.js > svelte > Typescript Test > style 1`] = `
 exports[`Alpine.js > svelte > Typescript Test > textExpressions 1`] = `
 "<div x-data=\\"myComponent()\\">
   normal:
-
   <span x-html=\\"a + b\\"></span>
   <br />
-
   conditional
-
   <span x-html=\\"a > 2 ? 'hello' : 'bye'\\"></span>
 </div>
 <script>

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -1527,6 +1527,31 @@ export class FormInputComponentModule {}
 "
 `;
 
+exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+})
+export class HelloModule {}
+"
+`;
+
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5792,6 +5817,31 @@ export class FormInputComponent {
   exports: [FormInputComponent],
 })
 export class FormInputComponentModule {}
+"
+`;
+
+exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+})
+export class HelloModule {}
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -1552,6 +1552,32 @@ export class FormInputComponentModule {}
 "
 `;
 
+exports[`Angular with Import Mapper Tests > jsx > Javascript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+  bootstrap: [SomeOtherComponent],
+})
+export class HelloModule {}
+"
+`;
+
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -5911,6 +5937,32 @@ export class FormInputComponent {
   bootstrap: [SomeOtherComponent],
 })
 export class FormInputComponentModule {}
+"
+`;
+
+exports[`Angular with Import Mapper Tests > jsx > Typescript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+  bootstrap: [SomeOtherComponent],
+})
+export class HelloModule {}
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -2875,6 +2875,49 @@ export class FormInputComponent {
 "
 `;
 
+exports[`Angular > jsx > Javascript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+})
+export class HelloModule {}
+"
+`;
+
+exports[`Angular > jsx > Javascript Test > Literal Space 2`] = `
+"import { Component, Input } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class Hello {
+  @Input() name: any;
+}
+"
+`;
+
 exports[`Angular > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -10730,6 +10773,49 @@ export class FormInputComponent {
   @Input() name: FormInputProps[\\"name\\"];
   @Input() value: FormInputProps[\\"value\\"];
   @Input() required: FormInputProps[\\"required\\"];
+}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > Literal Space 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component, Input } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+})
+export class Hello {
+  @Input() name: any;
+}
+
+@NgModule({
+  declarations: [Hello],
+  imports: [CommonModule],
+  exports: [Hello],
+})
+export class HelloModule {}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > Literal Space 2`] = `
+"import { Component, Input } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"hello, Hello\\",
+  template: \`
+    <div>Hello {{name ?? 'World'}}</div>
+  \`,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class Hello {
+  @Input() name: any;
 }
 "
 `;

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -570,14 +570,12 @@ function RenderBlock(props) {
     <>
       <TagNameRef {...properties()} style={css()}>
         <BlockStyles block={useBlock()} />
-
         {componentRef() ? (
           <ComponentRefRef
             {...componentOptions()}
             children={useBlock().children}
           />
         ) : null}
-
         {!componentRef() &&
         useBlock().children &&
         useBlock().children.length ? (

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -16,13 +16,10 @@ exports[`Html > jsx > Javascript Test > AdvancedRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\" data-dom-state=\\"select-1\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   </template>
-
   Hello
-
   <template data-el=\\"div-1\\"><!-- state.lowerCaseName() --></template>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -145,7 +142,6 @@ exports[`Html > jsx > Javascript Test > AdvancedRef 1`] = `
 exports[`Html > jsx > Javascript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <style>
@@ -213,7 +209,6 @@ exports[`Html > jsx > Javascript Test > Basic 2`] = `
   <template data-el=\\"for\\">
     <template data-el=\\"show\\">
       <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
       Hello
       <template data-el=\\"div-1\\"><!-- person --></template>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -378,9 +373,7 @@ exports[`Html > jsx > Javascript Test > Basic Context 1`] = `
   <template data-el=\\"div-1\\">
     <!-- myService.method('hello') + state.name -->
   </template>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
-
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
 </div>
 <script>
@@ -627,17 +620,13 @@ exports[`Html > jsx > Javascript Test > BasicAttribute 1`] = `
 exports[`Html > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "<div>
   <slot></slot>
-
   <template data-el=\\"div-2\\"><!-- props.type --></template>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component-2\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component-3\\"
   ></MyBooleanAttributeComponent>
@@ -715,7 +704,6 @@ exports[`Html > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 exports[`Html > jsx > Javascript Test > BasicChildComponent 1`] = `
 "<div>
   <MyBasicComponent data-el=\\"my-basic-component\\"></MyBasicComponent>
-
   <div>
     <MyBasicOnMountUpdateComponent
       data-el=\\"my-basic-on-mount-update-component\\"
@@ -775,7 +763,6 @@ exports[`Html > jsx > Javascript Test > BasicFor 1`] = `
 "<div>
   <template data-el=\\"for\\">
     <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
     Hello
     <template data-el=\\"div-1\\"><!-- person --></template>
     ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -925,13 +912,10 @@ exports[`Html > jsx > Javascript Test > BasicRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\" data-dom-state=\\"select-1\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   </template>
-
   Hello
-
   <template data-el=\\"div-1\\"><!-- state.lowerCaseName() --></template>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -1112,7 +1096,6 @@ exports[`Html > jsx > Javascript Test > BasicRefPrevious 1`] = `
     , before:
     <template data-el=\\"div-2\\"><!-- prevCount --></template>
   </h1>
-
   <button data-el=\\"button-1\\">Increment</button>
 </div>
 <script>
@@ -1191,7 +1174,6 @@ exports[`Html > jsx > Javascript Test > Button 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -1302,7 +1284,6 @@ exports[`Html > jsx > Javascript Test > Columns 1`] = `
   <template data-el=\\"for\\">
     <div class=\\"builder-column div-2\\">
       <template data-el=\\"div-1\\"><!-- column.content --></template>
-
       <template data-el=\\"div-2\\"><!-- index --></template>
     </div>
   </template>
@@ -1464,11 +1445,9 @@ exports[`Html > jsx > Javascript Test > Columns 1`] = `
 exports[`Html > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "<div>
   <slot data-el=\\"slot\\"></slot>
-
   <div>
     <hr />
   </div>
-
   <div>
     <slot></slot>
   </div>
@@ -1520,11 +1499,9 @@ exports[`Html > jsx > Javascript Test > ContentSlotJSX 1`] = `
         <template data-el=\\"div-2\\"><!-- props.content --></template>
       </slot>
     </template>
-
     <div>
       <hr />
     </div>
-
     <div><slot></slot></div>
   </div>
 </template>
@@ -1829,10 +1806,8 @@ exports[`Html > jsx > Javascript Test > Image 1`] = `
     <template data-el=\\"show\\">
       <img data-el=\\"img-1\\" />
     </template>
-
     <source data-el=\\"source-1\\" />
   </picture>
-
   <slot></slot>
 </div>
 <style>
@@ -2188,6 +2163,63 @@ exports[`Html > jsx > Javascript Test > Input 1`] = `
 
     // Update with initial state on first load
     update();
+  })();
+</script>
+"
+`;
+
+exports[`Html > jsx > Javascript Test > Literal Space 1`] = `
+"<div>
+  Hello
+  <template data-el=\\"div-1\\"><!-- props.name ?? 'World' --></template>
+</div>
+<script>
+  (() => {
+    const state = {};
+    let props = {};
+    let context = null;
+    let nodesToDestroy = [];
+    let pendingUpdate = false;
+
+    function destroyAnyNodes() {
+      // destroy current view template refs before rendering again
+      nodesToDestroy.forEach((el) => el.remove());
+      nodesToDestroy = [];
+    }
+
+    // Function to update data bindings and loops
+    // call update() when you mutate state and need the updates to reflect
+    // in the dom
+    function update() {
+      if (pendingUpdate === true) {
+        return;
+      }
+      pendingUpdate = true;
+
+      document.querySelectorAll(\\"[data-el='div-1']\\").forEach((el) => {
+        renderTextNode(el, props.name ?? \\"World\\");
+      });
+
+      destroyAnyNodes();
+
+      pendingUpdate = false;
+    }
+
+    // Update with initial state on first load
+    update();
+
+    // Helper text DOM nodes
+    function renderTextNode(el, text) {
+      const textNode = document.createTextNode(text);
+      if (el?.scope) {
+        textNode.scope = el.scope;
+      }
+      if (el?.context) {
+        child.context = el.context;
+      }
+      el.after(textNode);
+      nodesToDestroy.push(el.nextSibling);
+    }
   })();
 </script>
 "
@@ -2662,9 +2694,7 @@ exports[`Html > jsx > Javascript Test > SlotJsx 1`] = `
 exports[`Html > jsx > Javascript Test > SlotNamed 1`] = `
 "<div>
   <slot name=\\"top\\"></slot>
-
   <slot name=\\"left\\">Default left</slot>
-
   <slot>Default Child</slot>
 </div>
 "
@@ -2673,7 +2703,6 @@ exports[`Html > jsx > Javascript Test > SlotNamed 1`] = `
 exports[`Html > jsx > Javascript Test > Stamped.io 1`] = `
 "<div data-el=\\"div-1\\">
   <button data-el=\\"button-1\\">Write a review</button>
-
   <template data-el=\\"show\\">
     <input placeholder=\\"Email\\" data-dom-state=\\"input-1\\" />
 
@@ -2684,24 +2713,20 @@ exports[`Html > jsx > Javascript Test > Stamped.io 1`] = `
       class=\\"textarea\\"
       data-dom-state=\\"textarea-1\\"
     ></textarea>
-
     <button class=\\"button\\" data-el=\\"button-2\\">Submit</button>
   </template>
 
   <template data-el=\\"for\\">
     <div class=\\"review\\" data-el=\\"review\\">
       <img class=\\"img\\" data-el=\\"img-1\\" />
-
       <div data-el=\\"div-2\\">
         <div>
           N:
           <template data-el=\\"div-3\\"><!-- index --></template>
         </div>
-
         <div>
           <template data-el=\\"div-4\\"><!-- review.author --></template>
         </div>
-
         <div>
           <template data-el=\\"div-5\\"><!-- review.reviewMessage --></template>
         </div>
@@ -3238,7 +3263,6 @@ exports[`Html > jsx > Javascript Test > basicForNoTagReference 1`] = `
   <template data-el=\\"for\\">
     <state.TagName>
       <action.icon></action.icon>
-
       <span>
         <template data-el=\\"div-2\\"><!-- action.text --></template>
       </span>
@@ -3750,7 +3774,6 @@ exports[`Html > jsx > Javascript Test > componentWithContext 1`] = `
 
 exports[`Html > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
 "<template data-el=\\"div-1\\"><!-- foo.value --></template>
-
 <div>other</div>
 
 <script>
@@ -3817,7 +3840,6 @@ exports[`Html > jsx > Javascript Test > defaultProps 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.buttonText --></template>
@@ -3940,7 +3962,6 @@ exports[`Html > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -4494,9 +4515,7 @@ exports[`Html > jsx > Javascript Test > preserveTyping 1`] = `
 exports[`Html > jsx > Javascript Test > propsDestructure 1`] = `
 "<div>
   <slot></slot>
-
   <template data-el=\\"div-2\\"><!-- props.type --></template>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -4675,7 +4694,6 @@ exports[`Html > jsx > Javascript Test > renderBlock 1`] = `
   <template data-el=\\"show-2\\">
     <state.tag data-el=\\"state-tag\\"></state.tag>
   </template>
-
   <template data-el=\\"show-3\\">
     <template data-el=\\"for\\">
       <RenderRepeatedBlock
@@ -4683,7 +4701,6 @@ exports[`Html > jsx > Javascript Test > renderBlock 1`] = `
       ></RenderRepeatedBlock>
     </template>
   </template>
-
   <template data-el=\\"show-4\\">
     <state.tag data-el=\\"state-tag-2\\">
       <state.renderComponentTag
@@ -5130,7 +5147,6 @@ exports[`Html > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
     <template data-el=\\"div-1\\"><!-- props.text --></template>
   </a>
 </template>
-
 <template data-el=\\"show-2\\">
   <button type=\\"button\\" data-el=\\"button-1\\">
     <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -5305,7 +5321,6 @@ exports[`Html > jsx > Javascript Test > rootShow 1`] = `
 exports[`Html > jsx > Javascript Test > self-referencing component 1`] = `
 "<div>
   <template data-el=\\"div-1\\"><!-- props.name --></template>
-
   <template data-el=\\"show\\">
     <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
   </template>
@@ -5392,9 +5407,7 @@ exports[`Html > jsx > Javascript Test > self-referencing component 1`] = `
 exports[`Html > jsx > Javascript Test > self-referencing component with children 1`] = `
 "<div>
   <template data-el=\\"div-1\\"><!-- props.name --></template>
-
   <slot></slot>
-
   <template data-el=\\"show\\">
     <MyComponent name=\\"Bruce\\">
       <div>Wayne</div>
@@ -5770,13 +5783,11 @@ exports[`Html > jsx > Javascript Test > svgComponent 1`] = `
   <defs>
     <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
       <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
       <feBlend
         in=\\"SourceGraphic\\"
         in2=\\"BackgroundImageFix\\"
         result=\\"shape\\"
       ></feBlend>
-
       <feGaussianBlur
         result=\\"effect1_foregroundBlur\\"
         data-el=\\"fe-gaussian-blur\\"
@@ -6066,13 +6077,10 @@ exports[`Html > jsx > Typescript Test > AdvancedRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\" data-dom-state=\\"select-1\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   </template>
-
   Hello
-
   <template data-el=\\"div-1\\"><!-- state.lowerCaseName() --></template>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -6195,7 +6203,6 @@ exports[`Html > jsx > Typescript Test > AdvancedRef 1`] = `
 exports[`Html > jsx > Typescript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <style>
@@ -6263,7 +6270,6 @@ exports[`Html > jsx > Typescript Test > Basic 2`] = `
   <template data-el=\\"for\\">
     <template data-el=\\"show\\">
       <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
       Hello
       <template data-el=\\"div-1\\"><!-- person --></template>
       ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -6428,9 +6434,7 @@ exports[`Html > jsx > Typescript Test > Basic Context 1`] = `
   <template data-el=\\"div-1\\">
     <!-- myService.method('hello') + state.name -->
   </template>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
-
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
 </div>
 <script>
@@ -6677,17 +6681,13 @@ exports[`Html > jsx > Typescript Test > BasicAttribute 1`] = `
 exports[`Html > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "<div>
   <slot></slot>
-
   <template data-el=\\"div-2\\"><!-- props.type --></template>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component-2\\"
   ></MyBooleanAttributeComponent>
-
   <MyBooleanAttributeComponent
     data-el=\\"my-boolean-attribute-component-3\\"
   ></MyBooleanAttributeComponent>
@@ -6765,7 +6765,6 @@ exports[`Html > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 exports[`Html > jsx > Typescript Test > BasicChildComponent 1`] = `
 "<div>
   <MyBasicComponent data-el=\\"my-basic-component\\"></MyBasicComponent>
-
   <div>
     <MyBasicOnMountUpdateComponent
       data-el=\\"my-basic-on-mount-update-component\\"
@@ -6825,7 +6824,6 @@ exports[`Html > jsx > Typescript Test > BasicFor 1`] = `
 "<div>
   <template data-el=\\"for\\">
     <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
     Hello
     <template data-el=\\"div-1\\"><!-- person --></template>
     ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -6975,13 +6973,10 @@ exports[`Html > jsx > Typescript Test > BasicRef 1`] = `
 
     <select name=\\"cars\\" id=\\"cars\\" data-dom-state=\\"select-1\\">
       <option value=\\"supra\\">GR Supra</option>
-
       <option value=\\"86\\">GR 86</option>
     </select>
   </template>
-
   Hello
-
   <template data-el=\\"div-1\\"><!-- state.lowerCaseName() --></template>
   ! I can run in React, Qwik, Vue, Solid, or Web Component!
 </div>
@@ -7162,7 +7157,6 @@ exports[`Html > jsx > Typescript Test > BasicRefPrevious 1`] = `
     , before:
     <template data-el=\\"div-2\\"><!-- prevCount --></template>
   </h1>
-
   <button data-el=\\"button-1\\">Increment</button>
 </div>
 <script>
@@ -7241,7 +7235,6 @@ exports[`Html > jsx > Typescript Test > Button 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -7352,7 +7345,6 @@ exports[`Html > jsx > Typescript Test > Columns 1`] = `
   <template data-el=\\"for\\">
     <div class=\\"builder-column div-2\\">
       <template data-el=\\"div-1\\"><!-- column.content --></template>
-
       <template data-el=\\"div-2\\"><!-- index --></template>
     </div>
   </template>
@@ -7514,11 +7506,9 @@ exports[`Html > jsx > Typescript Test > Columns 1`] = `
 exports[`Html > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "<div>
   <slot data-el=\\"slot\\"></slot>
-
   <div>
     <hr />
   </div>
-
   <div>
     <slot></slot>
   </div>
@@ -7570,11 +7560,9 @@ exports[`Html > jsx > Typescript Test > ContentSlotJSX 1`] = `
         <template data-el=\\"div-2\\"><!-- props.content --></template>
       </slot>
     </template>
-
     <div>
       <hr />
     </div>
-
     <div><slot></slot></div>
   </div>
 </template>
@@ -7879,10 +7867,8 @@ exports[`Html > jsx > Typescript Test > Image 1`] = `
     <template data-el=\\"show\\">
       <img data-el=\\"img-1\\" />
     </template>
-
     <source data-el=\\"source-1\\" />
   </picture>
-
   <slot></slot>
 </div>
 <style>
@@ -8238,6 +8224,63 @@ exports[`Html > jsx > Typescript Test > Input 1`] = `
 
     // Update with initial state on first load
     update();
+  })();
+</script>
+"
+`;
+
+exports[`Html > jsx > Typescript Test > Literal Space 1`] = `
+"<div>
+  Hello
+  <template data-el=\\"div-1\\"><!-- props.name ?? 'World' --></template>
+</div>
+<script>
+  (() => {
+    const state = {};
+    let props = {};
+    let context = null;
+    let nodesToDestroy = [];
+    let pendingUpdate = false;
+
+    function destroyAnyNodes() {
+      // destroy current view template refs before rendering again
+      nodesToDestroy.forEach((el) => el.remove());
+      nodesToDestroy = [];
+    }
+
+    // Function to update data bindings and loops
+    // call update() when you mutate state and need the updates to reflect
+    // in the dom
+    function update() {
+      if (pendingUpdate === true) {
+        return;
+      }
+      pendingUpdate = true;
+
+      document.querySelectorAll(\\"[data-el='div-1']\\").forEach((el) => {
+        renderTextNode(el, props.name ?? \\"World\\");
+      });
+
+      destroyAnyNodes();
+
+      pendingUpdate = false;
+    }
+
+    // Update with initial state on first load
+    update();
+
+    // Helper text DOM nodes
+    function renderTextNode(el, text) {
+      const textNode = document.createTextNode(text);
+      if (el?.scope) {
+        textNode.scope = el.scope;
+      }
+      if (el?.context) {
+        child.context = el.context;
+      }
+      el.after(textNode);
+      nodesToDestroy.push(el.nextSibling);
+    }
   })();
 </script>
 "
@@ -8712,9 +8755,7 @@ exports[`Html > jsx > Typescript Test > SlotJsx 1`] = `
 exports[`Html > jsx > Typescript Test > SlotNamed 1`] = `
 "<div>
   <slot name=\\"top\\"></slot>
-
   <slot name=\\"left\\">Default left</slot>
-
   <slot>Default Child</slot>
 </div>
 "
@@ -8723,7 +8764,6 @@ exports[`Html > jsx > Typescript Test > SlotNamed 1`] = `
 exports[`Html > jsx > Typescript Test > Stamped.io 1`] = `
 "<div data-el=\\"div-1\\">
   <button data-el=\\"button-1\\">Write a review</button>
-
   <template data-el=\\"show\\">
     <input placeholder=\\"Email\\" data-dom-state=\\"input-1\\" />
 
@@ -8734,24 +8774,20 @@ exports[`Html > jsx > Typescript Test > Stamped.io 1`] = `
       class=\\"textarea\\"
       data-dom-state=\\"textarea-1\\"
     ></textarea>
-
     <button class=\\"button\\" data-el=\\"button-2\\">Submit</button>
   </template>
 
   <template data-el=\\"for\\">
     <div class=\\"review\\" data-el=\\"review\\">
       <img class=\\"img\\" data-el=\\"img-1\\" />
-
       <div data-el=\\"div-2\\">
         <div>
           N:
           <template data-el=\\"div-3\\"><!-- index --></template>
         </div>
-
         <div>
           <template data-el=\\"div-4\\"><!-- review.author --></template>
         </div>
-
         <div>
           <template data-el=\\"div-5\\"><!-- review.reviewMessage --></template>
         </div>
@@ -9288,7 +9324,6 @@ exports[`Html > jsx > Typescript Test > basicForNoTagReference 1`] = `
   <template data-el=\\"for\\">
     <state.TagName>
       <action.icon></action.icon>
-
       <span>
         <template data-el=\\"div-2\\"><!-- action.text --></template>
       </span>
@@ -9800,7 +9835,6 @@ exports[`Html > jsx > Typescript Test > componentWithContext 1`] = `
 
 exports[`Html > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
 "<template data-el=\\"div-1\\"><!-- foo.value --></template>
-
 <div>other</div>
 
 <script>
@@ -9867,7 +9901,6 @@ exports[`Html > jsx > Typescript Test > defaultProps 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.buttonText --></template>
@@ -9990,7 +10023,6 @@ exports[`Html > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
       <template data-el=\\"div-1\\"><!-- props.text --></template>
     </a>
   </template>
-
   <template data-el=\\"show-2\\">
     <button type=\\"button\\" data-el=\\"button-1\\">
       <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -10544,9 +10576,7 @@ exports[`Html > jsx > Typescript Test > preserveTyping 1`] = `
 exports[`Html > jsx > Typescript Test > propsDestructure 1`] = `
 "<div>
   <slot></slot>
-
   <template data-el=\\"div-2\\"><!-- props.type --></template>
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -10725,7 +10755,6 @@ exports[`Html > jsx > Typescript Test > renderBlock 1`] = `
   <template data-el=\\"show-2\\">
     <state.tag data-el=\\"state-tag\\"></state.tag>
   </template>
-
   <template data-el=\\"show-3\\">
     <template data-el=\\"for\\">
       <RenderRepeatedBlock
@@ -10733,7 +10762,6 @@ exports[`Html > jsx > Typescript Test > renderBlock 1`] = `
       ></RenderRepeatedBlock>
     </template>
   </template>
-
   <template data-el=\\"show-4\\">
     <state.tag data-el=\\"state-tag-2\\">
       <state.renderComponentTag
@@ -11183,7 +11211,6 @@ exports[`Html > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
     <template data-el=\\"div-1\\"><!-- props.text --></template>
   </a>
 </template>
-
 <template data-el=\\"show-2\\">
   <button type=\\"button\\" data-el=\\"button-1\\">
     <template data-el=\\"div-2\\"><!-- props.text --></template>
@@ -11358,7 +11385,6 @@ exports[`Html > jsx > Typescript Test > rootShow 1`] = `
 exports[`Html > jsx > Typescript Test > self-referencing component 1`] = `
 "<div>
   <template data-el=\\"div-1\\"><!-- props.name --></template>
-
   <template data-el=\\"show\\">
     <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
   </template>
@@ -11445,9 +11471,7 @@ exports[`Html > jsx > Typescript Test > self-referencing component 1`] = `
 exports[`Html > jsx > Typescript Test > self-referencing component with children 1`] = `
 "<div>
   <template data-el=\\"div-1\\"><!-- props.name --></template>
-
   <slot></slot>
-
   <template data-el=\\"show\\">
     <MyComponent name=\\"Bruce\\">
       <div>Wayne</div>
@@ -11823,13 +11847,11 @@ exports[`Html > jsx > Typescript Test > svgComponent 1`] = `
   <defs>
     <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
       <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
       <feBlend
         in=\\"SourceGraphic\\"
         in2=\\"BackgroundImageFix\\"
         result=\\"shape\\"
       ></feBlend>
-
       <feGaussianBlur
         result=\\"effect1_foregroundBlur\\"
         data-el=\\"fe-gaussian-blur\\"
@@ -12048,7 +12070,6 @@ exports[`Html > jsx > Typescript Test > useTarget 1`] = `
 exports[`Html > svelte > Javascript Test > basic 1`] = `
 "<div>
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -12824,7 +12845,6 @@ exports[`Html > svelte > Javascript Test > lifecycleHooks 1`] = `
 exports[`Html > svelte > Javascript Test > reactive 1`] = `
 "<div>
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Lowercase:
   <template data-el=\\"div-1\\"><!-- state.lowercaseName --></template>
 </div>
@@ -12893,7 +12913,6 @@ exports[`Html > svelte > Javascript Test > reactiveWithFn 1`] = `
 "<div>
   <input type=\\"number\\" data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
   <input type=\\"number\\" data-el=\\"input-3\\" data-dom-state=\\"input-4\\" />
-
   Result:
   <template data-el=\\"div-1\\"><!-- state.result --></template>
 </div>
@@ -13011,12 +13030,9 @@ exports[`Html > svelte > Javascript Test > style 1`] = `
 exports[`Html > svelte > Javascript Test > textExpressions 1`] = `
 "<div>
   normal:
-
   <template data-el=\\"div-1\\"><!-- state.a + state.b --></template>
   <br />
-
   conditional
-
   <template data-el=\\"div-2\\"><!-- state.a > 2 ? 'hello' : 'bye' --></template>
 </div>
 <script>
@@ -13078,7 +13094,6 @@ exports[`Html > svelte > Javascript Test > textExpressions 1`] = `
 exports[`Html > svelte > Typescript Test > basic 1`] = `
 "<div>
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Hello! I can run in React, Vue, Solid, or Liquid!
 </div>
 <script>
@@ -13854,7 +13869,6 @@ exports[`Html > svelte > Typescript Test > lifecycleHooks 1`] = `
 exports[`Html > svelte > Typescript Test > reactive 1`] = `
 "<div>
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
-
   Lowercase:
   <template data-el=\\"div-1\\"><!-- state.lowercaseName --></template>
 </div>
@@ -13923,7 +13937,6 @@ exports[`Html > svelte > Typescript Test > reactiveWithFn 1`] = `
 "<div>
   <input type=\\"number\\" data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
   <input type=\\"number\\" data-el=\\"input-3\\" data-dom-state=\\"input-4\\" />
-
   Result:
   <template data-el=\\"div-1\\"><!-- state.result --></template>
 </div>
@@ -14041,12 +14054,9 @@ exports[`Html > svelte > Typescript Test > style 1`] = `
 exports[`Html > svelte > Typescript Test > textExpressions 1`] = `
 "<div>
   normal:
-
   <template data-el=\\"div-1\\"><!-- state.a + state.b --></template>
   <br />
-
   conditional
-
   <template data-el=\\"div-2\\"><!-- state.a > 2 ? 'hello' : 'bye' --></template>
 </div>
 <script>

--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -294,6 +294,11 @@ exports[`Liquid > jsx > Javascript Test > Input 1`] = `
 "
 `;
 
+exports[`Liquid > jsx > Javascript Test > Literal Space 1`] = `
+"<div>Hello</div>
+"
+`;
+
 exports[`Liquid > jsx > Javascript Test > RawText 1`] = `
 "<span></span>
 "
@@ -1158,6 +1163,11 @@ exports[`Liquid > jsx > Typescript Test > Input 1`] = `
   defaultValue=\\"{{defaultValue}}\\"
   required=\\"{{required}}\\"
 />
+"
+`;
+
+exports[`Liquid > jsx > Typescript Test > Literal Space 1`] = `
+"<div>Hello</div>
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
@@ -1485,6 +1485,29 @@ export default class FormInputComponent extends LitElement {
 "
 `;
 
+exports[`Lit > jsx > Javascript Test > Literal Space 1`] = `
+"import { LitElement, html, css } from \\"lit\\";
+import { customElement, property, state, query } from \\"lit/decorators.js\\";
+
+@customElement(\\"my-hello\\")
+export default class Hello extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  @property() name: any;
+
+  render() {
+    return html\`
+
+          <div>Hello \${this.name ?? \\"World\\"}</div>
+
+        \`;
+  }
+}
+"
+`;
+
 exports[`Lit > jsx > Javascript Test > RawText 1`] = `
 "import { LitElement, html, css } from \\"lit\\";
 import { customElement, property, state, query } from \\"lit/decorators.js\\";
@@ -5631,6 +5654,29 @@ export default class FormInputComponent extends LitElement {
     } .placeholder=\${this.placeholder}
         .type=\${this.type} .name=\${this.name} .value=\${this.value}
         .defaultValue=\${this.defaultValue} .required=\${this.required} />
+
+        \`;
+  }
+}
+"
+`;
+
+exports[`Lit > jsx > Typescript Test > Literal Space 1`] = `
+"import { LitElement, html, css } from \\"lit\\";
+import { customElement, property, state, query } from \\"lit/decorators.js\\";
+
+@customElement(\\"my-hello\\")
+export default class Hello extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  @property() name: any;
+
+  render() {
+    return html\`
+
+          <div>Hello \${this.name ?? \\"World\\"}</div>
 
         \`;
   }

--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -894,7 +894,7 @@ class {
 }
 
 style { 
-  .pre-1e20cf46 {
+  .pre-694cf00c {
     padding: 10px;
     color: red;
     text-align: center;
@@ -929,7 +929,7 @@ style {
     ></BuilderBlocks></if>
 
   <if(component.submissionState === 'error' && state.responseData)>
-    <pre class=\\"builder-form-error-text pre-1e20cf46\\">
+    <pre class=\\"builder-form-error-text pre-694cf00c\\">
           
 \${JSON.stringify(state.responseData, null, 2)}
 
@@ -1071,6 +1071,12 @@ class {}
   defaultValue=(input.defaultValue)
   required=(input.required)
 />"
+`;
+
+exports[`Marko > jsx > Javascript Test > Literal Space 1`] = `
+"class {}
+
+<div>Hello \${input.name ?? 'World'}</div>"
 `;
 
 exports[`Marko > jsx > Javascript Test > RawText 1`] = `
@@ -3187,7 +3193,7 @@ class {
 }
 
 style { 
-  .pre-3c6996d6 {
+  .pre-11f69878 {
     padding: 10px;
     color: red;
     text-align: center;
@@ -3222,7 +3228,7 @@ style {
     ></BuilderBlocks></if>
 
   <if(component.submissionState === 'error' && state.responseData)>
-    <pre class=\\"builder-form-error-text pre-3c6996d6\\">
+    <pre class=\\"builder-form-error-text pre-11f69878\\">
           
 \${JSON.stringify(state.responseData, null, 2)}
 
@@ -3364,6 +3370,12 @@ class {}
   defaultValue=(input.defaultValue)
   required=(input.required)
 />"
+`;
+
+exports[`Marko > jsx > Typescript Test > Literal Space 1`] = `
+"class {}
+
+<div>Hello \${input.name ?? 'World'}</div>"
 `;
 
 exports[`Marko > jsx > Typescript Test > RawText 1`] = `

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -4592,6 +4592,62 @@ exports[`Parse JSX > Javascript > Input 1`] = `
 }
 `;
 
+exports[`Parse JSX > Javascript > Literal Space 1`] = `
+{
+  "@type": "@builder.io/mitosis/component",
+  "children": [
+    {
+      "@type": "@builder.io/mitosis/node",
+      "bindings": {},
+      "children": [
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {},
+          "children": [],
+          "meta": {},
+          "name": "div",
+          "properties": {
+            "_text": "Hello ",
+          },
+          "scope": {},
+        },
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {
+            "_text": {
+              "code": "props.name ?? 'World'",
+              "type": "single",
+            },
+          },
+          "children": [],
+          "meta": {},
+          "name": "div",
+          "properties": {},
+          "scope": {},
+        },
+      ],
+      "meta": {},
+      "name": "div",
+      "properties": {},
+      "scope": {},
+    },
+  ],
+  "context": {
+    "get": {},
+    "set": {},
+  },
+  "exports": {},
+  "hooks": {},
+  "imports": [],
+  "inputs": [],
+  "meta": {},
+  "name": "Hello",
+  "refs": {},
+  "state": {},
+  "subComponents": [],
+}
+`;
+
 exports[`Parse JSX > Javascript > RawText 1`] = `
 {
   "@type": "@builder.io/mitosis/component",
@@ -16725,6 +16781,62 @@ exports[`Parse JSX > Typescript > Input 1`] = `
   required?: boolean;
 }",
   ],
+}
+`;
+
+exports[`Parse JSX > Typescript > Literal Space 1`] = `
+{
+  "@type": "@builder.io/mitosis/component",
+  "children": [
+    {
+      "@type": "@builder.io/mitosis/node",
+      "bindings": {},
+      "children": [
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {},
+          "children": [],
+          "meta": {},
+          "name": "div",
+          "properties": {
+            "_text": "Hello ",
+          },
+          "scope": {},
+        },
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {
+            "_text": {
+              "code": "props.name ?? 'World'",
+              "type": "single",
+            },
+          },
+          "children": [],
+          "meta": {},
+          "name": "div",
+          "properties": {},
+          "scope": {},
+        },
+      ],
+      "meta": {},
+      "name": "div",
+      "properties": {},
+      "scope": {},
+    },
+  ],
+  "context": {
+    "get": {},
+    "set": {},
+  },
+  "exports": {},
+  "hooks": {},
+  "imports": [],
+  "inputs": [],
+  "meta": {},
+  "name": "Hello",
+  "refs": {},
+  "state": {},
+  "subComponents": [],
 }
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -42,7 +42,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -165,12 +164,7 @@ function MyBasicOnMountUpdateComponent(props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -237,14 +231,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props) {
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </div>
   );
@@ -269,7 +258,6 @@ function MyBasicChildComponent(props) {
   return (
     <div>
       <MyBasicComponent id={dev} />
-
       <div>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </div>
@@ -356,7 +344,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -432,11 +419,8 @@ function MyPreviousComponent(props) {
   return (
     <div>
       <h1>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </h1>
-
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
   );
@@ -464,7 +448,6 @@ function Button(props) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button type=\\"button\\" {...props.attributes}>
@@ -510,9 +493,7 @@ function Column(props) {
       <div className=\\"builder-columns div\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -553,11 +534,9 @@ function ContentSlotCode(props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div>{props.children}</div>
     </div>
   );
@@ -599,11 +578,9 @@ function ContentSlotJsxCode(props) {
             {showContent && props.slotContent ? (
               <Fragment>{props.slotContent || \\"{props.content}\\"}</Fragment>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </Fragment>
@@ -1126,10 +1103,8 @@ function Image(props) {
               />
             </Fragment>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
       <style jsx>{\`
@@ -1222,6 +1197,18 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Preact > jsx > Javascript Test > Literal Space 1`] = `
+"/** @jsx h */
+import { h, Fragment } from \\"preact\\";
+
+function Hello(props) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -1356,9 +1343,7 @@ function SlotCode(props) {
   return (
     <div>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </div>
   );
@@ -1407,7 +1392,6 @@ function SmileReviews(props) {
         <button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <Fragment>
             <input placeholder=\\"Email\\" />
@@ -1427,19 +1411,12 @@ function SmileReviews(props) {
             </button>
           </Fragment>
         ) : null}
-
         {reviews?.map((review, index) => (
           <div className=\\"review\\" key={review.id}>
             <img className=\\"img\\" src={review.avatar} />
-
             <div className={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -1592,12 +1569,7 @@ function MyComponent(props) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyComponent;
@@ -1624,12 +1596,10 @@ function MyBasicForNoTagRefComponent(props) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <Tag>{name}</Tag>
+      Hello <Tag>{name}</Tag>
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <span>{action.text}</span>
         </TagName>
       ))}
@@ -1728,12 +1698,7 @@ function MyBasicOnUpdateReturnComponent(props) {
     };
   }, [name]);
 
-  return (
-    <div>
-      Hello!
-      {name}
-    </div>
-  );
+  return <div>Hello! {name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -1975,7 +1940,6 @@ function Button(props) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button
@@ -2022,7 +1986,6 @@ function Button(props) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button
@@ -2058,13 +2021,7 @@ const DEFAULT_VALUES = {
 };
 
 function ComponentWithTypes(props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -2294,12 +2251,7 @@ function OnInit(props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {name}
-    </div>
-  );
+  return <div>Default name defined by parent {name}</div>;
 }
 
 export default OnInit;
@@ -2391,10 +2343,7 @@ import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2412,8 +2361,7 @@ function MyBasicComponent(props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -2429,10 +2377,7 @@ import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2446,10 +2391,7 @@ import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2728,7 +2670,6 @@ function RenderBlock(props) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -2869,7 +2810,6 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <Fragment>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -2891,9 +2831,7 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <Fragment>
           <MyComponent name=\\"Bruce\\">
@@ -3046,9 +2984,7 @@ function SvgComponent(props) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </filter>
       </defs>
@@ -3175,10 +3111,7 @@ function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
 
   return (
-    <div>
-      Hello
-      {name}! I can run in React, Qwik, Vue, Solid, or Liquid!
-    </div>
+    <div>Hello {name}! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   );
 }
 
@@ -3232,7 +3165,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -3364,12 +3296,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -3441,14 +3368,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props: Props) {
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </div>
   );
@@ -3473,7 +3395,6 @@ function MyBasicChildComponent(props: any) {
   return (
     <div>
       <MyBasicComponent id={dev} />
-
       <div>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </div>
@@ -3564,7 +3485,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -3648,11 +3568,8 @@ function MyPreviousComponent(props: Props) {
   return (
     <div>
       <h1>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </h1>
-
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
   );
@@ -3687,7 +3604,6 @@ function Button(props: ButtonProps) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button type=\\"button\\" {...props.attributes}>
@@ -3748,9 +3664,7 @@ function Column(props: ColumnProps) {
       <div className=\\"builder-columns div\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -3797,11 +3711,9 @@ function ContentSlotCode(props: Props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div>{props.children}</div>
     </div>
   );
@@ -3848,11 +3760,9 @@ function ContentSlotJsxCode(props: Props) {
             {showContent && props.slotContent ? (
               <Fragment>{props.slotContent || \\"{props.content}\\"}</Fragment>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </Fragment>
@@ -4435,10 +4345,8 @@ function Image(props: ImageProps) {
               />
             </Fragment>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
       <style jsx>{\`
@@ -4560,6 +4468,18 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Preact > jsx > Typescript Test > Literal Space 1`] = `
+"/** @jsx h */
+import { h, Fragment } from \\"preact\\";
+
+function Hello(props: any) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -4733,9 +4653,7 @@ function SlotCode(props: Props) {
   return (
     <div>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </div>
   );
@@ -4789,7 +4707,6 @@ function SmileReviews(props: SmileReviewsProps) {
         <button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <Fragment>
             <input placeholder=\\"Email\\" />
@@ -4809,19 +4726,12 @@ function SmileReviews(props: SmileReviewsProps) {
             </button>
           </Fragment>
         ) : null}
-
         {reviews?.map((review, index) => (
           <div className=\\"review\\" key={review.id}>
             <img className=\\"img\\" src={review.avatar} />
-
             <div className={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -5022,12 +4932,7 @@ function MyComponent(props: any) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyComponent;
@@ -5054,12 +4959,10 @@ function MyBasicForNoTagRefComponent(props: any) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <Tag>{name}</Tag>
+      Hello <Tag>{name}</Tag>
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <span>{action.text}</span>
         </TagName>
       ))}
@@ -5168,12 +5071,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
     };
   }, [name]);
 
-  return (
-    <div>
-      Hello!
-      {name}
-    </div>
-  );
+  return <div>Hello! {name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -5441,7 +5339,6 @@ function Button(props: ButtonProps) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button
@@ -5496,7 +5393,6 @@ function Button(props: ButtonProps) {
           </a>
         </Fragment>
       ) : null}
-
       {!props.link ? (
         <Fragment>
           <button
@@ -5536,13 +5432,7 @@ const DEFAULT_VALUES: Props = {
 };
 
 function ComponentWithTypes(props: Props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -5788,12 +5678,7 @@ function OnInit(props: Props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {name}
-    </div>
-  );
+  return <div>Default name defined by parent {name}</div>;
 }
 
 export default OnInit;
@@ -5912,10 +5797,7 @@ export interface MyBasicComponentProps {
 
 function MyBasicComponent(props: MyBasicComponentProps) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5938,8 +5820,7 @@ function MyBasicComponent(props: Props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -5960,10 +5841,7 @@ interface Person {
 
 function MyBasicComponent(props: Person | never) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5982,10 +5860,7 @@ type Person = {
 
 function MyBasicComponent(props: Person) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -6277,7 +6152,6 @@ function RenderBlock(props: RenderBlockProps) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -6437,7 +6311,6 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <Fragment>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -6459,9 +6332,7 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <Fragment>
           <MyComponent name=\\"Bruce\\">
@@ -6623,9 +6494,7 @@ function SvgComponent(props: any) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </filter>
       </defs>
@@ -6826,14 +6695,8 @@ function MyComponent(props) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla}
-      </p>
-      <p>
-        Fillings:
-        {fillings}
-      </p>
+      <p>Tortilla: {tortilla}</p>
+      <p>Fillings: {fillings}</p>
     </div>
   );
 }
@@ -7040,8 +6903,7 @@ function MyComponent(props) {
   return (
     <div>
       <input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -7082,8 +6944,7 @@ function MyComponent(props) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </div>
   );
 }
@@ -7236,14 +7097,8 @@ function MyComponent(props: any) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla}
-      </p>
-      <p>
-        Fillings:
-        {fillings}
-      </p>
+      <p>Tortilla: {tortilla}</p>
+      <p>Fillings: {fillings}</p>
     </div>
   );
 }
@@ -7450,8 +7305,7 @@ function MyComponent(props: any) {
   return (
     <div>
       <input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -7492,8 +7346,7 @@ function MyComponent(props: any) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </div>
   );
 }

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -3000,6 +3000,17 @@ export default FormInputComponent;
 "
 `;
 
+exports[`qwik > jsx > Javascript Test > Literal Space 1`] = `
+"import { Fragment, component$, h } from \\"@builder.io/qwik\\";
+
+export const Hello = component$((props) => {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+});
+
+export default Hello;
+"
+`;
+
 exports[`qwik > jsx > Javascript Test > RawText 1`] = `
 "import { Fragment, component$, h } from \\"@builder.io/qwik\\";
 
@@ -6159,6 +6170,17 @@ export const FormInputComponent = component$((props: FormInputProps) => {
 });
 
 export default FormInputComponent;
+"
+`;
+
+exports[`qwik > jsx > Typescript Test > Literal Space 1`] = `
+"import { Fragment, component$, h } from \\"@builder.io/qwik\\";
+
+export const Hello = component$((props: any) => {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+});
+
+export default Hello;
 "
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -50,7 +50,6 @@ function MyBasicRefComponent(props) {
             <View value=\\"supra\\">
               <Text>GR Supra</Text>
             </View>
-
             <View value=\\"86\\">
               <Text>GR 86</Text>
             </View>
@@ -287,14 +286,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props) {
   return (
     <View>
-      {props.children}
-
-      <Text>{props.type}</Text>
-
+      {props.children} <Text>{props.type}</Text>
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </View>
   );
@@ -326,7 +320,6 @@ function MyBasicChildComponent(props) {
   return (
     <View>
       <MyBasicComponent id={dev} />
-
       <View>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </View>
@@ -430,7 +423,6 @@ function MyBasicRefComponent(props) {
             <View value=\\"supra\\">
               <Text>GR Supra</Text>
             </View>
-
             <View value=\\"86\\">
               <Text>GR 86</Text>
             </View>
@@ -525,7 +517,6 @@ function MyPreviousComponent(props) {
         <Text>, before: </Text>
         <Text>{prevCount.current}</Text>
       </View>
-
       <View onClick={(event) => setCount(1)}>
         <Text>Increment</Text>
       </View>
@@ -562,7 +553,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View type=\\"button\\" {...props.attributes}>
@@ -614,9 +604,7 @@ function Column(props) {
     <View style={styles.view1}>
       {props.columns?.map((column, index) => (
         <View style={styles.view2}>
-          <Text>{column.content}</Text>
-
-          <Text>{index}</Text>
+          <Text>{column.content}</Text> <Text>{index}</Text>
         </View>
       ))}
     </View>
@@ -647,11 +635,9 @@ function ContentSlotCode(props) {
   return (
     <View>
       {props.slotTesting}
-
       <View>
         <View />
       </View>
-
       <View>{props.children}</View>
     </View>
   );
@@ -699,11 +685,9 @@ function ContentSlotJsxCode(props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || <Text>{props.content}</Text>}</>
             ) : null}
-
             <View>
               <View />
             </View>
-
             <View>{props.children}</View>
           </View>
         </>
@@ -1219,10 +1203,8 @@ function Image(props) {
             />
           </>
         ) : null}
-
         <View srcset={props.srcset} />
       </View>
-
       {props.children}
     </View>
   );
@@ -1336,6 +1318,30 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`React Native > jsx > Javascript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+} from \\"react-native\\";
+
+function Hello(props) {
+  return (
+    <View>
+      <Text>Hello </Text>
+      <Text>{props.name ?? \\"World\\"}</Text>
+    </View>
+  );
+}
+
+export default Hello;
 "
 `;
 
@@ -1518,9 +1524,7 @@ function SlotCode(props) {
   return (
     <View>
       {props.slotTop}
-
       {props.slotLeft || <Text>Default left</Text>}
-
       {props.children || <Text>Default Child</Text>}
     </View>
   );
@@ -1575,7 +1579,6 @@ function SmileReviews(props) {
       <View onClick={(event) => setShowReviewPrompt(true)}>
         <Text>Write a review</Text>
       </View>
-
       {showReviewPrompt || \\"asdf\\" ? (
         <>
           <View placeholder=\\"Email\\" />
@@ -1591,21 +1594,17 @@ function SmileReviews(props) {
           </View>
         </>
       ) : null}
-
       {reviews?.map((review, index) => (
         <View key={review.id} style={styles.view1}>
           <View src={review.avatar} style={styles.view2} />
-
           <View>
             <View>
               <Text>N: </Text>
               <Text>{index}</Text>
             </View>
-
             <View>
               <Text>{review.author}</Text>
             </View>
-
             <View>
               <Text>{review.reviewMessage}</Text>
             </View>
@@ -1825,11 +1824,9 @@ function MyBasicForNoTagRefComponent(props) {
       <Tag>
         <Text>{name}</Text>
       </Tag>
-
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <View>
             <Text>{action.text}</Text>
           </View>
@@ -2245,7 +2242,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View
@@ -2299,7 +2295,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View
@@ -2796,9 +2791,7 @@ function MyBasicComponent(props) {
 
   return (
     <View>
-      {props.children}
-
-      <Text>{props.type}</Text>
+      {props.children} <Text>{props.type}</Text>
       <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
     </View>
   );
@@ -3141,7 +3134,6 @@ function RenderBlock(props) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -3313,7 +3305,6 @@ function MyComponent(props) {
   return (
     <View>
       <Text>{props.name}</Text>
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -3342,9 +3333,7 @@ function MyComponent(props) {
   return (
     <View>
       <Text>{props.name}</Text>
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -3558,9 +3547,7 @@ function SvgComponent(props) {
       <View>
         <View id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </View>
       </View>
@@ -3782,7 +3769,6 @@ function MyBasicRefComponent(props: Props) {
             <View value=\\"supra\\">
               <Text>GR Supra</Text>
             </View>
-
             <View value=\\"86\\">
               <Text>GR 86</Text>
             </View>
@@ -4033,14 +4019,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props: Props) {
   return (
     <View>
-      {props.children}
-
-      <Text>{props.type}</Text>
-
+      {props.children} <Text>{props.type}</Text>
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </View>
   );
@@ -4072,7 +4053,6 @@ function MyBasicChildComponent(props: any) {
   return (
     <View>
       <MyBasicComponent id={dev} />
-
       <View>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </View>
@@ -4180,7 +4160,6 @@ function MyBasicRefComponent(props: Props) {
             <View value=\\"supra\\">
               <Text>GR Supra</Text>
             </View>
-
             <View value=\\"86\\">
               <Text>GR 86</Text>
             </View>
@@ -4283,7 +4262,6 @@ function MyPreviousComponent(props: Props) {
         <Text>, before: </Text>
         <Text>{prevCount.current}</Text>
       </View>
-
       <View onClick={(event) => setCount(1)}>
         <Text>Increment</Text>
       </View>
@@ -4327,7 +4305,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View type=\\"button\\" {...props.attributes}>
@@ -4394,9 +4371,7 @@ function Column(props: ColumnProps) {
     <View style={styles.view1}>
       {props.columns?.map((column, index) => (
         <View style={styles.view2}>
-          <Text>{column.content}</Text>
-
-          <Text>{index}</Text>
+          <Text>{column.content}</Text> <Text>{index}</Text>
         </View>
       ))}
     </View>
@@ -4433,11 +4408,9 @@ function ContentSlotCode(props: Props) {
   return (
     <View>
       {props.slotTesting}
-
       <View>
         <View />
       </View>
-
       <View>{props.children}</View>
     </View>
   );
@@ -4490,11 +4463,9 @@ function ContentSlotJsxCode(props: Props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || <Text>{props.content}</Text>}</>
             ) : null}
-
             <View>
               <View />
             </View>
-
             <View>{props.children}</View>
           </View>
         </>
@@ -5070,10 +5041,8 @@ function Image(props: ImageProps) {
             />
           </>
         ) : null}
-
         <View srcset={props.srcset} />
       </View>
-
       {props.children}
     </View>
   );
@@ -5216,6 +5185,30 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`React Native > jsx > Typescript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+} from \\"react-native\\";
+
+function Hello(props: any) {
+  return (
+    <View>
+      <Text>Hello </Text>
+      <Text>{props.name ?? \\"World\\"}</Text>
+    </View>
+  );
+}
+
+export default Hello;
 "
 `;
 
@@ -5437,9 +5430,7 @@ function SlotCode(props: Props) {
   return (
     <View>
       {props.slotTop}
-
       {props.slotLeft || <Text>Default left</Text>}
-
       {props.children || <Text>Default Child</Text>}
     </View>
   );
@@ -5499,7 +5490,6 @@ function SmileReviews(props: SmileReviewsProps) {
       <View onClick={(event) => setShowReviewPrompt(true)}>
         <Text>Write a review</Text>
       </View>
-
       {showReviewPrompt || \\"asdf\\" ? (
         <>
           <View placeholder=\\"Email\\" />
@@ -5515,21 +5505,17 @@ function SmileReviews(props: SmileReviewsProps) {
           </View>
         </>
       ) : null}
-
       {reviews?.map((review, index) => (
         <View key={review.id} style={styles.view1}>
           <View src={review.avatar} style={styles.view2} />
-
           <View>
             <View>
               <Text>N: </Text>
               <Text>{index}</Text>
             </View>
-
             <View>
               <Text>{review.author}</Text>
             </View>
-
             <View>
               <Text>{review.reviewMessage}</Text>
             </View>
@@ -5797,11 +5783,9 @@ function MyBasicForNoTagRefComponent(props: any) {
       <Tag>
         <Text>{name}</Text>
       </Tag>
-
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <View>
             <Text>{action.text}</Text>
           </View>
@@ -6253,7 +6237,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View
@@ -6315,7 +6298,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <View
@@ -6864,9 +6846,7 @@ function MyBasicComponent(props: Props) {
 
   return (
     <View>
-      {props.children}
-
-      <Text>{props.type}</Text>
+      {props.children} <Text>{props.type}</Text>
       <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
     </View>
   );
@@ -7232,7 +7212,6 @@ function RenderBlock(props: RenderBlockProps) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -7423,7 +7402,6 @@ function MyComponent(props: any) {
   return (
     <View>
       <Text>{props.name}</Text>
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -7452,9 +7430,7 @@ function MyComponent(props: any) {
   return (
     <View>
       <Text>{props.name}</Text>
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -7677,9 +7653,7 @@ function SvgComponent(props: any) {
       <View>
         <View id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </View>
       </View>

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -41,7 +41,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -161,12 +160,7 @@ function MyBasicOnMountUpdateComponent(props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -229,14 +223,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props) {
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </div>
   );
@@ -260,7 +249,6 @@ function MyBasicChildComponent(props) {
   return (
     <div>
       <MyBasicComponent id={dev} />
-
       <div>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </div>
@@ -345,7 +333,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -419,11 +406,8 @@ function MyPreviousComponent(props) {
   return (
     <div>
       <h1>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </h1>
-
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
   );
@@ -450,7 +434,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -495,9 +478,7 @@ function Column(props) {
       <div className=\\"builder-columns div\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -537,11 +518,9 @@ function ContentSlotCode(props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div>{props.children}</div>
     </div>
   );
@@ -582,11 +561,9 @@ function ContentSlotJsxCode(props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </>
@@ -1105,10 +1082,8 @@ function Image(props) {
               />
             </>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
       <style jsx>{\`
@@ -1198,6 +1173,17 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`React > jsx > Javascript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+
+function Hello(props) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -1325,9 +1311,7 @@ function SlotCode(props) {
   return (
     <div>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </div>
   );
@@ -1375,7 +1359,6 @@ function SmileReviews(props) {
         <button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -1395,19 +1378,12 @@ function SmileReviews(props) {
             </button>
           </>
         ) : null}
-
         {reviews?.map((review, index) => (
           <div className=\\"review\\" key={review.id}>
             <img className=\\"img\\" src={review.avatar} />
-
             <div className={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -1555,12 +1531,7 @@ function MyComponent(props) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyComponent;
@@ -1586,12 +1557,10 @@ function MyBasicForNoTagRefComponent(props) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <Tag>{name}</Tag>
+      Hello <Tag>{name}</Tag>
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <span>{action.text}</span>
         </TagName>
       ))}
@@ -1691,12 +1660,7 @@ function MyBasicOnUpdateReturnComponent(props) {
     };
   }, [name]);
 
-  return (
-    <div>
-      Hello!
-      {name}
-    </div>
-  );
+  return <div>Hello! {name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -1929,7 +1893,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button
@@ -1975,7 +1938,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button
@@ -2010,13 +1972,7 @@ const DEFAULT_VALUES = {
 };
 
 function ComponentWithTypes(props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -2237,12 +2193,7 @@ function OnInit(props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {name}
-    </div>
-  );
+  return <div>Default name defined by parent {name}</div>;
 }
 
 export default OnInit;
@@ -2329,10 +2280,7 @@ exports[`React > jsx > Javascript Test > preserveTyping 1`] = `
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2349,8 +2297,7 @@ function MyBasicComponent(props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -2365,10 +2312,7 @@ exports[`React > jsx > Javascript Test > propsInterface 1`] = `
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2381,10 +2325,7 @@ exports[`React > jsx > Javascript Test > propsType 1`] = `
 
 function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2661,7 +2602,6 @@ function RenderBlock(props) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -2798,7 +2738,6 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -2819,9 +2758,7 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -2958,9 +2895,7 @@ function SvgComponent(props) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </filter>
       </defs>
@@ -3081,10 +3016,7 @@ function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
 
   return (
-    <div>
-      Hello
-      {name}! I can run in React, Qwik, Vue, Solid, or Liquid!
-    </div>
+    <div>Hello {name}! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   );
 }
 
@@ -3137,7 +3069,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -3266,12 +3197,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -3339,14 +3265,9 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
 function MyBooleanAttribute(props: Props) {
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </div>
   );
@@ -3370,7 +3291,6 @@ function MyBasicChildComponent(props: any) {
   return (
     <div>
       <MyBasicComponent id={dev} />
-
       <div>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </div>
@@ -3459,7 +3379,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -3541,11 +3460,8 @@ function MyPreviousComponent(props: Props) {
   return (
     <div>
       <h1>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </h1>
-
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
   );
@@ -3579,7 +3495,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -3639,9 +3554,7 @@ function Column(props: ColumnProps) {
       <div className=\\"builder-columns div\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -3687,11 +3600,9 @@ function ContentSlotCode(props: Props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div>{props.children}</div>
     </div>
   );
@@ -3737,11 +3648,9 @@ function ContentSlotJsxCode(props: Props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </>
@@ -4320,10 +4229,8 @@ function Image(props: ImageProps) {
               />
             </>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
       <style jsx>{\`
@@ -4442,6 +4349,17 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`React > jsx > Typescript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+
+function Hello(props: any) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -4608,9 +4526,7 @@ function SlotCode(props: Props) {
   return (
     <div>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </div>
   );
@@ -4663,7 +4579,6 @@ function SmileReviews(props: SmileReviewsProps) {
         <button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -4683,19 +4598,12 @@ function SmileReviews(props: SmileReviewsProps) {
             </button>
           </>
         ) : null}
-
         {reviews?.map((review, index) => (
           <div className=\\"review\\" key={review.id}>
             <img className=\\"img\\" src={review.avatar} />
-
             <div className={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -4891,12 +4799,7 @@ function MyComponent(props: any) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name}
-    </div>
-  );
+  return <div>Hello {name}</div>;
 }
 
 export default MyComponent;
@@ -4922,12 +4825,10 @@ function MyBasicForNoTagRefComponent(props: any) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <Tag>{name}</Tag>
+      Hello <Tag>{name}</Tag>
       {props.actions?.map((action) => (
         <TagName>
           <action.icon />
-
           <span>{action.text}</span>
         </TagName>
       ))}
@@ -5037,12 +4938,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
     };
   }, [name]);
 
-  return (
-    <div>
-      Hello!
-      {name}
-    </div>
-  );
+  return <div>Hello! {name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -5301,7 +5197,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button
@@ -5355,7 +5250,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button
@@ -5394,13 +5288,7 @@ const DEFAULT_VALUES: Props = {
 };
 
 function ComponentWithTypes(props: Props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -5637,12 +5525,7 @@ function OnInit(props: Props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {name}
-    </div>
-  );
+  return <div>Default name defined by parent {name}</div>;
 }
 
 export default OnInit;
@@ -5756,10 +5639,7 @@ export interface MyBasicComponentProps {
 
 function MyBasicComponent(props: MyBasicComponentProps) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5781,8 +5661,7 @@ function MyBasicComponent(props: Props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -5802,10 +5681,7 @@ interface Person {
 
 function MyBasicComponent(props: Person | never) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5823,10 +5699,7 @@ type Person = {
 
 function MyBasicComponent(props: Person) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -6116,7 +5989,6 @@ function RenderBlock(props: RenderBlockProps) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -6272,7 +6144,6 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -6293,9 +6164,7 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -6441,9 +6310,7 @@ function SvgComponent(props: any) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </filter>
       </defs>
@@ -6600,7 +6467,6 @@ function SmileReviews(props) {
         <button onClick={(event) => (state.showReviewPrompt = true)}>
           Write a review
         </button>
-
         {state.showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -6620,21 +6486,14 @@ function SmileReviews(props) {
             </button>
           </>
         ) : null}
-
         {state.reviews?.map((review, index) => (
           <div className=\\"review-4e06abd9\\" key={review.id}>
             <img className=\\"img-4e06abd9\\" src={review.avatar} />
-
             <div
               className={state.showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}
             >
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -6706,7 +6565,6 @@ function SmileReviews(props) {
         <button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -6726,19 +6584,12 @@ function SmileReviews(props) {
             </button>
           </>
         ) : null}
-
         {reviews?.map((review, index) => (
           <div className=\\"review-33281325\\" key={review.id}>
             <img className=\\"img-33281325\\" src={review.avatar} />
-
             <div className={showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -6845,14 +6696,8 @@ function MyComponent(props) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla}
-      </p>
-      <p>
-        Fillings:
-        {fillings}
-      </p>
+      <p>Tortilla: {tortilla}</p>
+      <p>Fillings: {fillings}</p>
     </div>
   );
 }
@@ -7050,8 +6895,7 @@ function MyComponent(props) {
   return (
     <div>
       <input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -7091,8 +6935,7 @@ function MyComponent(props) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </div>
   );
 }
@@ -7240,14 +7083,8 @@ function MyComponent(props: any) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla}
-      </p>
-      <p>
-        Fillings:
-        {fillings}
-      </p>
+      <p>Tortilla: {tortilla}</p>
+      <p>Fillings: {fillings}</p>
     </div>
   );
 }
@@ -7445,8 +7282,7 @@ function MyComponent(props: any) {
   return (
     <div>
       <input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -7486,8 +7322,7 @@ function MyComponent(props: any) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </div>
   );
 }

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -28,7 +28,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -135,12 +134,7 @@ function MyBasicOnMountUpdateComponent(props) {
     state.name = \\"PatrickJS onInit\\" + props.hi;
   }, []);
 
-  return (
-    <div>
-      Hello
-      {state.name}
-    </div>
-  );
+  return <div>Hello {state.name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -199,14 +193,9 @@ function MyBooleanAttribute(props) {
 
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} _context={_context} />
-
       <MyBooleanAttributeComponent toggle={true} _context={_context} />
-
       <MyBooleanAttributeComponent list={null} _context={_context} />
     </div>
   );
@@ -229,7 +218,6 @@ function MyBasicChildComponent(props) {
   return (
     <div>
       <MyBasicComponent id={state.dev} _context={_context} />
-
       <div>
         <MyBasicOnMountUpdateComponent
           hi={state.name}
@@ -299,7 +287,6 @@ function MyBasicRefComponent(props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -369,11 +356,8 @@ function MyPreviousComponent(props) {
   return (
     <div>
       <h1>
-        Now:
-        {state.count}, before:
-        {prevCount}
+        Now: {state.count}, before: {prevCount}
       </h1>
-
       <button>Increment</button>
     </div>
   );
@@ -402,7 +386,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -449,9 +432,7 @@ function Column(props) {
       <div className=\\"builder-columns div-6557df1e\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-6557df1e-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -481,11 +462,9 @@ function ContentSlotCode(props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div slotContext={_context}></div>
     </div>
   );
@@ -525,11 +504,9 @@ function ContentSlotJsxCode(props) {
             {state.showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </>
@@ -930,7 +907,7 @@ function FormComponent(props) {
         ) : null}{\\" \\"}
         {state.submissionState === \\"error\\" && state.responseData ? (
           <>
-            <pre className=\\"builder-form-error-text pre-27dbad5e\\">
+            <pre className=\\"builder-form-error-text pre-99a3fede\\">
               {\\" \\"}
               {JSON.stringify(state.responseData, null, 2)}{\\" \\"}
             </pre>
@@ -946,7 +923,7 @@ function FormComponent(props) {
           </>
         ) : null}{\\" \\"}
       </form>{\\" \\"}
-      <style>{\`.pre-27dbad5e {   padding: 10px;   color: red;   text-align: center; }\`}</style>{\\" \\"}
+      <style>{\`.pre-99a3fede {   padding: 10px;   color: red;   text-align: center; }\`}</style>{\\" \\"}
     </>
   );
 }
@@ -999,10 +976,8 @@ function Image(props) {
               />
             </>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
 
@@ -1094,6 +1069,19 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`RSC > jsx > Javascript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+
+function Hello(props) {
+  const _context = { ...props[\\"_context\\"] };
+
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -1234,7 +1222,6 @@ function SlotCode(props) {
   return (
     <div slotContext={_context}>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
     </div>
   );
@@ -1267,7 +1254,6 @@ function SmileReviews(props) {
     <>
       <div data-user={state.name}>
         <button>Write a review</button>
-
         {state.showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -1279,21 +1265,14 @@ function SmileReviews(props) {
             <button className=\\"button-70c9b54e\\">Submit</button>
           </>
         ) : null}
-
         {state.reviews?.map((review, index) => (
           <div className=\\"review-70c9b54e\\" key={review.id}>
             <img className=\\"img-70c9b54e\\" src={review.avatar} />
-
             <div
               className={state.showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}
             >
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -1444,12 +1423,7 @@ function MyComponent(props) {
     },
   };
 
-  return (
-    <div>
-      Hello
-      {state.name}
-    </div>
-  );
+  return <div>Hello {state.name}</div>;
 }
 
 export default MyComponent;
@@ -1473,12 +1447,10 @@ function MyBasicForNoTagRefComponent(props) {
 
   return (
     <state.TagNameGetter _context={_context}>
-      Hello
-      <state.tag>{state.name}</state.tag>
+      Hello <state.tag>{state.name}</state.tag>
       {props.actions?.map((action) => (
         <state.TagName _context={_context}>
           <action.icon />
-
           <span>{action.text}</span>
         </state.TagName>
       ))}
@@ -1550,12 +1522,7 @@ function MyBasicOnUpdateReturnComponent(props) {
 
   const state = { name: \\"PatrickJS\\" };
 
-  return (
-    <div>
-      Hello!
-      {state.name}
-    </div>
-  );
+  return <div>Hello! {state.name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -1781,7 +1748,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -1825,7 +1791,6 @@ function Button(props) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -1858,13 +1823,7 @@ const DEFAULT_VALUES = {
 function ComponentWithTypes(props) {
   const _context = { ...props[\\"_context\\"] };
 
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -2063,12 +2022,7 @@ function OnInit(props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {state.name}
-    </div>
-  );
+  return <div>Default name defined by parent {state.name}</div>;
 }
 
 export default OnInit;
@@ -2142,10 +2096,7 @@ function MyBasicComponent(props) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2163,8 +2114,7 @@ function MyBasicComponent(props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -2181,10 +2131,7 @@ function MyBasicComponent(props) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2199,10 +2146,7 @@ function MyBasicComponent(props) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -2466,7 +2410,6 @@ function RenderBlock(props) {
                     _context={_context}
                   />
                 ))}
-
                 {state.childrenWithoutParentComponent?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -2602,7 +2545,6 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" _context={_context} />
@@ -2625,9 +2567,7 @@ function MyComponent(props) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\" _context={_context}>
@@ -2779,14 +2719,12 @@ function SvgComponent(props) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" _context={_context} />
-
           <feBlend
             in=\\"SourceGraphic\\"
             in2=\\"BackgroundImageFix\\"
             result=\\"shape\\"
             _context={_context}
           />
-
           <feGaussianBlur
             result=\\"effect1_foregroundBlur\\"
             stdDeviation={7}
@@ -2929,8 +2867,7 @@ function MyBasicComponent(props) {
 
   return (
     <div>
-      Hello
-      {state.name}! I can run in React, Qwik, Vue, Solid, or Liquid!
+      Hello {state.name}! I can run in React, Qwik, Vue, Solid, or Liquid!
     </div>
   );
 }
@@ -2971,7 +2908,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -3087,12 +3023,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
     state.name = \\"PatrickJS onInit\\" + props.hi;
   }, []);
 
-  return (
-    <div>
-      Hello
-      {state.name}
-    </div>
-  );
+  return <div>Hello {state.name}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -3156,14 +3087,9 @@ function MyBooleanAttribute(props: Props) {
 
   return (
     <div>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} _context={_context} />
-
       <MyBooleanAttributeComponent toggle={true} _context={_context} />
-
       <MyBooleanAttributeComponent list={null} _context={_context} />
     </div>
   );
@@ -3186,7 +3112,6 @@ function MyBasicChildComponent(props: any) {
   return (
     <div>
       <MyBasicComponent id={state.dev} _context={_context} />
-
       <div>
         <MyBasicOnMountUpdateComponent
           hi={state.name}
@@ -3260,7 +3185,6 @@ function MyBasicRefComponent(props: Props) {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </>
@@ -3338,11 +3262,8 @@ function MyPreviousComponent(props: Props) {
   return (
     <div>
       <h1>
-        Now:
-        {state.count}, before:
-        {prevCount}
+        Now: {state.count}, before: {prevCount}
       </h1>
-
       <button>Increment</button>
     </div>
   );
@@ -3378,7 +3299,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -3440,9 +3360,7 @@ function Column(props: ColumnProps) {
       <div className=\\"builder-columns div-574fbebc\\">
         {props.columns?.map((column, index) => (
           <div className=\\"builder-column div-574fbebc-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -3478,11 +3396,9 @@ function ContentSlotCode(props: Props) {
   return (
     <div>
       {props.slotTesting}
-
       <div>
         <hr />
       </div>
-
       <div slotContext={_context}></div>
     </div>
   );
@@ -3527,11 +3443,9 @@ function ContentSlotJsxCode(props: Props) {
             {state.showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <div>
               <hr />
             </div>
-
             <div>{props.children}</div>
           </div>
         </>
@@ -3973,7 +3887,7 @@ function FormComponent(props: FormProps) {
         ) : null}{\\" \\"}
         {state.submissionState === \\"error\\" && state.responseData ? (
           <>
-            <pre className=\\"builder-form-error-text pre-1e9e272a\\">
+            <pre className=\\"builder-form-error-text pre-0db4a61c\\">
               {\\" \\"}
               {JSON.stringify(state.responseData, null, 2)}{\\" \\"}
             </pre>
@@ -3989,7 +3903,7 @@ function FormComponent(props: FormProps) {
           </>
         ) : null}{\\" \\"}
       </form>{\\" \\"}
-      <style>{\`.pre-1e9e272a {   padding: 10px;   color: red;   text-align: center; }\`}</style>{\\" \\"}
+      <style>{\`.pre-0db4a61c {   padding: 10px;   color: red;   text-align: center; }\`}</style>{\\" \\"}
     </>
   );
 }
@@ -4061,10 +3975,8 @@ function Image(props: ImageProps) {
               />
             </>
           ) : null}
-
           <source srcset={props.srcset} />
         </picture>
-
         {props.children}
       </div>
 
@@ -4185,6 +4097,19 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`RSC > jsx > Typescript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+
+function Hello(props: any) {
+  const _context = { ...props[\\"_context\\"] };
+
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
 "
 `;
 
@@ -4364,7 +4289,6 @@ function SlotCode(props: Props) {
   return (
     <div slotContext={_context}>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
     </div>
   );
@@ -4402,7 +4326,6 @@ function SmileReviews(props: SmileReviewsProps) {
     <>
       <div data-user={state.name}>
         <button>Write a review</button>
-
         {state.showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -4414,21 +4337,14 @@ function SmileReviews(props: SmileReviewsProps) {
             <button className=\\"button-381fc214\\">Submit</button>
           </>
         ) : null}
-
         {state.reviews?.map((review, index) => (
           <div className=\\"review-381fc214\\" key={review.id}>
             <img className=\\"img-381fc214\\" src={review.avatar} />
-
             <div
               className={state.showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}
             >
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -4627,12 +4543,7 @@ function MyComponent(props: any) {
     },
   };
 
-  return (
-    <div>
-      Hello
-      {state.name}
-    </div>
-  );
+  return <div>Hello {state.name}</div>;
 }
 
 export default MyComponent;
@@ -4656,12 +4567,10 @@ function MyBasicForNoTagRefComponent(props: any) {
 
   return (
     <state.TagNameGetter _context={_context}>
-      Hello
-      <state.tag>{state.name}</state.tag>
+      Hello <state.tag>{state.name}</state.tag>
       {props.actions?.map((action) => (
         <state.TagName _context={_context}>
           <action.icon />
-
           <span>{action.text}</span>
         </state.TagName>
       ))}
@@ -4743,12 +4652,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
 
   const state = { name: \\"PatrickJS\\" };
 
-  return (
-    <div>
-      Hello!
-      {state.name}
-    </div>
-  );
+  return <div>Hello! {state.name}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -5000,7 +4904,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -5052,7 +4955,6 @@ function Button(props: ButtonProps) {
           </a>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <button type=\\"button\\" {...props.attributes}>
@@ -5089,13 +4991,7 @@ const DEFAULT_VALUES: Props = {
 function ComponentWithTypes(props: Props) {
   const _context = { ...props[\\"_context\\"] };
 
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -5310,12 +5206,7 @@ function OnInit(props: Props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <div>
-      Default name defined by parent
-      {state.name}
-    </div>
-  );
+  return <div>Default name defined by parent {state.name}</div>;
 }
 
 export default OnInit;
@@ -5416,10 +5307,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5442,8 +5330,7 @@ function MyBasicComponent(props: Props) {
 
   return (
     <div>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   );
@@ -5465,10 +5352,7 @@ function MyBasicComponent(props: Person | never) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5488,10 +5372,7 @@ function MyBasicComponent(props: Person) {
   const _context = { ...props[\\"_context\\"] };
 
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -5768,7 +5649,6 @@ function RenderBlock(props: RenderBlockProps) {
                     _context={_context}
                   />
                 ))}
-
                 {state.childrenWithoutParentComponent?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -5923,7 +5803,6 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" _context={_context} />
@@ -5946,9 +5825,7 @@ function MyComponent(props: any) {
   return (
     <div>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\" _context={_context}>
@@ -6109,14 +5986,12 @@ function SvgComponent(props: any) {
       <defs>
         <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" _context={_context} />
-
           <feBlend
             in=\\"SourceGraphic\\"
             in2=\\"BackgroundImageFix\\"
             result=\\"shape\\"
             _context={_context}
           />
-
           <feGaussianBlur
             result=\\"effect1_foregroundBlur\\"
             stdDeviation={7}
@@ -6315,14 +6190,8 @@ function MyComponent(props) {
         value=\\"Guac (extra)\\"
         checked={state.fillings === \\"Guac (extra)\\"}
       />
-      <p>
-        Tortilla:
-        {state.tortilla}
-      </p>
-      <p>
-        Fillings:
-        {state.fillings}
-      </p>
+      <p>Tortilla: {state.tortilla}</p>
+      <p>Fillings: {state.fillings}</p>
     </div>
   );
 }
@@ -6515,8 +6384,7 @@ function MyComponent(props) {
   return (
     <div>
       <input value={state.name} />
-      Lowercase:
-      {state.lowercaseName}
+      Lowercase: {state.lowercaseName}
     </div>
   );
 }
@@ -6544,8 +6412,7 @@ function MyComponent(props) {
     <div>
       <input type=\\"number\\" value={state.a} />
       <input type=\\"number\\" value={state.b} />
-      Result:
-      {state.result}
+      Result: {state.result}
     </div>
   );
 }
@@ -6680,14 +6547,8 @@ function MyComponent(props: any) {
         value=\\"Guac (extra)\\"
         checked={state.fillings === \\"Guac (extra)\\"}
       />
-      <p>
-        Tortilla:
-        {state.tortilla}
-      </p>
-      <p>
-        Fillings:
-        {state.fillings}
-      </p>
+      <p>Tortilla: {state.tortilla}</p>
+      <p>Fillings: {state.fillings}</p>
     </div>
   );
 }
@@ -6880,8 +6741,7 @@ function MyComponent(props: any) {
   return (
     <div>
       <input value={state.name} />
-      Lowercase:
-      {state.lowercaseName}
+      Lowercase: {state.lowercaseName}
     </div>
   );
 }
@@ -6909,8 +6769,7 @@ function MyComponent(props: any) {
     <div>
       <input type=\\"number\\" value={state.a} />
       <input type=\\"number\\" value={state.b} />
-      Result:
-      {state.result}
+      Result: {state.result}
     </div>
   );
 }

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -183,9 +183,8 @@ function MyBasicForShowComponent(props) {
                   setName(event.target.value + \\" and \\" + person);
                 }}
               />
-              Hello
-              {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-              Liquid!
+              Hello {person}! I can run in Qwik, Web Component, React, Vue,
+              Solid, or Liquid!
             </Show>
           );
         }}
@@ -264,9 +263,8 @@ function MyBasicForShowComponent(props) {
                     setName(event.target.value + \\" and \\" + person);
                   }}
                 />
-                Hello
-                {person}! I can run in Qwik, Web Component, React, Vue, Solid,
-                or Liquid!
+                Hello {person}! I can run in Qwik, Web Component, React, Vue,
+                Solid, or Liquid!
               </Show>
             );
           }}
@@ -366,12 +364,7 @@ function MyBasicOnMountUpdateComponent(props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   });
 
-  return (
-    <div>
-      Hello
-      {name()}
-    </div>
-  );
+  return <div>Hello {name()}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -394,10 +387,7 @@ function MyBasicOnMountUpdateComponent(props) {
 
   return (
     <>
-      <div>
-        Hello
-        {name()}
-      </div>
+      <div>Hello {name()}</div>
     </>
   );
 }
@@ -645,9 +635,8 @@ function MyBasicForComponent(props) {
                   setName(event.target.value + \\" and \\" + person);
                 }}
               />
-              Hello
-              {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-              Liquid!
+              Hello {person}! I can run in Qwik, Web Component, React, Vue,
+              Solid, or Liquid!
             </>
           );
         }}
@@ -688,9 +677,8 @@ function MyBasicForComponent(props) {
                     setName(event.target.value + \\" and \\" + person);
                   }}
                 />
-                Hello
-                {person}! I can run in Qwik, Web Component, React, Vue, Solid,
-                or Liquid!
+                Hello {person}! I can run in Qwik, Web Component, React, Vue,
+                Solid, or Liquid!
               </>
             );
           }}
@@ -887,9 +875,7 @@ function MyPreviousComponent(props) {
   return (
     <div>
       <h1>
-        Now:
-        {count()}, before:
-        {prevCount}
+        Now: {count()}, before: {prevCount}
       </h1>
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
@@ -930,9 +916,7 @@ function MyPreviousComponent(props) {
     <>
       <div>
         <h1>
-          Now:
-          {count()}, before:
-          {prevCount}
+          Now: {count()}, before: {prevCount}
         </h1>
         <button onClick={(event) => setCount(1)}>Increment</button>
       </div>
@@ -2146,7 +2130,7 @@ function FormComponent(props) {
           ></BuilderBlocks>
         </Show>
         <Show when={submissionState() === \\"error\\" && responseData()}>
-          <pre class=\\"builder-form-error-text pre-441bb54e\\">
+          <pre class=\\"builder-form-error-text pre-6c59c35e\\">
             {JSON.stringify(responseData(), null, 2)}
           </pre>
         </Show>
@@ -2158,7 +2142,7 @@ function FormComponent(props) {
         </Show>
       </form>
       <style jsx>{\`
-        .pre-441bb54e {
+        .pre-6c59c35e {
           padding: 10px;
           color: red;
           text-align: center;
@@ -2515,6 +2499,30 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Solid > jsx > Javascript Test > Literal Space 1`] = `
+"function Hello(props) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
+"
+`;
+
+exports[`Solid > jsx > Javascript Test > Literal Space 2`] = `
+"import { css } from \\"solid-styled-components\\";
+
+function Hello(props) {
+  return (
+    <>
+      <div>Hello {props.name ?? \\"World\\"}</div>
+    </>
+  );
+}
+
+export default Hello;
 "
 `;
 
@@ -2973,10 +2981,7 @@ function SmileReviews(props) {
                 src={review.avatar}
               />
               <div class={showReviewPrompt() ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-                <div>
-                  N:
-                  {index}
-                </div>
+                <div>N: {index}</div>
                 <div>{review.author}</div>
                 <div>{review.reviewMessage}</div>
               </div>
@@ -3056,10 +3061,7 @@ function SmileReviews(props) {
               <div class=\\"div-8aa000e4\\" key={review.id}>
                 <img class=\\"img-8aa000e4\\" src={review.avatar} />
                 <div class={showReviewPrompt() ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-                  <div>
-                    N:
-                    {index}
-                  </div>
+                  <div>N: {index}</div>
                   <div>{review.author}</div>
                   <div>{review.reviewMessage}</div>
                 </div>
@@ -3306,12 +3308,7 @@ function MyComponent(props) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name()}
-    </div>
-  );
+  return <div>Hello {name()}</div>;
 }
 
 export default MyComponent;
@@ -3336,10 +3333,7 @@ function MyComponent(props) {
 
   return (
     <>
-      <div>
-        Hello
-        {name()}
-      </div>
+      <div>Hello {name()}</div>
     </>
   );
 }
@@ -3365,8 +3359,7 @@ function MyBasicForNoTagRefComponent(props) {
 
   return (
     <Dynamic component={TagNameGetter()}>
-      Hello
-      <Dynamic component={tag()}>{name()}</Dynamic>
+      Hello <Dynamic component={tag()}>{name()}</Dynamic>
       <For each={props.actions}>
         {(action, _index) => {
           const index = _index();
@@ -3406,8 +3399,7 @@ function MyBasicForNoTagRefComponent(props) {
   return (
     <>
       <Dynamic component={TagNameGetter()}>
-        Hello
-        <Dynamic component={tag()}>{name()}</Dynamic>
+        Hello <Dynamic component={tag()}>{name()}</Dynamic>
         <For each={props.actions}>
           {(action, _index) => {
             const index = _index();
@@ -3452,12 +3444,7 @@ function MyBasicOnUpdateReturnComponent(props) {
   }
   createEffect(on(() => [name()], onUpdateFn_0));
 
-  return (
-    <div>
-      Hello!
-      {name()}
-    </div>
-  );
+  return <div>Hello! {name()}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -3492,10 +3479,7 @@ function MyBasicOnUpdateReturnComponent(props) {
 
   return (
     <>
-      <div>
-        Hello!
-        {name()}
-      </div>
+      <div>Hello! {name()}</div>
     </>
   );
 }
@@ -4078,13 +4062,7 @@ exports[`Solid > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 };
 
 function ComponentWithTypes(props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -4101,11 +4079,7 @@ const DEFAULT_VALUES = {
 function ComponentWithTypes(props) {
   return (
     <>
-      <div>
-        {\\" \\"}
-        Hello
-        {props.name || DEFAULT_VALUES.name}
-      </div>
+      <div> Hello {props.name || DEFAULT_VALUES.name}</div>
     </>
   );
 }
@@ -4511,12 +4485,7 @@ export const defaultValues = {
 function OnInit(props) {
   const [name, setName] = createSignal(\\"\\");
 
-  return (
-    <div>
-      Default name defined by parent
-      {name()}
-    </div>
-  );
+  return <div>Default name defined by parent {name()}</div>;
 }
 
 export default OnInit;
@@ -4537,10 +4506,7 @@ function OnInit(props) {
 
   return (
     <>
-      <div>
-        Default name defined by parent
-        {name()}
-      </div>
+      <div>Default name defined by parent {name()}</div>
     </>
   );
 }
@@ -4698,10 +4664,7 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > preserveTyping 1`] = `
 "function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -4715,10 +4678,7 @@ exports[`Solid > jsx > Javascript Test > preserveTyping 2`] = `
 function MyBasicComponent(props) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -4772,10 +4732,7 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > propsInterface 1`] = `
 "function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -4789,10 +4746,7 @@ exports[`Solid > jsx > Javascript Test > propsInterface 2`] = `
 function MyBasicComponent(props) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -4804,10 +4758,7 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > propsType 1`] = `
 "function MyBasicComponent(props) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -4821,10 +4772,7 @@ exports[`Solid > jsx > Javascript Test > propsType 2`] = `
 function MyBasicComponent(props) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -6237,10 +6185,7 @@ function MyBasicComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
   return (
-    <div>
-      Hello
-      {name()}! I can run in React, Qwik, Vue, Solid, or Liquid!
-    </div>
+    <div>Hello {name()}! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   );
 }
 
@@ -6259,8 +6204,7 @@ function MyBasicComponent(props) {
   return (
     <>
       <div>
-        Hello
-        {name()}! I can run in React, Qwik, Vue, Solid, or Liquid!
+        Hello {name()}! I can run in React, Qwik, Vue, Solid, or Liquid!
       </div>
     </>
   );
@@ -6462,9 +6406,8 @@ function MyBasicForShowComponent(props: any) {
                   setName(event.target.value + \\" and \\" + person);
                 }}
               />
-              Hello
-              {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-              Liquid!
+              Hello {person}! I can run in Qwik, Web Component, React, Vue,
+              Solid, or Liquid!
             </Show>
           );
         }}
@@ -6546,9 +6489,8 @@ function MyBasicForShowComponent(props: any) {
                     setName(event.target.value + \\" and \\" + person);
                   }}
                 />
-                Hello
-                {person}! I can run in Qwik, Web Component, React, Vue, Solid,
-                or Liquid!
+                Hello {person}! I can run in Qwik, Web Component, React, Vue,
+                Solid, or Liquid!
               </Show>
             );
           }}
@@ -6653,12 +6595,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   });
 
-  return (
-    <div>
-      Hello
-      {name()}
-    </div>
-  );
+  return <div>Hello {name()}</div>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -6685,10 +6622,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
 
   return (
     <>
-      <div>
-        Hello
-        {name()}
-      </div>
+      <div>Hello {name()}</div>
     </>
   );
 }
@@ -6945,9 +6879,8 @@ function MyBasicForComponent(props: any) {
                   setName(event.target.value + \\" and \\" + person);
                 }}
               />
-              Hello
-              {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-              Liquid!
+              Hello {person}! I can run in Qwik, Web Component, React, Vue,
+              Solid, or Liquid!
             </>
           );
         }}
@@ -6988,9 +6921,8 @@ function MyBasicForComponent(props: any) {
                     setName(event.target.value + \\" and \\" + person);
                   }}
                 />
-                Hello
-                {person}! I can run in Qwik, Web Component, React, Vue, Solid,
-                or Liquid!
+                Hello {person}! I can run in Qwik, Web Component, React, Vue,
+                Solid, or Liquid!
               </>
             );
           }}
@@ -7204,9 +7136,7 @@ function MyPreviousComponent(props: Props) {
   return (
     <div>
       <h1>
-        Now:
-        {count()}, before:
-        {prevCount}
+        Now: {count()}, before: {prevCount}
       </h1>
       <button onClick={(event) => setCount(1)}>Increment</button>
     </div>
@@ -7250,9 +7180,7 @@ function MyPreviousComponent(props: Props) {
     <>
       <div>
         <h1>
-          Now:
-          {count()}, before:
-          {prevCount}
+          Now: {count()}, before: {prevCount}
         </h1>
         <button onClick={(event) => setCount(1)}>Increment</button>
       </div>
@@ -8609,7 +8537,7 @@ function FormComponent(props: FormProps) {
           ></BuilderBlocks>
         </Show>
         <Show when={submissionState() === \\"error\\" && responseData()}>
-          <pre class=\\"builder-form-error-text pre-0a36e30c\\">
+          <pre class=\\"builder-form-error-text pre-0f4ff540\\">
             {JSON.stringify(responseData(), null, 2)}
           </pre>
         </Show>
@@ -8621,7 +8549,7 @@ function FormComponent(props: FormProps) {
         </Show>
       </form>
       <style jsx>{\`
-        .pre-0a36e30c {
+        .pre-0f4ff540 {
           padding: 10px;
           color: red;
           text-align: center;
@@ -9066,6 +8994,30 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Solid > jsx > Typescript Test > Literal Space 1`] = `
+"function Hello(props: any) {
+  return <div>Hello {props.name ?? \\"World\\"}</div>;
+}
+
+export default Hello;
+"
+`;
+
+exports[`Solid > jsx > Typescript Test > Literal Space 2`] = `
+"import { css } from \\"solid-styled-components\\";
+
+function Hello(props: any) {
+  return (
+    <>
+      <div>Hello {props.name ?? \\"World\\"}</div>
+    </>
+  );
+}
+
+export default Hello;
 "
 `;
 
@@ -9608,10 +9560,7 @@ function SmileReviews(props: SmileReviewsProps) {
                 src={review.avatar}
               />
               <div class={showReviewPrompt() ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-                <div>
-                  N:
-                  {index}
-                </div>
+                <div>N: {index}</div>
                 <div>{review.author}</div>
                 <div>{review.reviewMessage}</div>
               </div>
@@ -9695,10 +9644,7 @@ function SmileReviews(props: SmileReviewsProps) {
               <div class=\\"div-66d09606\\" key={review.id}>
                 <img class=\\"img-66d09606\\" src={review.avatar} />
                 <div class={showReviewPrompt() ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-                  <div>
-                    N:
-                    {index}
-                  </div>
+                  <div>N: {index}</div>
                   <div>{review.author}</div>
                   <div>{review.reviewMessage}</div>
                 </div>
@@ -10035,12 +9981,7 @@ function MyComponent(props: any) {
     setName(value);
   }
 
-  return (
-    <div>
-      Hello
-      {name()}
-    </div>
-  );
+  return <div>Hello {name()}</div>;
 }
 
 export default MyComponent;
@@ -10065,10 +10006,7 @@ function MyComponent(props: any) {
 
   return (
     <>
-      <div>
-        Hello
-        {name()}
-      </div>
+      <div>Hello {name()}</div>
     </>
   );
 }
@@ -10094,8 +10032,7 @@ function MyBasicForNoTagRefComponent(props: any) {
 
   return (
     <Dynamic component={TagNameGetter()}>
-      Hello
-      <Dynamic component={tag()}>{name()}</Dynamic>
+      Hello <Dynamic component={tag()}>{name()}</Dynamic>
       <For each={props.actions}>
         {(action, _index) => {
           const index = _index();
@@ -10135,8 +10072,7 @@ function MyBasicForNoTagRefComponent(props: any) {
   return (
     <>
       <Dynamic component={TagNameGetter()}>
-        Hello
-        <Dynamic component={tag()}>{name()}</Dynamic>
+        Hello <Dynamic component={tag()}>{name()}</Dynamic>
         <For each={props.actions}>
           {(action, _index) => {
             const index = _index();
@@ -10181,12 +10117,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
   }
   createEffect(on(() => [name()], onUpdateFn_0));
 
-  return (
-    <div>
-      Hello!
-      {name()}
-    </div>
-  );
+  return <div>Hello! {name()}</div>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -10221,10 +10152,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
 
   return (
     <>
-      <div>
-        Hello!
-        {name()}
-      </div>
+      <div>Hello! {name()}</div>
     </>
   );
 }
@@ -10872,13 +10800,7 @@ const DEFAULT_VALUES: Props = {
 };
 
 function ComponentWithTypes(props: Props) {
-  return (
-    <div>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </div>
-  );
+  return <div> Hello {props.name || DEFAULT_VALUES.name}</div>;
 }
 
 export default ComponentWithTypes;
@@ -10898,11 +10820,7 @@ const DEFAULT_VALUES: Props = {
 function ComponentWithTypes(props: Props) {
   return (
     <>
-      <div>
-        {\\" \\"}
-        Hello
-        {props.name || DEFAULT_VALUES.name}
-      </div>
+      <div> Hello {props.name || DEFAULT_VALUES.name}</div>
     </>
   );
 }
@@ -11334,12 +11252,7 @@ export const defaultValues = {
 function OnInit(props: Props) {
   const [name, setName] = createSignal(\\"\\");
 
-  return (
-    <div>
-      Default name defined by parent
-      {name()}
-    </div>
-  );
+  return <div>Default name defined by parent {name()}</div>;
 }
 
 export default OnInit;
@@ -11363,10 +11276,7 @@ function OnInit(props: Props) {
 
   return (
     <>
-      <div>
-        Default name defined by parent
-        {name()}
-      </div>
+      <div>Default name defined by parent {name()}</div>
     </>
   );
 }
@@ -11563,10 +11473,7 @@ export interface MyBasicComponentProps {
 
 function MyBasicComponent(props: MyBasicComponentProps) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -11592,10 +11499,7 @@ export interface MyBasicComponentProps {
 function MyBasicComponent(props: MyBasicComponentProps) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -11663,10 +11567,7 @@ exports[`Solid > jsx > Typescript Test > propsInterface 1`] = `
 
 function MyBasicComponent(props: Person | never) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -11684,10 +11585,7 @@ interface Person {
 function MyBasicComponent(props: Person | never) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -11704,10 +11602,7 @@ exports[`Solid > jsx > Typescript Test > propsType 1`] = `
 
 function MyBasicComponent(props: Person) {
   return (
-    <div>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </div>
+    <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
   );
 }
 
@@ -11725,10 +11620,7 @@ type Person = {
 function MyBasicComponent(props: Person) {
   return (
     <>
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {props.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</div>
     </>
   );
 }
@@ -13321,14 +13213,8 @@ function MyComponent(props) {
         checked={fillings() === \\"Guac (extra)\\"}
         onInput={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla()}
-      </p>
-      <p>
-        Fillings:
-        {fillings()}
-      </p>
+      <p>Tortilla: {tortilla()}</p>
+      <p>Fillings: {fillings()}</p>
     </div>
   );
 }
@@ -13394,14 +13280,8 @@ function MyComponent(props) {
           checked={fillings() === \\"Guac (extra)\\"}
           onInput={(event) => setFillings(event.target.value)}
         />
-        <p>
-          Tortilla:
-          {tortilla()}
-        </p>
-        <p>
-          Fillings:
-          {fillings()}
-        </p>
+        <p>Tortilla: {tortilla()}</p>
+        <p>Fillings: {fillings()}</p>
       </div>
     </>
   );
@@ -13780,8 +13660,7 @@ function MyComponent(props) {
   return (
     <div>
       <input value={name()} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -13806,8 +13685,7 @@ function MyComponent(props) {
     <>
       <div>
         <input value={name()} />
-        Lowercase:
-        {lowercaseName()}
+        Lowercase: {lowercaseName()}
       </div>
     </>
   );
@@ -13848,8 +13726,7 @@ function MyComponent(props) {
         onInput={(event) => setB(event.target.value)}
         value={b()}
       />
-      Result:
-      {result()}
+      Result: {result()}
     </div>
   );
 }
@@ -13892,8 +13769,7 @@ function MyComponent(props) {
           onInput={(event) => setB(event.target.value)}
           value={b()}
         />
-        Result:
-        {result()}
+        Result: {result()}
       </div>
     </>
   );
@@ -14137,14 +14013,8 @@ function MyComponent(props: any) {
         checked={fillings() === \\"Guac (extra)\\"}
         onInput={(event) => setFillings(event.target.value)}
       />
-      <p>
-        Tortilla:
-        {tortilla()}
-      </p>
-      <p>
-        Fillings:
-        {fillings()}
-      </p>
+      <p>Tortilla: {tortilla()}</p>
+      <p>Fillings: {fillings()}</p>
     </div>
   );
 }
@@ -14210,14 +14080,8 @@ function MyComponent(props: any) {
           checked={fillings() === \\"Guac (extra)\\"}
           onInput={(event) => setFillings(event.target.value)}
         />
-        <p>
-          Tortilla:
-          {tortilla()}
-        </p>
-        <p>
-          Fillings:
-          {fillings()}
-        </p>
+        <p>Tortilla: {tortilla()}</p>
+        <p>Fillings: {fillings()}</p>
       </div>
     </>
   );
@@ -14596,8 +14460,7 @@ function MyComponent(props: any) {
   return (
     <div>
       <input value={name()} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </div>
   );
 }
@@ -14622,8 +14485,7 @@ function MyComponent(props: any) {
     <>
       <div>
         <input value={name()} />
-        Lowercase:
-        {lowercaseName()}
+        Lowercase: {lowercaseName()}
       </div>
     </>
   );
@@ -14664,8 +14526,7 @@ function MyComponent(props: any) {
         onInput={(event) => setB(event.target.value)}
         value={b()}
       />
-      Result:
-      {result()}
+      Result: {result()}
     </div>
   );
 }
@@ -14708,8 +14569,7 @@ function MyComponent(props: any) {
           onInput={(event) => setB(event.target.value)}
           value={b()}
         />
-        Result:
-        {result()}
+        Result: {result()}
       </div>
     </>
   );

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -47,7 +47,6 @@ export default class MyBasicRefComponent {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -153,12 +152,7 @@ export default class MyBasicOnMountUpdateComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello
-        {this.name}
-      </div>
-    );
+    return <div>Hello {this.name}</div>;
   }
 }
 "
@@ -243,18 +237,13 @@ export default class MyBooleanAttribute {
   render() {
     return (
       <div>
-        {this.children}
-
-        {this.type}
-
+        {this.children} {this.type}
         <MyBooleanAttributeComponent
           toggle={true}
         ></MyBooleanAttributeComponent>
-
         <MyBooleanAttributeComponent
           toggle={true}
         ></MyBooleanAttributeComponent>
-
         <MyBooleanAttributeComponent list={null}></MyBooleanAttributeComponent>
       </div>
     );
@@ -280,7 +269,6 @@ export default class MyBasicChildComponent {
     return (
       <div>
         <MyBasicComponent id={this.dev}></MyBasicComponent>
-
         <div>
           <MyBasicOnMountUpdateComponent
             hi={this.name}
@@ -319,9 +307,8 @@ export default class MyBasicForComponent {
                 this.name = event.target.value + \\" and \\" + person;
               }}
             />
-            Hello
-            {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-            Liquid!
+            Hello {person}! I can run in Qwik, Web Component, React, Vue, Solid,
+            or Liquid!
           </Fragment>
         ))}
       </div>
@@ -374,7 +361,6 @@ export default class MyBasicRefComponent {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -443,11 +429,8 @@ export default class MyPreviousComponent {
     return (
       <div>
         <h1>
-          Now:
-          {this.count}, before:
-          {prevCount}
+          Now: {this.count}, before: {prevCount}
         </h1>
-
         <button onClick={(event) => (this.count += 1)}>Increment</button>
       </div>
     );
@@ -482,7 +465,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button type=\\"button\\" {...props.attributes}>
@@ -550,9 +532,7 @@ export default class Column {
       <div class=\\"builder-columns div\\">
         {this.columns?.map((column, index) => (
           <div class=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -575,11 +555,9 @@ export default class ContentSlotCode {
     return (
       <div>
         <Slot name={this.slotTesting}></Slot>
-
         <div>
           <hr />
         </div>
-
         <div>
           <Slot></Slot>
         </div>
@@ -597,8 +575,8 @@ exports[`Stencil > jsx > Javascript Test > ContentSlotJSX 1`] = `
 > 33 |          {this.slotReference ? (
      |               ^
   34 |      <><div  class={state.cls}  name={this.slotContent ? 'name1' : 'name2'}  title={this.slotContent ? 'title1' : 'title2'}  {...(props.attributes)}  onClick={event => this.show()} >
-  35 |
-  36 | {this.showContent && this.slotContent ? ("
+  35 |        {this.showContent && this.slotContent ? (
+  36 |      <><Slot  name=\\"content\\" >{this.content}</Slot></>"
 `;
 
 exports[`Stencil > jsx > Javascript Test > CustomCode 1`] = `
@@ -1166,10 +1144,8 @@ export default class Image {
               />
             </>
           ) : null}
-
           <source srcset={this.srcset} />
         </picture>
-
         {this.children}
       </div>
     );
@@ -1270,6 +1246,22 @@ export default class FormInputComponent {
         required={this.required}
       />
     );
+  }
+}
+"
+`;
+
+exports[`Stencil > jsx > Javascript Test > Literal Space 1`] = `
+"import { Component, Prop, h, State, Fragment } from \\"@stencil/core\\";
+
+@Component({
+  tag: \\"hello\\",
+})
+export default class Hello {
+  @Prop() name: any;
+
+  render() {
+    return <div>Hello {this.name ?? \\"World\\"}</div>;
   }
 }
 "
@@ -1441,9 +1433,7 @@ export default class SlotCode {
     return (
       <div>
         <Slot name=\\"top\\"></Slot>
-
         <Slot name=\\"left\\">Default left</Slot>
-
         <Slot>Default Child</Slot>
       </div>
     );
@@ -1517,7 +1507,6 @@ export default class SmileReviews {
         <button onClick={(event) => (this.showReviewPrompt = true)}>
           Write a review
         </button>
-
         {this.showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -1537,19 +1526,12 @@ export default class SmileReviews {
             </button>
           </>
         ) : null}
-
         {this.reviews?.map((review, index) => (
           <div class=\\"review\\" key={review.id}>
             <img class=\\"img\\" src={review.avatar} />
-
             <div class={state.showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -1706,12 +1688,7 @@ export default class MyComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello
-        {this.name}
-      </div>
-    );
+    return <div>Hello {this.name}</div>;
   }
 }
 "
@@ -1737,12 +1714,10 @@ export default class MyBasicForNoTagRefComponent {
   render() {
     return (
       <state.TagNameGetter>
-        Hello
-        <state.tag>{this.name}</state.tag>
+        Hello <state.tag>{this.name}</state.tag>
         {this.actions?.map((action) => (
           <state.TagName>
             <action.icon></action.icon>
-
             <span>{action.text}</span>
           </state.TagName>
         ))}
@@ -1844,12 +1819,7 @@ export default class MyBasicOnUpdateReturnComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello!
-        {this.name}
-      </div>
-    );
+    return <div>Hello! {this.name}</div>;
   }
 }
 "
@@ -2013,7 +1983,6 @@ export default class ComponentWithContext {
     return (
       <Fragment>
         <Fragment>{foo.value}</Fragment>
-
         <div>other</div>
       </Fragment>
     );
@@ -2069,7 +2038,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button
@@ -2115,7 +2083,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button
@@ -2148,13 +2115,7 @@ export default class ComponentWithTypes {
   @Prop() name: any;
 
   render() {
-    return (
-      <div>
-        {\\" \\"}
-        Hello
-        {this.name || DEFAULT_VALUES.name}
-      </div>
-    );
+    return <div> Hello {this.name || DEFAULT_VALUES.name}</div>;
   }
 }
 "
@@ -2302,12 +2263,7 @@ export default class OnInit {
   @State() name = \\"\\";
 
   render() {
-    return (
-      <div>
-        Default name defined by parent
-        {this.name}
-      </div>
-    );
+    return <div>Default name defined by parent {this.name}</div>;
   }
 }
 "
@@ -2406,10 +2362,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -2431,8 +2384,7 @@ export default class MyBasicComponent {
   render() {
     return (
       <div>
-        {this.children}
-        {this.type}
+        {this.children} {this.type}
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>
     );
@@ -2452,10 +2404,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -2473,10 +2422,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -2519,7 +2465,7 @@ exports[`Stencil > jsx > Javascript Test > renderBlock 1`] = `
       |               ^
   206 |      <>{isEmptyHtmlElement(this.tag) ? (
   207 |      <><state.tag  {...(state.attributes)}  {...(state.actions)} ></state.tag></>
-  208 |    ) : null}"
+  208 |    ) : null}{!isEmptyHtmlElement(this.tag) && this.repeatItemData ? ("
 `;
 
 exports[`Stencil > jsx > Javascript Test > renderContentExample 1`] = `
@@ -2591,7 +2537,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button type=\\"button\\" {...props.attributes}>
@@ -2619,7 +2564,6 @@ export default class MyComponent {
     return (
       <div>
         {this.name}
-
         {this.name === \\"Batman\\" ? (
           <>
             <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
@@ -2646,9 +2590,7 @@ export default class MyComponent {
     return (
       <div>
         {this.name}
-
         {this.children}
-
         {this.name === \\"Batman\\" ? (
           <>
             <MyComponent name=\\"Bruce\\">
@@ -2770,13 +2712,11 @@ export default class SvgComponent {
         <defs>
           <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
             <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
             <feBlend
               in=\\"SourceGraphic\\"
               in2=\\"BackgroundImageFix\\"
               result=\\"shape\\"
             ></feBlend>
-
             <feGaussianBlur
               result=\\"effect1_foregroundBlur\\"
               stdDeviation={7}
@@ -2910,8 +2850,7 @@ export default class MyBasicComponent {
   render() {
     return (
       <div>
-        Hello
-        {this.name}! I can run in React, Qwik, Vue, Solid, or Liquid!
+        Hello {this.name}! I can run in React, Qwik, Vue, Solid, or Liquid!
       </div>
     );
   }
@@ -2966,7 +2905,6 @@ export default class MyBasicRefComponent {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -3072,12 +3010,7 @@ export default class MyBasicOnMountUpdateComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello
-        {this.name}
-      </div>
-    );
+    return <div>Hello {this.name}</div>;
   }
 }
 "
@@ -3162,18 +3095,13 @@ export default class MyBooleanAttribute {
   render() {
     return (
       <div>
-        {this.children}
-
-        {this.type}
-
+        {this.children} {this.type}
         <MyBooleanAttributeComponent
           toggle={true}
         ></MyBooleanAttributeComponent>
-
         <MyBooleanAttributeComponent
           toggle={true}
         ></MyBooleanAttributeComponent>
-
         <MyBooleanAttributeComponent list={null}></MyBooleanAttributeComponent>
       </div>
     );
@@ -3199,7 +3127,6 @@ export default class MyBasicChildComponent {
     return (
       <div>
         <MyBasicComponent id={this.dev}></MyBasicComponent>
-
         <div>
           <MyBasicOnMountUpdateComponent
             hi={this.name}
@@ -3238,9 +3165,8 @@ export default class MyBasicForComponent {
                 this.name = event.target.value + \\" and \\" + person;
               }}
             />
-            Hello
-            {person}! I can run in Qwik, Web Component, React, Vue, Solid, or
-            Liquid!
+            Hello {person}! I can run in Qwik, Web Component, React, Vue, Solid,
+            or Liquid!
           </Fragment>
         ))}
       </div>
@@ -3293,7 +3219,6 @@ export default class MyBasicRefComponent {
 
             <select name=\\"cars\\" id=\\"cars\\">
               <option value=\\"supra\\">GR Supra</option>
-
               <option value=\\"86\\">GR 86</option>
             </select>
           </Fragment>
@@ -3362,11 +3287,8 @@ export default class MyPreviousComponent {
     return (
       <div>
         <h1>
-          Now:
-          {this.count}, before:
-          {prevCount}
+          Now: {this.count}, before: {prevCount}
         </h1>
-
         <button onClick={(event) => (this.count += 1)}>Increment</button>
       </div>
     );
@@ -3401,7 +3323,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button type=\\"button\\" {...props.attributes}>
@@ -3469,9 +3390,7 @@ export default class Column {
       <div class=\\"builder-columns div\\">
         {this.columns?.map((column, index) => (
           <div class=\\"builder-column div-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </div>
         ))}
       </div>
@@ -3496,11 +3415,9 @@ export default class ContentSlotCode {
     return (
       <div>
         <Slot name={this.slotTesting}></Slot>
-
         <div>
           <hr />
         </div>
-
         <div>
           <Slot></Slot>
         </div>
@@ -3518,8 +3435,8 @@ exports[`Stencil > jsx > Typescript Test > ContentSlotJSX 1`] = `
 > 38 |          {this.slotReference ? (
      |               ^
   39 |      <><div  class={state.cls}  name={this.slotContent ? 'name1' : 'name2'}  title={this.slotContent ? 'title1' : 'title2'}  {...(props.attributes)}  onClick={event => this.show()} >
-  40 |
-  41 | {this.showContent && this.slotContent ? ("
+  40 |        {this.showContent && this.slotContent ? (
+  41 |      <><Slot  name=\\"content\\" >{this.content}</Slot></>"
 `;
 
 exports[`Stencil > jsx > Typescript Test > CustomCode 1`] = `
@@ -4094,10 +4011,8 @@ export default class Image {
               />
             </>
           ) : null}
-
           <source srcset={this.srcset} />
         </picture>
-
         {this.children}
       </div>
     );
@@ -4198,6 +4113,22 @@ export default class FormInputComponent {
         required={this.required}
       />
     );
+  }
+}
+"
+`;
+
+exports[`Stencil > jsx > Typescript Test > Literal Space 1`] = `
+"import { Component, Prop, h, State, Fragment } from \\"@stencil/core\\";
+
+@Component({
+  tag: \\"hello\\",
+})
+export default class Hello {
+  @Prop() name: any;
+
+  render() {
+    return <div>Hello {this.name ?? \\"World\\"}</div>;
   }
 }
 "
@@ -4369,9 +4300,7 @@ export default class SlotCode {
     return (
       <div>
         <Slot name=\\"top\\"></Slot>
-
         <Slot name=\\"left\\">Default left</Slot>
-
         <Slot>Default Child</Slot>
       </div>
     );
@@ -4445,7 +4374,6 @@ export default class SmileReviews {
         <button onClick={(event) => (this.showReviewPrompt = true)}>
           Write a review
         </button>
-
         {this.showReviewPrompt || \\"asdf\\" ? (
           <>
             <input placeholder=\\"Email\\" />
@@ -4465,19 +4393,12 @@ export default class SmileReviews {
             </button>
           </>
         ) : null}
-
         {this.reviews?.map((review, index) => (
           <div class=\\"review\\" key={review.id}>
             <img class=\\"img\\" src={review.avatar} />
-
             <div class={state.showReviewPrompt ? \\"bg-primary\\" : \\"bg-secondary\\"}>
-              <div>
-                N:
-                {index}
-              </div>
-
+              <div>N: {index}</div>
               <div>{review.author}</div>
-
               <div>{review.reviewMessage}</div>
             </div>
           </div>
@@ -4634,12 +4555,7 @@ export default class MyComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello
-        {this.name}
-      </div>
-    );
+    return <div>Hello {this.name}</div>;
   }
 }
 "
@@ -4665,12 +4581,10 @@ export default class MyBasicForNoTagRefComponent {
   render() {
     return (
       <state.TagNameGetter>
-        Hello
-        <state.tag>{this.name}</state.tag>
+        Hello <state.tag>{this.name}</state.tag>
         {this.actions?.map((action) => (
           <state.TagName>
             <action.icon></action.icon>
-
             <span>{action.text}</span>
           </state.TagName>
         ))}
@@ -4772,12 +4686,7 @@ export default class MyBasicOnUpdateReturnComponent {
   }
 
   render() {
-    return (
-      <div>
-        Hello!
-        {this.name}
-      </div>
-    );
+    return <div>Hello! {this.name}</div>;
   }
 }
 "
@@ -4943,7 +4852,6 @@ export default class ComponentWithContext {
     return (
       <Fragment>
         <Fragment>{foo.value}</Fragment>
-
         <div>other</div>
       </Fragment>
     );
@@ -4999,7 +4907,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button
@@ -5045,7 +4952,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button
@@ -5078,13 +4984,7 @@ export default class ComponentWithTypes {
   @Prop() name: any;
 
   render() {
-    return (
-      <div>
-        {\\" \\"}
-        Hello
-        {this.name || DEFAULT_VALUES.name}
-      </div>
-    );
+    return <div> Hello {this.name || DEFAULT_VALUES.name}</div>;
   }
 }
 "
@@ -5233,12 +5133,7 @@ export default class OnInit {
   @State() name = \\"\\";
 
   render() {
-    return (
-      <div>
-        Default name defined by parent
-        {this.name}
-      </div>
-    );
+    return <div>Default name defined by parent {this.name}</div>;
   }
 }
 "
@@ -5337,10 +5232,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -5362,8 +5254,7 @@ export default class MyBasicComponent {
   render() {
     return (
       <div>
-        {this.children}
-        {this.type}
+        {this.children} {this.type}
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>
     );
@@ -5383,10 +5274,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -5404,10 +5292,7 @@ export default class MyBasicComponent {
 
   render() {
     return (
-      <div>
-        Hello! I can run in React, Vue, Solid, or Liquid!
-        {this.name}
-      </div>
+      <div>Hello! I can run in React, Vue, Solid, or Liquid! {this.name}</div>
     );
   }
 }
@@ -5450,7 +5335,7 @@ exports[`Stencil > jsx > Typescript Test > renderBlock 1`] = `
       |               ^
   211 |      <>{isEmptyHtmlElement(this.tag) ? (
   212 |      <><state.tag  {...(state.attributes)}  {...(state.actions)} ></state.tag></>
-  213 |    ) : null}"
+  213 |    ) : null}{!isEmptyHtmlElement(this.tag) && this.repeatItemData ? ("
 `;
 
 exports[`Stencil > jsx > Typescript Test > renderContentExample 1`] = `
@@ -5522,7 +5407,6 @@ export default class Button {
             </a>
           </>
         ) : null}
-
         {!this.link ? (
           <>
             <button type=\\"button\\" {...props.attributes}>
@@ -5550,7 +5434,6 @@ export default class MyComponent {
     return (
       <div>
         {this.name}
-
         {this.name === \\"Batman\\" ? (
           <>
             <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
@@ -5577,9 +5460,7 @@ export default class MyComponent {
     return (
       <div>
         {this.name}
-
         {this.children}
-
         {this.name === \\"Batman\\" ? (
           <>
             <MyComponent name=\\"Bruce\\">
@@ -5701,13 +5582,11 @@ export default class SvgComponent {
         <defs>
           <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
             <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-
             <feBlend
               in=\\"SourceGraphic\\"
               in2=\\"BackgroundImageFix\\"
               result=\\"shape\\"
             ></feBlend>
-
             <feGaussianBlur
               result=\\"effect1_foregroundBlur\\"
               stdDeviation={7}
@@ -5913,14 +5792,8 @@ export default class MyComponent {
           checked={this.fillings === \\"Guac (extra)\\"}
           onInput={(event) => (this.fillings = event.target.value)}
         />
-        <p>
-          Tortilla:
-          {this.tortilla}
-        </p>
-        <p>
-          Fillings:
-          {this.fillings}
-        </p>
+        <p>Tortilla: {this.tortilla}</p>
+        <p>Fillings: {this.fillings}</p>
       </div>
     );
   }
@@ -6122,8 +5995,7 @@ export default class MyComponent {
     return (
       <div>
         <input value={this.name} />
-        Lowercase:
-        {this.lowercaseName}
+        Lowercase: {this.lowercaseName}
       </div>
     );
   }
@@ -6163,8 +6035,7 @@ export default class MyComponent {
           onInput={(event) => (this.b = event.target.value)}
           value={this.b}
         />
-        Result:
-        {this.result}
+        Result: {this.result}
       </div>
     );
   }
@@ -6323,14 +6194,8 @@ export default class MyComponent {
           checked={this.fillings === \\"Guac (extra)\\"}
           onInput={(event) => (this.fillings = event.target.value)}
         />
-        <p>
-          Tortilla:
-          {this.tortilla}
-        </p>
-        <p>
-          Fillings:
-          {this.fillings}
-        </p>
+        <p>Tortilla: {this.tortilla}</p>
+        <p>Fillings: {this.fillings}</p>
       </div>
     );
   }
@@ -6532,8 +6397,7 @@ export default class MyComponent {
     return (
       <div>
         <input value={this.name} />
-        Lowercase:
-        {this.lowercaseName}
+        Lowercase: {this.lowercaseName}
       </div>
     );
   }
@@ -6573,8 +6437,7 @@ export default class MyComponent {
           onInput={(event) => (this.b = event.target.value)}
           value={this.b}
         />
-        Result:
-        {this.result}
+        Result: {this.result}
       </div>
     );
   }

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1093,6 +1093,14 @@ exports[`Svelte > jsx > Javascript Test > Input 1`] = `
 />"
 `;
 
+exports[`Svelte > jsx > Javascript Test > Literal Space 1`] = `
+"<script>
+  export let name;
+</script>
+
+<div>Hello {name ?? \\"World\\"}</div>"
+`;
+
 exports[`Svelte > jsx > Javascript Test > RawText 1`] = `
 "<script>
   export let attributes;
@@ -3858,6 +3866,14 @@ exports[`Svelte > jsx > Typescript Test > Input 1`] = `
   {defaultValue}
   {required}
 />"
+`;
+
+exports[`Svelte > jsx > Typescript Test > Literal Space 1`] = `
+"<script lang=\\"ts\\">
+  export let name;
+</script>
+
+<div>Hello {name ?? \\"World\\"}</div>"
 `;
 
 exports[`Svelte > jsx > Typescript Test > RawText 1`] = `

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -42,7 +42,6 @@ function MyBasicRefComponent(props) {
 
             <View name=\\"cars\\" id=\\"cars\\">
               <View value=\\"supra\\">GR Supra</View>
-
               <View value=\\"86\\">GR 86</View>
             </View>
           </>
@@ -164,12 +163,7 @@ function MyBasicOnMountUpdateComponent(props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <View>
-      Hello
-      {name}
-    </View>
-  );
+  return <View>Hello {name}</View>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -236,14 +230,9 @@ import { View, Text } from \\"@tarojs/components\\";
 function MyBooleanAttribute(props) {
   return (
     <View>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </View>
   );
@@ -268,7 +257,6 @@ function MyBasicChildComponent(props) {
   return (
     <View>
       <MyBasicComponent id={dev} />
-
       <View>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </View>
@@ -355,7 +343,6 @@ function MyBasicRefComponent(props) {
 
             <View name=\\"cars\\" id=\\"cars\\">
               <View value=\\"supra\\">GR Supra</View>
-
               <View value=\\"86\\">GR 86</View>
             </View>
           </>
@@ -430,11 +417,8 @@ function MyPreviousComponent(props) {
   return (
     <View>
       <View>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </View>
-
       <Button onClick={(event) => setCount(1)}>Increment</Button>
     </View>
   );
@@ -462,7 +446,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button type=\\"button\\" {...props.attributes}>
@@ -508,9 +491,7 @@ function Column(props) {
       <View className=\\"view\\">
         {props.columns?.map((column, index) => (
           <View className=\\"view-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </View>
         ))}
       </View>
@@ -551,11 +532,9 @@ function ContentSlotCode(props) {
   return (
     <View>
       {props.slotTesting}
-
       <View>
         <View />
       </View>
-
       <View>{props.children}</View>
     </View>
   );
@@ -596,11 +575,9 @@ function ContentSlotJsxCode(props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <View>
               <View />
             </View>
-
             <View>{props.children}</View>
           </View>
         </>
@@ -1103,10 +1080,8 @@ function Image(props) {
               />
             </>
           ) : null}
-
           <View srcset={props.srcset} />
         </View>
-
         {props.children}
       </View>
       <style jsx>{\`
@@ -1199,6 +1174,18 @@ function FormInputComponent(props) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Taro > jsx > Javascript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+import { View, Text } from \\"@tarojs/components\\";
+
+function Hello(props) {
+  return <View>Hello {props.name ?? \\"World\\"}</View>;
+}
+
+export default Hello;
 "
 `;
 
@@ -1324,9 +1311,7 @@ function SlotCode(props) {
   return (
     <View>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </View>
   );
@@ -1375,7 +1360,6 @@ function SmileReviews(props) {
         <Button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </Button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <>
             <Input placeholder=\\"Email\\" />
@@ -1395,19 +1379,12 @@ function SmileReviews(props) {
             </Button>
           </>
         ) : null}
-
         {reviews?.map((review, index) => (
           <View className=\\"review\\" key={review.id}>
             <Image className=\\"image\\" src={review.avatar} />
-
             <View>
-              <View>
-                N:
-                {index}
-              </View>
-
+              <View>N: {index}</View>
               <View>{review.author}</View>
-
               <View>{review.reviewMessage}</View>
             </View>
           </View>
@@ -1560,12 +1537,7 @@ function MyComponent(props) {
     setName(value);
   }
 
-  return (
-    <View>
-      Hello
-      {name}
-    </View>
-  );
+  return <View>Hello {name}</View>;
 }
 
 export default MyComponent;
@@ -1592,12 +1564,10 @@ function MyBasicForNoTagRefComponent(props) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <View>{name}</View>
+      Hello <View>{name}</View>
       {props.actions?.map((action) => (
         <TagName>
           <View />
-
           <Text>{action.text}</Text>
         </TagName>
       ))}
@@ -1700,12 +1670,7 @@ function MyBasicOnUpdateReturnComponent(props) {
     };
   }, [name]);
 
-  return (
-    <View>
-      Hello!
-      {name}
-    </View>
-  );
+  return <View>Hello! {name}</View>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -1947,7 +1912,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button
@@ -1994,7 +1958,6 @@ function Button(props) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button
@@ -2029,13 +1992,7 @@ const DEFAULT_VALUES = {
 };
 
 function ComponentWithTypes(props) {
-  return (
-    <View>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </View>
-  );
+  return <View> Hello {props.name || DEFAULT_VALUES.name}</View>;
 }
 
 export default ComponentWithTypes;
@@ -2264,12 +2221,7 @@ function OnInit(props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <View>
-      Default name defined by parent
-      {name}
-    </View>
-  );
+  return <View>Default name defined by parent {name}</View>;
 }
 
 export default OnInit;
@@ -2360,10 +2312,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -2381,8 +2330,7 @@ function MyBasicComponent(props) {
 
   return (
     <View>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </View>
   );
@@ -2398,10 +2346,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -2415,10 +2360,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -2696,7 +2638,6 @@ function RenderBlock(props) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -2840,7 +2781,6 @@ function MyComponent(props) {
   return (
     <View>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -2862,9 +2802,7 @@ function MyComponent(props) {
   return (
     <View>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -3011,9 +2949,7 @@ function SvgComponent(props) {
       <View>
         <View id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </View>
       </View>
@@ -3140,10 +3076,7 @@ function MyBasicComponent(props) {
   const [name, setName] = useState(() => \\"PatrickJS\\");
 
   return (
-    <View>
-      Hello
-      {name}! I can run in React, Qwik, Vue, Solid, or Liquid!
-    </View>
+    <View>Hello {name}! I can run in React, Qwik, Vue, Solid, or Liquid!</View>
   );
 }
 
@@ -3198,7 +3131,6 @@ function MyBasicRefComponent(props: Props) {
 
             <View name=\\"cars\\" id=\\"cars\\">
               <View value=\\"supra\\">GR Supra</View>
-
               <View value=\\"86\\">GR 86</View>
             </View>
           </>
@@ -3331,12 +3263,7 @@ function MyBasicOnMountUpdateComponent(props: Props) {
     setName(\\"PatrickJS onMount\\" + props.bye);
   }, []);
 
-  return (
-    <View>
-      Hello
-      {name}
-    </View>
-  );
+  return <View>Hello {name}</View>;
 }
 
 export default MyBasicOnMountUpdateComponent;
@@ -3408,14 +3335,9 @@ import { View, Text } from \\"@tarojs/components\\";
 function MyBooleanAttribute(props: Props) {
   return (
     <View>
-      {props.children}
-
-      {props.type}
-
+      {props.children} {props.type}
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent toggle={true} />
-
       <MyBooleanAttributeComponent list={null} />
     </View>
   );
@@ -3440,7 +3362,6 @@ function MyBasicChildComponent(props: any) {
   return (
     <View>
       <MyBasicComponent id={dev} />
-
       <View>
         <MyBasicOnMountUpdateComponent hi={name} bye={dev} />
       </View>
@@ -3532,7 +3453,6 @@ function MyBasicRefComponent(props: Props) {
 
             <View name=\\"cars\\" id=\\"cars\\">
               <View value=\\"supra\\">GR Supra</View>
-
               <View value=\\"86\\">GR 86</View>
             </View>
           </>
@@ -3617,11 +3537,8 @@ function MyPreviousComponent(props: Props) {
   return (
     <View>
       <View>
-        Now:
-        {count}, before:
-        {prevCount.current}
+        Now: {count}, before: {prevCount.current}
       </View>
-
       <Button onClick={(event) => setCount(1)}>Increment</Button>
     </View>
   );
@@ -3657,7 +3574,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button type=\\"button\\" {...props.attributes}>
@@ -3719,9 +3635,7 @@ function Column(props: ColumnProps) {
       <View className=\\"view\\">
         {props.columns?.map((column, index) => (
           <View className=\\"view-2\\">
-            {column.content}
-
-            {index}
+            {column.content} {index}
           </View>
         ))}
       </View>
@@ -3768,11 +3682,9 @@ function ContentSlotCode(props: Props) {
   return (
     <View>
       {props.slotTesting}
-
       <View>
         <View />
       </View>
-
       <View>{props.children}</View>
     </View>
   );
@@ -3818,11 +3730,9 @@ function ContentSlotJsxCode(props: Props) {
             {showContent && props.slotContent ? (
               <>{props.slotContent || \\"{props.content}\\"}</>
             ) : null}
-
             <View>
               <View />
             </View>
-
             <View>{props.children}</View>
           </View>
         </>
@@ -4388,10 +4298,8 @@ function Image(props: ImageProps) {
               />
             </>
           ) : null}
-
           <View srcset={props.srcset} />
         </View>
-
         {props.children}
       </View>
       <style jsx>{\`
@@ -4513,6 +4421,18 @@ function FormInputComponent(props: FormInputProps) {
 }
 
 export default FormInputComponent;
+"
+`;
+
+exports[`Taro > jsx > Typescript Test > Literal Space 1`] = `
+"import * as React from \\"react\\";
+import { View, Text } from \\"@tarojs/components\\";
+
+function Hello(props: any) {
+  return <View>Hello {props.name ?? \\"World\\"}</View>;
+}
+
+export default Hello;
 "
 `;
 
@@ -4679,9 +4599,7 @@ function SlotCode(props: Props) {
   return (
     <View>
       {props.slotTop}
-
       {props.slotLeft || \\"Default left\\"}
-
       {props.children || \\"Default Child\\"}
     </View>
   );
@@ -4735,7 +4653,6 @@ function SmileReviews(props: SmileReviewsProps) {
         <Button onClick={(event) => setShowReviewPrompt(true)}>
           Write a review
         </Button>
-
         {showReviewPrompt || \\"asdf\\" ? (
           <>
             <Input placeholder=\\"Email\\" />
@@ -4755,19 +4672,12 @@ function SmileReviews(props: SmileReviewsProps) {
             </Button>
           </>
         ) : null}
-
         {reviews?.map((review, index) => (
           <View className=\\"review\\" key={review.id}>
             <Image className=\\"image\\" src={review.avatar} />
-
             <View>
-              <View>
-                N:
-                {index}
-              </View>
-
+              <View>N: {index}</View>
               <View>{review.author}</View>
-
               <View>{review.reviewMessage}</View>
             </View>
           </View>
@@ -4971,12 +4881,7 @@ function MyComponent(props: any) {
     setName(value);
   }
 
-  return (
-    <View>
-      Hello
-      {name}
-    </View>
-  );
+  return <View>Hello {name}</View>;
 }
 
 export default MyComponent;
@@ -5003,12 +4908,10 @@ function MyBasicForNoTagRefComponent(props: any) {
 
   return (
     <TagNameGetterRef>
-      Hello
-      <View>{name}</View>
+      Hello <View>{name}</View>
       {props.actions?.map((action) => (
         <TagName>
           <View />
-
           <Text>{action.text}</Text>
         </TagName>
       ))}
@@ -5123,12 +5026,7 @@ function MyBasicOnUpdateReturnComponent(props: any) {
     };
   }, [name]);
 
-  return (
-    <View>
-      Hello!
-      {name}
-    </View>
-  );
+  return <View>Hello! {name}</View>;
 }
 
 export default MyBasicOnUpdateReturnComponent;
@@ -5397,7 +5295,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button
@@ -5453,7 +5350,6 @@ function Button(props: ButtonProps) {
           </View>
         </>
       ) : null}
-
       {!props.link ? (
         <>
           <Button
@@ -5492,13 +5388,7 @@ const DEFAULT_VALUES: Props = {
 };
 
 function ComponentWithTypes(props: Props) {
-  return (
-    <View>
-      {\\" \\"}
-      Hello
-      {props.name || DEFAULT_VALUES.name}
-    </View>
-  );
+  return <View> Hello {props.name || DEFAULT_VALUES.name}</View>;
 }
 
 export default ComponentWithTypes;
@@ -5744,12 +5634,7 @@ function OnInit(props: Props) {
     console.log(\\"set defaults with props\\");
   }, []);
 
-  return (
-    <View>
-      Default name defined by parent
-      {name}
-    </View>
-  );
+  return <View>Default name defined by parent {name}</View>;
 }
 
 export default OnInit;
@@ -5869,10 +5754,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: MyBasicComponentProps) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -5895,8 +5777,7 @@ function MyBasicComponent(props: Props) {
 
   return (
     <View>
-      {props.children}
-      {props.type}
+      {props.children} {props.type}
       Hello! I can run in React, Vue, Solid, or Liquid!
     </View>
   );
@@ -5918,10 +5799,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: Person | never) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -5940,10 +5818,7 @@ import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: Person) {
   return (
-    <View>
-      Hello! I can run in React, Vue, Solid, or Liquid!
-      {props.name}
-    </View>
+    <View>Hello! I can run in React, Vue, Solid, or Liquid! {props.name}</View>
   );
 }
 
@@ -6234,7 +6109,6 @@ function RenderBlock(props: RenderBlockProps) {
                     context={childrenContext()}
                   />
                 ))}
-
                 {childrenWithoutParentComponent()?.map((child) => (
                   <BlockStyles
                     key={\\"block-style-\\" + child.id}
@@ -6399,7 +6273,6 @@ function MyComponent(props: any) {
   return (
     <View>
       {props.name}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce Wayne\\" />
@@ -6421,9 +6294,7 @@ function MyComponent(props: any) {
   return (
     <View>
       {props.name}
-
       {props.children}
-
       {props.name === \\"Batman\\" ? (
         <>
           <MyComponent name=\\"Bruce\\">
@@ -6581,9 +6452,7 @@ function SvgComponent(props: any) {
       <View>
         <View id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
           <feFlood result=\\"BackgroundImageFix\\" />
-
           <feBlend in=\\"SourceGraphic\\" in2=\\"BackgroundImageFix\\" result=\\"shape\\" />
-
           <feGaussianBlur result=\\"effect1_foregroundBlur\\" stdDeviation={7} />
         </View>
       </View>
@@ -6784,14 +6653,8 @@ function MyComponent(props) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <View>
-        Tortilla:
-        {tortilla}
-      </View>
-      <View>
-        Fillings:
-        {fillings}
-      </View>
+      <View>Tortilla: {tortilla}</View>
+      <View>Fillings: {fillings}</View>
     </View>
   );
 }
@@ -6992,8 +6855,7 @@ function MyComponent(props) {
   return (
     <View>
       <Input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </View>
   );
 }
@@ -7034,8 +6896,7 @@ function MyComponent(props) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </View>
   );
 }
@@ -7188,14 +7049,8 @@ function MyComponent(props: any) {
         checked={fillings === \\"Guac (extra)\\"}
         onChange={(event) => setFillings(event.target.value)}
       />
-      <View>
-        Tortilla:
-        {tortilla}
-      </View>
-      <View>
-        Fillings:
-        {fillings}
-      </View>
+      <View>Tortilla: {tortilla}</View>
+      <View>Fillings: {fillings}</View>
     </View>
   );
 }
@@ -7396,8 +7251,7 @@ function MyComponent(props: any) {
   return (
     <View>
       <Input value={name} />
-      Lowercase:
-      {lowercaseName()}
+      Lowercase: {lowercaseName()}
     </View>
   );
 }
@@ -7438,8 +7292,7 @@ function MyComponent(props: any) {
         onChange={(event) => setB(event.target.value)}
         value={b}
       />
-      Result:
-      {result}
+      Result: {result}
     </View>
   );
 }

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -1205,6 +1205,16 @@ const props = defineProps([
 </script>"
 `;
 
+exports[`Vue > jsx > Javascript Test > Literal Space 1`] = `
+"<template>
+  <div>Hello {{ name ?? \\"World\\" }}</div>
+</template>
+
+<script setup>
+const props = defineProps([\\"name\\"]);
+</script>"
+`;
+
 exports[`Vue > jsx > Javascript Test > RawText 1`] = `
 "<template>
   <span
@@ -4167,6 +4177,16 @@ export interface FormInputProps {
 }
 
 const props = defineProps<FormInputProps>();
+</script>"
+`;
+
+exports[`Vue > jsx > Typescript Test > Literal Space 1`] = `
+"<template>
+  <div>Hello {{ name ?? \\"World\\" }}</div>
+</template>
+
+<script setup lang=\\"ts\\">
+const props = defineProps([\\"name\\"]);
 </script>"
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1385,6 +1385,22 @@ export default defineComponent({
 </script>"
 `;
 
+exports[`Vue > jsx > Javascript Test > Literal Space 1`] = `
+"<template>
+  <div>Hello {{ name ?? \\"World\\" }}</div>
+</template>
+
+<script>
+import { defineComponent } from \\"vue\\";
+
+export default defineComponent({
+  name: \\"hello\\",
+
+  props: [\\"name\\"],
+});
+</script>"
+`;
+
 exports[`Vue > jsx > Javascript Test > RawText 1`] = `
 "<template>
   <span
@@ -5040,6 +5056,22 @@ export default defineComponent({
     \\"value\\",
     \\"required\\",
   ],
+});
+</script>"
+`;
+
+exports[`Vue > jsx > Typescript Test > Literal Space 1`] = `
+"<template>
+  <div>Hello {{ name ?? \\"World\\" }}</div>
+</template>
+
+<script lang=\\"ts\\">
+import { defineComponent } from \\"vue\\";
+
+export default defineComponent({
+  name: \\"hello\\",
+
+  props: [\\"name\\"],
 });
 </script>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -68,7 +68,6 @@ class SmileReviews extends HTMLElement {
     this._root.innerHTML = \`
       <div data-el=\\"div-smile-reviews-1\\">
         <button data-el=\\"button-smile-reviews-1\\">Write a review</button>
-      
         <template data-el=\\"show-smile-reviews\\">
           <input
             placeholder=\\"Email\\"
@@ -86,7 +85,6 @@ class SmileReviews extends HTMLElement {
             class=\\"textarea-smile-reviews\\"
             data-dom-state=\\"SmileReviews-textarea-smile-reviews-1\\"
           ></textarea>
-      
           <button class=\\"button-smile-reviews\\" data-el=\\"button-smile-reviews-2\\">
             Submit
           </button>
@@ -95,19 +93,16 @@ class SmileReviews extends HTMLElement {
         <template data-el=\\"for-smile-reviews\\">
           <div class=\\"review-smile-reviews\\" data-el=\\"div-smile-reviews-2\\">
             <img class=\\"img-smile-reviews\\" data-el=\\"img-smile-reviews-1\\" />
-      
             <div data-el=\\"div-smile-reviews-3\\">
               <div>
                 N:
                 <template data-el=\\"div-smile-reviews-4\\"><!-- index --></template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-5\\">
                   <!-- review.author -->
                 </template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-6\\">
                   <!-- review.reviewMessage -->
@@ -502,13 +497,10 @@ class MyBasicRefComponent extends HTMLElement {
             data-dom-state=\\"MyBasicRefComponent-select-my-basic-ref-component-1\\"
           >
             <option value=\\"supra\\">GR Supra</option>
-      
             <option value=\\"86\\">GR 86</option>
           </select>
         </template>
-      
         Hello
-      
         <template data-el=\\"div-my-basic-ref-component-1\\">
           <!-- state.lowerCaseName() -->
         </template>
@@ -721,7 +713,6 @@ class MyBasicComponent extends HTMLElement {
           data-el=\\"input-my-basic-component-1\\"
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
         />
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>
       <style>
@@ -876,7 +867,6 @@ class MyBasicForShowComponent extends HTMLElement {
               data-el=\\"input-my-basic-for-show-component-1\\"
               data-dom-state=\\"MyBasicForShowComponent-input-my-basic-for-show-component-1\\"
             />
-      
             Hello
             <template data-el=\\"div-my-basic-for-show-component-1\\">
               <!-- person -->
@@ -1140,9 +1130,7 @@ class MyBasicComponent extends HTMLElement {
         <template data-el=\\"div-my-basic-component-1\\">
           <!-- myService.method('hello') + state.name -->
         </template>
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
-      
         <input
           data-el=\\"input-my-basic-component-1\\"
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
@@ -1815,17 +1803,13 @@ class MyBooleanAttribute extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot></slot>
-      
         <template data-el=\\"div-my-boolean-attribute-2\\"><!-- props.type --></template>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute\\"
         ></my-boolean-attribute-component>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute-2\\"
         ></my-boolean-attribute-component>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute-3\\"
         ></my-boolean-attribute-component>
@@ -1990,7 +1974,6 @@ class MyBasicChildComponent extends HTMLElement {
         <my-basic-component
           data-el=\\"my-basic-component-my-basic-child-component\\"
         ></my-basic-component>
-      
         <div>
           <my-basic-on-mount-update-component
             data-el=\\"my-basic-on-mount-update-component-my-basic-child-component\\"
@@ -2140,7 +2123,6 @@ class MyBasicForComponent extends HTMLElement {
             data-el=\\"input-my-basic-for-component-1\\"
             data-dom-state=\\"MyBasicForComponent-input-my-basic-for-component-1\\"
           />
-      
           Hello
           <template data-el=\\"div-my-basic-for-component-1\\"><!-- person --></template>
           ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -2418,13 +2400,10 @@ class MyBasicRefComponent extends HTMLElement {
             data-dom-state=\\"MyBasicRefComponent-select-my-basic-ref-component-1\\"
           >
             <option value=\\"supra\\">GR Supra</option>
-      
             <option value=\\"86\\">GR 86</option>
           </select>
         </template>
-      
         Hello
-      
         <template data-el=\\"div-my-basic-ref-component-1\\">
           <!-- state.lowerCaseName() -->
         </template>
@@ -2760,7 +2739,6 @@ class MyPreviousComponent extends HTMLElement {
             <!-- self._prevCount -->
           </template>
         </h1>
-      
         <button data-el=\\"button-my-previous-component-1\\">Increment</button>
       </div>\`;
     this.pendingUpdate = true;
@@ -2900,7 +2878,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -3085,7 +3062,6 @@ class Column extends HTMLElement {
         <template data-el=\\"for-column\\">
           <div class=\\"builder-column div-column-2\\">
             <template data-el=\\"div-column-1\\"><!-- column.content --></template>
-      
             <template data-el=\\"div-column-2\\"><!-- index --></template>
           </div>
         </template>
@@ -3283,11 +3259,9 @@ class ContentSlotCode extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot data-el=\\"slot-content-slot-code\\"></slot>
-      
         <div>
           <hr />
         </div>
-      
         <div>
           <slot></slot>
         </div>
@@ -3431,11 +3405,9 @@ class ContentSlotJsxCode extends HTMLElement {
               </template>
             </slot>
           </template>
-      
           <div>
             <hr />
           </div>
-      
           <div><slot></slot></div>
         </div>
       </template>\`;
@@ -3971,10 +3943,8 @@ class Image extends HTMLElement {
           <template data-el=\\"show-image\\">
             <img data-el=\\"img-image-1\\" />
           </template>
-      
           <source data-el=\\"source-image-1\\" />
         </picture>
-      
         <slot></slot>
       </div>
       <style>
@@ -4559,6 +4529,116 @@ class FormInputComponent extends HTMLElement {
 }
 
 customElements.define(\\"form-input-component\\", FormInputComponent);
+"
+`;
+
+exports[`webcomponent > jsx > Javascript Test > Literal Space 1`] = `
+"/**
+ * Usage:
+ *
+ *  <hello></hello>
+ *
+ */
+class Hello extends HTMLElement {
+  get _root() {
+    return this.shadowRoot || this;
+  }
+
+  constructor() {
+    super();
+    const self = this;
+
+    this.state = {};
+    if (!this.props) {
+      this.props = {};
+    }
+
+    this.componentProps = [\\"name\\"];
+
+    // used to keep track of all nodes created by show/for
+    this.nodesToDestroy = [];
+    // batch updates
+    this.pendingUpdate = false;
+
+    if (undefined) {
+      this.attachShadow({ mode: \\"open\\" });
+    }
+  }
+
+  destroyAnyNodes() {
+    // destroy current view template refs before rendering again
+    this.nodesToDestroy.forEach((el) => el.remove());
+    this.nodesToDestroy = [];
+  }
+
+  connectedCallback() {
+    this.getAttributeNames().forEach((attr) => {
+      const jsVar = attr.replace(/-/g, \\"\\");
+      const regexp = new RegExp(jsVar, \\"i\\");
+      this.componentProps.forEach((prop) => {
+        if (regexp.test(prop)) {
+          const attrValue = this.getAttribute(attr);
+          if (this.props[prop] !== attrValue) {
+            this.props[prop] = attrValue;
+          }
+        }
+      });
+    });
+
+    this._root.innerHTML = \`
+      <div>
+        Hello
+        <template data-el=\\"div-hello-1\\"><!-- props.name ?? 'World' --></template>
+      </div>\`;
+    this.pendingUpdate = true;
+
+    this.render();
+    this.onMount();
+    this.pendingUpdate = false;
+    this.update();
+  }
+
+  onMount() {}
+
+  onUpdate() {}
+
+  update() {
+    if (this.pendingUpdate === true) {
+      return;
+    }
+    this.pendingUpdate = true;
+    this.render();
+    this.onUpdate();
+    this.pendingUpdate = false;
+  }
+
+  render() {
+    // re-rendering needs to ensure that all nodes generated by for/show are refreshed
+    this.destroyAnyNodes();
+    this.updateBindings();
+  }
+
+  updateBindings() {
+    this._root.querySelectorAll(\\"[data-el='div-hello-1']\\").forEach((el) => {
+      this.renderTextNode(el, this.props.name ?? \\"World\\");
+    });
+  }
+
+  // Helper to render content
+  renderTextNode(el, text) {
+    const textNode = document.createTextNode(text);
+    if (el?.scope) {
+      textNode.scope = el.scope;
+    }
+    if (el?.context) {
+      textNode.context = el.context;
+    }
+    el.after(textNode);
+    this.nodesToDestroy.push(el.nextSibling);
+  }
+}
+
+customElements.define(\\"hello\\", Hello);
 "
 `;
 
@@ -5585,9 +5665,7 @@ class SlotCode extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot name=\\"top\\"></slot>
-      
         <slot name=\\"left\\">Default left</slot>
-      
         <slot>Default Child</slot>
       </div>\`;
     this.pendingUpdate = true;
@@ -5719,7 +5797,6 @@ class SmileReviews extends HTMLElement {
     this._root.innerHTML = \`
       <div data-el=\\"div-smile-reviews-1\\">
         <button data-el=\\"button-smile-reviews-1\\">Write a review</button>
-      
         <template data-el=\\"show-smile-reviews\\">
           <input
             placeholder=\\"Email\\"
@@ -5737,7 +5814,6 @@ class SmileReviews extends HTMLElement {
             class=\\"textarea-smile-reviews\\"
             data-dom-state=\\"SmileReviews-textarea-smile-reviews-1\\"
           ></textarea>
-      
           <button class=\\"button-smile-reviews\\" data-el=\\"button-smile-reviews-2\\">
             Submit
           </button>
@@ -5746,19 +5822,16 @@ class SmileReviews extends HTMLElement {
         <template data-el=\\"for-smile-reviews\\">
           <div class=\\"review-smile-reviews\\" data-el=\\"div-smile-reviews-2\\">
             <img class=\\"img-smile-reviews\\" data-el=\\"img-smile-reviews-1\\" />
-      
             <div data-el=\\"div-smile-reviews-3\\">
               <div>
                 N:
                 <template data-el=\\"div-smile-reviews-4\\"><!-- index --></template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-5\\">
                   <!-- review.author -->
                 </template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-6\\">
                   <!-- review.reviewMessage -->
@@ -6739,7 +6812,6 @@ class MyBasicForNoTagRefComponent extends HTMLElement {
         <template data-el=\\"for-my-basic-for-no-tag-ref-component\\">
           <state.TagName>
             <action.icon></action.icon>
-      
             <span>
               <template data-el=\\"div-my-basic-for-no-tag-ref-component-2\\">
                 <!-- action.text -->
@@ -7996,7 +8068,6 @@ class ComponentWithContext extends HTMLElement {
 
     this._root.innerHTML = \`
       <template data-el=\\"div-component-with-context-1\\"><!-- foo.value --></template>
-      
       <div>other</div>\`;
     this.pendingUpdate = true;
 
@@ -8244,7 +8315,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.buttonText --></template>
@@ -8427,7 +8497,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -10291,9 +10360,7 @@ class MyBasicComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot></slot>
-      
         <template data-el=\\"div-my-basic-component-2\\"><!-- props.type --></template>
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>\`;
     this.pendingUpdate = true;
@@ -10911,7 +10978,6 @@ class Button extends HTMLElement {
           <template data-el=\\"div-button-1\\"><!-- props.text --></template>
         </a>
       </template>
-      
       <template data-el=\\"show-button-2\\">
         <button type=\\"button\\" data-el=\\"button-button-1\\">
           <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -11208,7 +11274,6 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <template data-el=\\"div-my-component-1\\"><!-- props.name --></template>
-      
         <template data-el=\\"show-my-component\\">
           <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
         </template>
@@ -11353,9 +11418,7 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <template data-el=\\"div-my-component-1\\"><!-- props.name --></template>
-      
         <slot></slot>
-      
         <template data-el=\\"show-my-component\\">
           <MyComponent name=\\"Bruce\\">
             <div>Wayne</div>
@@ -12425,13 +12488,11 @@ class SvgComponent extends HTMLElement {
         <defs>
           <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
             <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-      
             <feBlend
               in=\\"SourceGraphic\\"
               in2=\\"BackgroundImageFix\\"
               result=\\"shape\\"
             ></feBlend>
-      
             <feGaussianBlur
               result=\\"effect1_foregroundBlur\\"
               data-el=\\"fe-gaussian-blur-svg-component\\"
@@ -13217,13 +13278,10 @@ class MyBasicRefComponent extends HTMLElement {
             data-dom-state=\\"MyBasicRefComponent-select-my-basic-ref-component-1\\"
           >
             <option value=\\"supra\\">GR Supra</option>
-      
             <option value=\\"86\\">GR 86</option>
           </select>
         </template>
-      
         Hello
-      
         <template data-el=\\"div-my-basic-ref-component-1\\">
           <!-- state.lowerCaseName() -->
         </template>
@@ -13440,7 +13498,6 @@ class MyBasicComponent extends HTMLElement {
           data-el=\\"input-my-basic-component-1\\"
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
         />
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>
       <style>
@@ -13595,7 +13652,6 @@ class MyBasicForShowComponent extends HTMLElement {
               data-el=\\"input-my-basic-for-show-component-1\\"
               data-dom-state=\\"MyBasicForShowComponent-input-my-basic-for-show-component-1\\"
             />
-      
             Hello
             <template data-el=\\"div-my-basic-for-show-component-1\\">
               <!-- person -->
@@ -13859,9 +13915,7 @@ class MyBasicComponent extends HTMLElement {
         <template data-el=\\"div-my-basic-component-1\\">
           <!-- myService.method('hello') + state.name -->
         </template>
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
-      
         <input
           data-el=\\"input-my-basic-component-1\\"
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
@@ -14544,17 +14598,13 @@ class MyBooleanAttribute extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot></slot>
-      
         <template data-el=\\"div-my-boolean-attribute-2\\"><!-- props.type --></template>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute\\"
         ></my-boolean-attribute-component>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute-2\\"
         ></my-boolean-attribute-component>
-      
         <my-boolean-attribute-component
           data-el=\\"my-boolean-attribute-component-my-boolean-attribute-3\\"
         ></my-boolean-attribute-component>
@@ -14719,7 +14769,6 @@ class MyBasicChildComponent extends HTMLElement {
         <my-basic-component
           data-el=\\"my-basic-component-my-basic-child-component\\"
         ></my-basic-component>
-      
         <div>
           <my-basic-on-mount-update-component
             data-el=\\"my-basic-on-mount-update-component-my-basic-child-component\\"
@@ -14869,7 +14918,6 @@ class MyBasicForComponent extends HTMLElement {
             data-el=\\"input-my-basic-for-component-1\\"
             data-dom-state=\\"MyBasicForComponent-input-my-basic-for-component-1\\"
           />
-      
           Hello
           <template data-el=\\"div-my-basic-for-component-1\\"><!-- person --></template>
           ! I can run in Qwik, Web Component, React, Vue, Solid, or Liquid!
@@ -15151,13 +15199,10 @@ class MyBasicRefComponent extends HTMLElement {
             data-dom-state=\\"MyBasicRefComponent-select-my-basic-ref-component-1\\"
           >
             <option value=\\"supra\\">GR Supra</option>
-      
             <option value=\\"86\\">GR 86</option>
           </select>
         </template>
-      
         Hello
-      
         <template data-el=\\"div-my-basic-ref-component-1\\">
           <!-- state.lowerCaseName() -->
         </template>
@@ -15501,7 +15546,6 @@ class MyPreviousComponent extends HTMLElement {
             <!-- self._prevCount -->
           </template>
         </h1>
-      
         <button data-el=\\"button-my-previous-component-1\\">Increment</button>
       </div>\`;
     this.pendingUpdate = true;
@@ -15648,7 +15692,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -15848,7 +15891,6 @@ class Column extends HTMLElement {
         <template data-el=\\"for-column\\">
           <div class=\\"builder-column div-column-2\\">
             <template data-el=\\"div-column-1\\"><!-- column.content --></template>
-      
             <template data-el=\\"div-column-2\\"><!-- index --></template>
           </div>
         </template>
@@ -16053,11 +16095,9 @@ class ContentSlotCode extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot data-el=\\"slot-content-slot-code\\"></slot>
-      
         <div>
           <hr />
         </div>
-      
         <div>
           <slot></slot>
         </div>
@@ -16207,11 +16247,9 @@ class ContentSlotJsxCode extends HTMLElement {
               </template>
             </slot>
           </template>
-      
           <div>
             <hr />
           </div>
-      
           <div><slot></slot></div>
         </div>
       </template>\`;
@@ -16776,10 +16814,8 @@ class Image extends HTMLElement {
           <template data-el=\\"show-image\\">
             <img data-el=\\"img-image-1\\" />
           </template>
-      
           <source data-el=\\"source-image-1\\" />
         </picture>
-      
         <slot></slot>
       </div>
       <style>
@@ -17391,6 +17427,116 @@ class FormInputComponent extends HTMLElement {
 }
 
 customElements.define(\\"form-input-component\\", FormInputComponent);
+"
+`;
+
+exports[`webcomponent > jsx > Typescript Test > Literal Space 1`] = `
+"/**
+ * Usage:
+ *
+ *  <hello></hello>
+ *
+ */
+class Hello extends HTMLElement {
+  get _root() {
+    return this.shadowRoot || this;
+  }
+
+  constructor() {
+    super();
+    const self = this;
+
+    this.state = {};
+    if (!this.props) {
+      this.props = {};
+    }
+
+    this.componentProps = [\\"name\\"];
+
+    // used to keep track of all nodes created by show/for
+    this.nodesToDestroy = [];
+    // batch updates
+    this.pendingUpdate = false;
+
+    if (undefined) {
+      this.attachShadow({ mode: \\"open\\" });
+    }
+  }
+
+  destroyAnyNodes() {
+    // destroy current view template refs before rendering again
+    this.nodesToDestroy.forEach((el) => el.remove());
+    this.nodesToDestroy = [];
+  }
+
+  connectedCallback() {
+    this.getAttributeNames().forEach((attr) => {
+      const jsVar = attr.replace(/-/g, \\"\\");
+      const regexp = new RegExp(jsVar, \\"i\\");
+      this.componentProps.forEach((prop) => {
+        if (regexp.test(prop)) {
+          const attrValue = this.getAttribute(attr);
+          if (this.props[prop] !== attrValue) {
+            this.props[prop] = attrValue;
+          }
+        }
+      });
+    });
+
+    this._root.innerHTML = \`
+      <div>
+        Hello
+        <template data-el=\\"div-hello-1\\"><!-- props.name ?? 'World' --></template>
+      </div>\`;
+    this.pendingUpdate = true;
+
+    this.render();
+    this.onMount();
+    this.pendingUpdate = false;
+    this.update();
+  }
+
+  onMount() {}
+
+  onUpdate() {}
+
+  update() {
+    if (this.pendingUpdate === true) {
+      return;
+    }
+    this.pendingUpdate = true;
+    this.render();
+    this.onUpdate();
+    this.pendingUpdate = false;
+  }
+
+  render() {
+    // re-rendering needs to ensure that all nodes generated by for/show are refreshed
+    this.destroyAnyNodes();
+    this.updateBindings();
+  }
+
+  updateBindings() {
+    this._root.querySelectorAll(\\"[data-el='div-hello-1']\\").forEach((el) => {
+      this.renderTextNode(el, this.props.name ?? \\"World\\");
+    });
+  }
+
+  // Helper to render content
+  renderTextNode(el, text) {
+    const textNode = document.createTextNode(text);
+    if (el?.scope) {
+      textNode.scope = el.scope;
+    }
+    if (el?.context) {
+      textNode.context = el.context;
+    }
+    el.after(textNode);
+    this.nodesToDestroy.push(el.nextSibling);
+  }
+}
+
+customElements.define(\\"hello\\", Hello);
 "
 `;
 
@@ -18461,9 +18607,7 @@ class SlotCode extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot name=\\"top\\"></slot>
-      
         <slot name=\\"left\\">Default left</slot>
-      
         <slot>Default Child</slot>
       </div>\`;
     this.pendingUpdate = true;
@@ -18600,7 +18744,6 @@ class SmileReviews extends HTMLElement {
     this._root.innerHTML = \`
       <div data-el=\\"div-smile-reviews-1\\">
         <button data-el=\\"button-smile-reviews-1\\">Write a review</button>
-      
         <template data-el=\\"show-smile-reviews\\">
           <input
             placeholder=\\"Email\\"
@@ -18618,7 +18761,6 @@ class SmileReviews extends HTMLElement {
             class=\\"textarea-smile-reviews\\"
             data-dom-state=\\"SmileReviews-textarea-smile-reviews-1\\"
           ></textarea>
-      
           <button class=\\"button-smile-reviews\\" data-el=\\"button-smile-reviews-2\\">
             Submit
           </button>
@@ -18627,19 +18769,16 @@ class SmileReviews extends HTMLElement {
         <template data-el=\\"for-smile-reviews\\">
           <div class=\\"review-smile-reviews\\" data-el=\\"div-smile-reviews-2\\">
             <img class=\\"img-smile-reviews\\" data-el=\\"img-smile-reviews-1\\" />
-      
             <div data-el=\\"div-smile-reviews-3\\">
               <div>
                 N:
                 <template data-el=\\"div-smile-reviews-4\\"><!-- index --></template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-5\\">
                   <!-- review.author -->
                 </template>
               </div>
-      
               <div>
                 <template data-el=\\"div-smile-reviews-6\\">
                   <!-- review.reviewMessage -->
@@ -19667,7 +19806,6 @@ class MyBasicForNoTagRefComponent extends HTMLElement {
         <template data-el=\\"for-my-basic-for-no-tag-ref-component\\">
           <state.TagName>
             <action.icon></action.icon>
-      
             <span>
               <template data-el=\\"div-my-basic-for-no-tag-ref-component-2\\">
                 <!-- action.text -->
@@ -20949,7 +21087,6 @@ class ComponentWithContext extends HTMLElement {
 
     this._root.innerHTML = \`
       <template data-el=\\"div-component-with-context-1\\"><!-- foo.value --></template>
-      
       <div>other</div>\`;
     this.pendingUpdate = true;
 
@@ -21207,7 +21344,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.buttonText --></template>
@@ -21398,7 +21534,6 @@ class Button extends HTMLElement {
             <template data-el=\\"div-button-1\\"><!-- props.text --></template>
           </a>
         </template>
-      
         <template data-el=\\"show-button-2\\">
           <button type=\\"button\\" data-el=\\"button-button-1\\">
             <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -23314,9 +23449,7 @@ class MyBasicComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <slot></slot>
-      
         <template data-el=\\"div-my-basic-component-2\\"><!-- props.type --></template>
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>\`;
     this.pendingUpdate = true;
@@ -23959,7 +24092,6 @@ class Button extends HTMLElement {
           <template data-el=\\"div-button-1\\"><!-- props.text --></template>
         </a>
       </template>
-      
       <template data-el=\\"show-button-2\\">
         <button type=\\"button\\" data-el=\\"button-button-1\\">
           <template data-el=\\"div-button-2\\"><!-- props.text --></template>
@@ -24260,7 +24392,6 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <template data-el=\\"div-my-component-1\\"><!-- props.name --></template>
-      
         <template data-el=\\"show-my-component\\">
           <MyComponent name=\\"Bruce Wayne\\"></MyComponent>
         </template>
@@ -24405,9 +24536,7 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         <template data-el=\\"div-my-component-1\\"><!-- props.name --></template>
-      
         <slot></slot>
-      
         <template data-el=\\"show-my-component\\">
           <MyComponent name=\\"Bruce\\">
             <div>Wayne</div>
@@ -25486,13 +25615,11 @@ class SvgComponent extends HTMLElement {
         <defs>
           <filter id=\\"prefix__filter0_f\\" filterUnits=\\"userSpaceOnUse\\">
             <feFlood result=\\"BackgroundImageFix\\"></feFlood>
-      
             <feBlend
               in=\\"SourceGraphic\\"
               in2=\\"BackgroundImageFix\\"
               result=\\"shape\\"
             ></feBlend>
-      
             <feGaussianBlur
               result=\\"effect1_foregroundBlur\\"
               data-el=\\"fe-gaussian-blur-svg-component\\"
@@ -26123,7 +26250,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-1\\"
           data-dom-state=\\"MyComponent-input-my-component-1\\"
         />
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>\`;
     this.pendingUpdate = true;
@@ -27681,7 +27807,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-1\\"
           data-dom-state=\\"MyComponent-input-my-component-1\\"
         />
-      
         Lowercase:
         <template data-el=\\"div-my-component-1\\"><!-- state.lowercaseName --></template>
       </div>\`;
@@ -27854,7 +27979,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-2\\"
           data-dom-state=\\"MyComponent-input-my-component-2\\"
         />
-      
         Result:
         <template data-el=\\"div-my-component-1\\"><!-- state.result --></template>
       </div>\`;
@@ -28242,12 +28366,9 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         normal:
-      
         <template data-el=\\"div-my-component-1\\"><!-- state.a + state.b --></template>
         <br />
-      
         conditional
-      
         <template data-el=\\"div-my-component-2\\">
           <!-- state.a > 2 ? 'hello' : 'bye' -->
         </template>
@@ -28362,7 +28483,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-1\\"
           data-dom-state=\\"MyComponent-input-my-component-1\\"
         />
-      
         Hello! I can run in React, Vue, Solid, or Liquid!
       </div>\`;
     this.pendingUpdate = true;
@@ -29920,7 +30040,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-1\\"
           data-dom-state=\\"MyComponent-input-my-component-1\\"
         />
-      
         Lowercase:
         <template data-el=\\"div-my-component-1\\"><!-- state.lowercaseName --></template>
       </div>\`;
@@ -30093,7 +30212,6 @@ class MyComponent extends HTMLElement {
           data-el=\\"input-my-component-2\\"
           data-dom-state=\\"MyComponent-input-my-component-2\\"
         />
-      
         Result:
         <template data-el=\\"div-my-component-1\\"><!-- state.result --></template>
       </div>\`;
@@ -30481,12 +30599,9 @@ class MyComponent extends HTMLElement {
     this._root.innerHTML = \`
       <div>
         normal:
-      
         <template data-el=\\"div-my-component-1\\"><!-- state.a + state.b --></template>
         <br />
-      
         conditional
-      
         <template data-el=\\"div-my-component-2\\">
           <!-- state.a > 2 ? 'hello' : 'bye' -->
         </template>

--- a/packages/core/src/__tests__/data/literal-space.raw.tsx
+++ b/packages/core/src/__tests__/data/literal-space.raw.tsx
@@ -1,0 +1,3 @@
+export default function Hello(props) {
+  return <div>Hello {props.name ?? 'World'}</div>;
+}

--- a/packages/core/src/__tests__/test-generator.ts
+++ b/packages/core/src/__tests__/test-generator.ts
@@ -40,6 +40,7 @@ const preserveExportOrLocalStatement = getRawFile(
 );
 const arrowFunctionInUseStore = getRawFile('./data/arrow-function-in-use-store.raw.tsx');
 const svgComponent = getRawFile('./data/svg.raw.tsx');
+const literalSpace = getRawFile('./data/literal-space.raw.tsx');
 
 const propsType = getRawFile('./data/types/component-props-type.raw.tsx');
 const propsInterface = getRawFile('./data/types/component-props-interface.raw.tsx');
@@ -177,6 +178,7 @@ const BASIC_TESTS: Tests = {
   'Basic Context': basicContext,
   'Basic Outputs Meta': basicOutputsMeta,
   'Basic Outputs': basicOutputs,
+  'Literal Space': literalSpace,
   className: classNameJsx,
   'Image State': imageState,
   'Basic OnMount Update': basicOnMountUpdate,

--- a/packages/core/src/generators/alpine/generate.ts
+++ b/packages/core/src/generators/alpine/generate.ts
@@ -1,4 +1,4 @@
-import { camelCase, curry, flow, flowRight as compose } from 'lodash';
+import { camelCase, flowRight as compose, curry, flow } from 'lodash';
 import { format } from 'prettier/standalone';
 import { SELF_CLOSING_HTML_TAGS } from '../../constants/html_tags';
 import { babelTransformCode } from '../../helpers/babel-transform';
@@ -19,7 +19,7 @@ import {
   runPreJsonPlugins,
 } from '../../modules/plugins';
 import { MitosisComponent } from '../../types/mitosis-component';
-import { checkIsForNode, ForNode, MitosisNode } from '../../types/mitosis-node';
+import { ForNode, MitosisNode, checkIsForNode } from '../../types/mitosis-node';
 import { BaseTranspilerOptions, TranspilerGenerator } from '../../types/transpiler';
 import { renderMountHook } from './render-mount-hook';
 import { hasRootUpdateHook, renderUpdateHooks } from './render-update-hooks';
@@ -117,14 +117,14 @@ const mappers: {
       : `<template x-for="${json.scope.forName} in ${stripStateAndPropsRefs(
           json.bindings.each?.code,
         )}">
-    ${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('\n')}
+    ${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('')}
     </template>`,
   Fragment: (json, options) => blockToAlpine({ ...json, name: 'div' }, options),
   Show: (json, options) =>
     !isValidAlpineBinding(json.bindings.when?.code)
       ? ''
       : `<template x-if="${stripStateAndPropsRefs(json.bindings.when?.code)}">
-    ${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('\n')}
+    ${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('')}
     </template>`,
 };
 
@@ -186,7 +186,7 @@ const blockToAlpine = (json: MitosisNode | ForNode, options: ToAlpineOptions = {
   }
   return SELF_CLOSING_HTML_TAGS.has(json.name)
     ? `${str} />`
-    : `${str}>${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('\n')}</${
+    : `${str}>${(json.children ?? []).map((item) => blockToAlpine(item, options)).join('')}</${
         json.name
       }>`;
 };
@@ -219,7 +219,7 @@ export const componentToAlpine: TranspilerGenerator<ToAlpineOptions> =
     }
 
     let str = css.trim().length ? `<style>${css}</style>` : '';
-    str += json.children.map((item) => blockToAlpine(item, options)).join('\n');
+    str += json.children.map((item) => blockToAlpine(item, options)).join('');
 
     if (!options.inlineState) {
       str += `<script>

--- a/packages/core/src/generators/html.ts
+++ b/packages/core/src/generators/html.ts
@@ -30,8 +30,8 @@ import {
   DO_NOT_USE_ARGS,
   DO_NOT_USE_CONTEXT_VARS_TRANSFORMS,
   DO_NOT_USE_VARS_TRANSFORMS,
-  stripStateAndPropsRefs,
   StripStateAndPropsRefsOptions,
+  stripStateAndPropsRefs,
 } from '../helpers/strip-state-and-props-refs';
 import { collectCss } from '../helpers/styles/collect-css';
 import {
@@ -41,7 +41,7 @@ import {
   runPreJsonPlugins,
 } from '../modules/plugins';
 import { MitosisComponent } from '../types/mitosis-component';
-import { checkIsForNode, MitosisNode } from '../types/mitosis-node';
+import { MitosisNode, checkIsForNode } from '../types/mitosis-node';
 import { BaseTranspilerOptions, TranspilerGenerator } from '../types/transpiler';
 
 export interface ToHtmlOptions extends BaseTranspilerOptions {
@@ -183,7 +183,7 @@ const mappers: {
   ) => string;
 } = {
   Fragment: (json, options, blockOptions) => {
-    return json.children.map((item) => blockToHtml(item, options, blockOptions)).join('\n');
+    return json.children.map((item) => blockToHtml(item, options, blockOptions)).join('');
   },
 };
 
@@ -359,7 +359,7 @@ const blockToHtml = (
             scopeVars: localScopeVars,
           }),
         )
-        .join('\n');
+        .join('');
     }
     str += '</template>';
   } else if (json.name === 'Show') {
@@ -385,7 +385,7 @@ const blockToHtml = (
 
     str += `<template data-el="${elId}">`;
     if (json.children) {
-      str += json.children.map((item) => blockToHtml(item, options, blockOptions)).join('\n');
+      str += json.children.map((item) => blockToHtml(item, options, blockOptions)).join('');
     }
 
     str += '</template>';
@@ -531,7 +531,7 @@ const blockToHtml = (
     }
     str += '>';
     if (json.children) {
-      str += json.children.map((item) => blockToHtml(item, options, blockOptions)).join('\n');
+      str += json.children.map((item) => blockToHtml(item, options, blockOptions)).join('');
     }
     if (json.properties.innerHTML) {
       // Maybe put some kind of safety here for broken HTML such as no close tag
@@ -628,7 +628,7 @@ export const componentToHtml: TranspilerGenerator<ToHtmlOptions> =
       prefix: options.prefix,
     });
 
-    let str = json.children.map((item) => blockToHtml(item, options)).join('\n');
+    let str = json.children.map((item) => blockToHtml(item, options)).join('');
 
     if (css.trim().length) {
       str += `<style>${css}</style>`;
@@ -956,7 +956,7 @@ export const componentToCustomElement: TranspilerGenerator<ToHtmlOptions> =
           contextVars,
         }),
       )
-      .join('\n');
+      .join('');
     if (options?.experimental?.childrenHtml) {
       html = options?.experimental?.childrenHtml(html, kebabName, json, options);
     }

--- a/packages/core/src/generators/mitosis.ts
+++ b/packages/core/src/generators/mitosis.ts
@@ -107,7 +107,7 @@ export const blockToMitosis = (
   }
   str += '>';
   if (json.children) {
-    str += json.children.map((item) => blockToMitosis(item, options, component)).join('\n');
+    str += json.children.map((item) => blockToMitosis(item, options, component)).join('');
   }
 
   str += `</${json.name}>`;
@@ -200,7 +200,7 @@ export const componentToMitosis: TranspilerGenerator<Partial<ToMitosisOptions>> 
       ${!json.hooks.onUnMount?.code ? '' : `onUnMount(() => { ${json.hooks.onUnMount.code} })`}
 
       return (${addWrapper ? '<>' : ''}
-        ${json.children.map((item) => blockToMitosis(item, options, component)).join('\n')}
+        ${json.children.map((item) => blockToMitosis(item, options, component)).join('')}
         ${addWrapper ? '</>' : ''})
     }
 

--- a/packages/core/src/generators/react/blocks.ts
+++ b/packages/core/src/generators/react/blocks.ts
@@ -7,7 +7,7 @@ import { isValidAttributeName } from '../../helpers/is-valid-attribute-name';
 import { getForArguments } from '../../helpers/nodes/for';
 import { isSlotProperty } from '../../helpers/slots';
 import { MitosisComponent } from '../../types/mitosis-component';
-import { checkIsForNode, ForNode, MitosisNode } from '../../types/mitosis-node';
+import { ForNode, MitosisNode, checkIsForNode } from '../../types/mitosis-node';
 import { closeFrag, getFragment, openFrag, processBinding, wrapInFragment } from './helpers';
 import { updateStateSettersInCode } from './state';
 import { ToReactOptions } from './types';
@@ -250,7 +250,7 @@ export const blockToReact = (
   if (json.children) {
     childrenNodes = json.children
       .map((item) => blockToReact(item, options, component, needsToRenderSlots))
-      .join('\n');
+      .join('');
   }
   if (needsToRenderSlots.length) {
     needsToRenderSlots.forEach(({ key, value }) => {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -439,7 +439,7 @@ const _componentToReact = (
 
     return (
       ${wrap ? openFrag(options) : ''}
-      ${json.children.map((item) => blockToReact(item, options, json, [])).join('\n')}
+      ${json.children.map((item) => blockToReact(item, options, json, [])).join('')}
       ${
         componentHasStyles && options.stylesType === 'styled-jsx'
           ? `<style jsx>{\`${css}\`}</style>`

--- a/packages/core/src/generators/solid/blocks.ts
+++ b/packages/core/src/generators/solid/blocks.ts
@@ -117,7 +117,7 @@ export const blockToSolid = ({
     str += json.children
       .filter(filterEmptyTextNodes)
       .map((item) => blockToSolid({ component, json: item, options }))
-      .join('\n');
+      .join('');
   }
 
   if (json.name === 'Fragment') {

--- a/packages/core/src/generators/solid/index.ts
+++ b/packages/core/src/generators/solid/index.ts
@@ -213,7 +213,7 @@ export const componentToSolid: TranspilerGenerator<Partial<ToSolidOptions>> =
         ${json.children
           .filter(filterEmptyTextNodes)
           .map((item) => blockToSolid({ component, json: item, options }))
-          .join('\n')}
+          .join('')}
         ${
           options.stylesType === 'style-tag' && css && css.trim().length > 4
             ? // We add the jsx attribute so prettier formats this nicely

--- a/packages/core/src/generators/stencil/generate.ts
+++ b/packages/core/src/generators/stencil/generate.ts
@@ -20,7 +20,7 @@ import {
   runPreCodePlugins,
   runPreJsonPlugins,
 } from '../../modules/plugins';
-import { checkIsForNode, MitosisNode } from '../../types/mitosis-node';
+import { MitosisNode, checkIsForNode } from '../../types/mitosis-node';
 import { BaseTranspilerOptions, TranspilerGenerator } from '../../types/transpiler';
 import { collectClassString } from './collect-class-string';
 
@@ -41,7 +41,7 @@ const blockToStencil = (json: MitosisNode, options: ToStencilOptions = {}): stri
       ${wrap ? '<>' : ''}${json.children
       .filter(filterEmptyTextNodes)
       .map((item) => blockToStencil(item, options))
-      .join('\n')}${wrap ? '</>' : ''}
+      .join('')}${wrap ? '</>' : ''}
     ))}`;
   } else if (json.name === 'Show') {
     const wrap = json.children.length !== 1;
@@ -49,7 +49,7 @@ const blockToStencil = (json: MitosisNode, options: ToStencilOptions = {}): stri
       ${wrap ? '<>' : ''}${json.children
       .filter(filterEmptyTextNodes)
       .map((item) => blockToStencil(item, options))
-      .join('\n')}${wrap ? '</>' : ''}
+      .join('')}${wrap ? '</>' : ''}
     ) : ${!json.meta.else ? 'null' : blockToStencil(json.meta.else as any, options)}}`;
   }
 
@@ -85,7 +85,7 @@ const blockToStencil = (json: MitosisNode, options: ToStencilOptions = {}): stri
   }
   str += '>';
   if (json.children) {
-    str += json.children.map((item) => blockToStencil(item, options)).join('\n');
+    str += json.children.map((item) => blockToStencil(item, options)).join('');
   }
 
   str += `</${json.name}>`;
@@ -200,7 +200,7 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
       render() {
         return (${wrap ? '<>' : ''}
         
-          ${json.children.map((item) => blockToStencil(item, options)).join('\n')}
+          ${json.children.map((item) => blockToStencil(item, options)).join('')}
 
         ${wrap ? '</>' : ''})
       }

--- a/packages/core/src/parsers/jsx/__snapshots__/types-identification.test.ts.snap
+++ b/packages/core/src/parsers/jsx/__snapshots__/types-identification.test.ts.snap
@@ -2,15 +2,9 @@
 
 exports[`Signals type parsing > findSignals 1`] = `
 {
-  "context": Set {
-    "context",
-  },
-  "props": Set {
-    "k",
-  },
-  "state": Set {
-    "n",
-  },
+  "context": Set {},
+  "props": Set {},
+  "state": Set {},
 }
 `;
 


### PR DESCRIPTION
Fixes #1218

## Description

Some code generators were joining blocks with newlines (`\n`), which, when run through the `dedent` helper, would then trim any trailing whitespace. This ended up causing problems with significant whitespace in some scenarios.

This PR simply changes the join operation to use the empty string. The parser for mitosis already preserves the significant whitespace, so this makes the output components more closely resemble their mitosis source code. Prettier can still be used to format the output code, which will use a syntax tree that preserves meaningful whitespace while avoiding excessively long line lengths and adding stylistic line breaks.

The main focus for review should be:

1. Ensure that the large changes to snapshots are correct.
2. Considering that many generators have the same structure in terms of a `componentToX` function that calls a `blockToX` function recursively and joins children together, would it make sense to have a helper method for the join operation so that this type of change can be made more accurately across generators?