### PR TITLE
only add "use client" when needed

### DIFF
--- a/packages/cli/src/__tests__/__snapshots__/cli-integration.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/cli-integration.test.ts.snap
@@ -343,73 +343,46 @@ function MyComponent(props) {
       }}
     >
       <div
-        className=\\"builder-columns\\"
         css={{
+          gap: \\"20px\\",
           display: \\"flex\\",
-          \\"@media (max-width: 999px)\\": {
+          \\"@media (max-width: 991px)\\": {
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
+            gap: \\"0px\\",
           },
         }}
       >
         <div
-          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
+            width: \\"33%\\",
             marginLeft: \\"0px\\",
-            \\"@media (max-width: 999px)\\": {
+            \\"@media (max-width: 991px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <div
+          <img
+            loading=\\"lazy\\"
+            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=376&height=1000 376w\\"
             css={{
-              display: \\"flex\\",
-              flexDirection: \\"column\\",
+              aspectRatio: \\"1.43\\",
+              objectFit: \\"cover\\",
+              objectPosition: \\"center\\",
+              width: \\"100%\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
-              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
             }}
-          >
-            <picture>
-              <source
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=376&height=1000 376w\\"
-                type=\\"image/webp\\"
-              />
-              <img
-                loading=\\"lazy\\"
-                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000\\"
-                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=376&height=1000 376w\\"
-                css={{
-                  objectFit: \\"cover\\",
-                  objectPosition: \\"center\\",
-                  position: \\"absolute\\",
-                  height: \\"100%\\",
-                  width: \\"100%\\",
-                  top: \\"0\\",
-                  left: \\"0\\",
-                }}
-              />
-            </picture>
-            <div
-              className=\\"builder-image-sizer\\"
-              css={{
-                width: \\"100%\\",
-                paddingTop: \\"70.04048582995948%\\",
-                pointerEvents: \\"none\\",
-                fontSize: \\"0\\",
-              }}
-            />
-          </div>
+          />
           <div
             css={{
               display: \\"flex\\",
@@ -479,27 +452,30 @@ function MyComponent(props) {
           </div>
         </div>
         <div
-          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
+            width: \\"33%\\",
             marginLeft: \\"20px\\",
-            \\"@media (max-width: 999px)\\": {
+            \\"@media (max-width: 991px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <div
+          <img
+            loading=\\"lazy\\"
+            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=376&height=1000 376w\\"
             css={{
-              display: \\"flex\\",
-              flexDirection: \\"column\\",
+              aspectRatio: \\"1.43\\",
+              objectFit: \\"cover\\",
+              objectPosition: \\"center\\",
+              width: \\"100%\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
-              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
@@ -508,38 +484,7 @@ function MyComponent(props) {
                 containIntrinsicSize: \\"699px\\",
               },
             }}
-          >
-            <picture>
-              <source
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=376&height=1000 376w\\"
-                type=\\"image/webp\\"
-              />
-              <img
-                loading=\\"lazy\\"
-                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000\\"
-                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=376&height=1000 376w\\"
-                css={{
-                  objectFit: \\"cover\\",
-                  objectPosition: \\"center\\",
-                  position: \\"absolute\\",
-                  height: \\"100%\\",
-                  width: \\"100%\\",
-                  top: \\"0\\",
-                  left: \\"0\\",
-                }}
-              />
-            </picture>
-            <div
-              className=\\"builder-image-sizer\\"
-              css={{
-                width: \\"100%\\",
-                paddingTop: \\"70.04048582995948%\\",
-                pointerEvents: \\"none\\",
-                fontSize: \\"0\\",
-              }}
-            />
-          </div>
+          />
           <div
             css={{
               display: \\"flex\\",
@@ -615,27 +560,30 @@ function MyComponent(props) {
           </div>
         </div>
         <div
-          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
+            width: \\"33%\\",
             marginLeft: \\"20px\\",
-            \\"@media (max-width: 999px)\\": {
+            \\"@media (max-width: 991px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <div
+          <img
+            loading=\\"lazy\\"
+            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=376&height=1000 376w\\"
             css={{
-              display: \\"flex\\",
-              flexDirection: \\"column\\",
+              aspectRatio: \\"1.43\\",
+              objectFit: \\"cover\\",
+              objectPosition: \\"center\\",
+              width: \\"100%\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
-              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
@@ -648,38 +596,7 @@ function MyComponent(props) {
                 containIntrinsicSize: \\"447px\\",
               },
             }}
-          >
-            <picture>
-              <source
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=376&height=1000 376w\\"
-                type=\\"image/webp\\"
-              />
-              <img
-                loading=\\"lazy\\"
-                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000\\"
-                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=376&height=1000 376w\\"
-                css={{
-                  objectFit: \\"cover\\",
-                  objectPosition: \\"center\\",
-                  position: \\"absolute\\",
-                  height: \\"100%\\",
-                  width: \\"100%\\",
-                  top: \\"0\\",
-                  left: \\"0\\",
-                }}
-              />
-            </picture>
-            <div
-              className=\\"builder-image-sizer\\"
-              css={{
-                width: \\"100%\\",
-                paddingTop: \\"70.04048582995948%\\",
-                pointerEvents: \\"none\\",
-                fontSize: \\"0\\",
-              }}
-            />
-          </div>
+          />
           <div
             css={{
               display: \\"flex\\",

--- a/packages/cli/src/__tests__/__snapshots__/cli-integration.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/cli-integration.test.ts.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`--builder-components keeps builder components 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -326,15 +325,11 @@ export default MyComponent;
 `;
 
 exports[`strips out builder components by default 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
     <div
-      stackColumnsAt=\\"tablet\\"
-      space={36}
-      reverseColumnsWhenStacked={false}
       css={{
         display: \\"flex\\",
         flexDirection: \\"column\\",
@@ -348,46 +343,73 @@ function MyComponent(props) {
       }}
     >
       <div
+        className=\\"builder-columns\\"
         css={{
-          gap: \\"20px\\",
           display: \\"flex\\",
-          \\"@media (max-width: 991px)\\": {
+          \\"@media (max-width: 999px)\\": {
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
-            gap: \\"0px\\",
           },
         }}
       >
         <div
+          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"33%\\",
+            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
             marginLeft: \\"0px\\",
-            \\"@media (max-width: 991px)\\": {
+            \\"@media (max-width: 999px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <img
-            loading=\\"lazy\\"
-            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=376&height=1000 376w\\"
+          <div
             css={{
-              aspectRatio: \\"1.43\\",
-              objectFit: \\"cover\\",
-              objectPosition: \\"center\\",
-              width: \\"100%\\",
+              display: \\"flex\\",
+              flexDirection: \\"column\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
+              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
             }}
-          />
+          >
+            <picture>
+              <source
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?format=webp&width=376&height=1000 376w\\"
+                type=\\"image/webp\\"
+              />
+              <img
+                loading=\\"lazy\\"
+                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000\\"
+                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=376&height=1000 376w\\"
+                css={{
+                  objectFit: \\"cover\\",
+                  objectPosition: \\"center\\",
+                  position: \\"absolute\\",
+                  height: \\"100%\\",
+                  width: \\"100%\\",
+                  top: \\"0\\",
+                  left: \\"0\\",
+                }}
+              />
+            </picture>
+            <div
+              className=\\"builder-image-sizer\\"
+              css={{
+                width: \\"100%\\",
+                paddingTop: \\"70.04048582995948%\\",
+                pointerEvents: \\"none\\",
+                fontSize: \\"0\\",
+              }}
+            />
+          </div>
           <div
             css={{
               display: \\"flex\\",
@@ -457,30 +479,27 @@ function MyComponent(props) {
           </div>
         </div>
         <div
+          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"33%\\",
+            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
             marginLeft: \\"20px\\",
-            \\"@media (max-width: 991px)\\": {
+            \\"@media (max-width: 999px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <img
-            loading=\\"lazy\\"
-            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=376&height=1000 376w\\"
+          <div
             css={{
-              aspectRatio: \\"1.43\\",
-              objectFit: \\"cover\\",
-              objectPosition: \\"center\\",
-              width: \\"100%\\",
+              display: \\"flex\\",
+              flexDirection: \\"column\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
+              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
@@ -489,7 +508,38 @@ function MyComponent(props) {
                 containIntrinsicSize: \\"699px\\",
               },
             }}
-          />
+          >
+            <picture>
+              <source
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?format=webp&width=376&height=1000 376w\\"
+                type=\\"image/webp\\"
+              />
+              <img
+                loading=\\"lazy\\"
+                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000\\"
+                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=376&height=1000 376w\\"
+                css={{
+                  objectFit: \\"cover\\",
+                  objectPosition: \\"center\\",
+                  position: \\"absolute\\",
+                  height: \\"100%\\",
+                  width: \\"100%\\",
+                  top: \\"0\\",
+                  left: \\"0\\",
+                }}
+              />
+            </picture>
+            <div
+              className=\\"builder-image-sizer\\"
+              css={{
+                width: \\"100%\\",
+                paddingTop: \\"70.04048582995948%\\",
+                pointerEvents: \\"none\\",
+                fontSize: \\"0\\",
+              }}
+            />
+          </div>
           <div
             css={{
               display: \\"flex\\",
@@ -565,30 +615,27 @@ function MyComponent(props) {
           </div>
         </div>
         <div
+          className=\\"builder-column\\"
           css={{
             display: \\"flex\\",
             flexDirection: \\"column\\",
             alignItems: \\"stretch\\",
             lineHeight: \\"normal\\",
-            width: \\"33%\\",
+            width: \\"calc(33.333333333333336% - 13.333333333333334px)\\",
             marginLeft: \\"20px\\",
-            \\"@media (max-width: 991px)\\": {
+            \\"@media (max-width: 999px)\\": {
               width: \\"100%\\",
               marginLeft: 0,
             },
           }}
         >
-          <img
-            loading=\\"lazy\\"
-            sizes=\\"(max-width: 638px) 100vw, 27vw\\"
-            srcSet=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=376&height=1000 376w\\"
+          <div
             css={{
-              aspectRatio: \\"1.43\\",
-              objectFit: \\"cover\\",
-              objectPosition: \\"center\\",
-              width: \\"100%\\",
+              display: \\"flex\\",
+              flexDirection: \\"column\\",
               alignItems: \\"stretch\\",
               flexShrink: \\"0\\",
+              position: \\"relative\\",
               textAlign: \\"center\\",
               lineHeight: \\"normal\\",
               height: \\"auto\\",
@@ -601,7 +648,38 @@ function MyComponent(props) {
                 containIntrinsicSize: \\"447px\\",
               },
             }}
-          />
+          >
+            <picture>
+              <source
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?format=webp&width=376&height=1000 376w\\"
+                type=\\"image/webp\\"
+              />
+              <img
+                loading=\\"lazy\\"
+                src=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000\\"
+                sizes=\\"(max-width: 638px) 100vw, 27vw\\"
+                srcset=\\"https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=376&height=1000 376w\\"
+                css={{
+                  objectFit: \\"cover\\",
+                  objectPosition: \\"center\\",
+                  position: \\"absolute\\",
+                  height: \\"100%\\",
+                  width: \\"100%\\",
+                  top: \\"0\\",
+                  left: \\"0\\",
+                }}
+              />
+            </picture>
+            <div
+              className=\\"builder-image-sizer\\"
+              css={{
+                width: \\"100%\\",
+                paddingTop: \\"70.04048582995948%\\",
+                pointerEvents: \\"none\\",
+                fontSize: \\"0\\",
+              }}
+            />
+          </div>
           <div
             css={{
               display: \\"flex\\",

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -759,8 +759,7 @@ export default ComponentWithContext;
 `;
 
 exports[`Context > Use and set context in components 3`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -1,9 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`Preact > jsx > Javascript Test > AdvancedRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -67,9 +65,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Basic 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -111,9 +107,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Basic Context 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useContext, useEffect } from \\"preact/hooks\\";
 import { createInjector, Injector, MyService } from \\"@dummy/injection-js\\";
@@ -154,9 +148,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Basic OnMount Update 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -186,9 +178,7 @@ export default MyBasicOnMountUpdateComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Basic Outputs 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -208,9 +198,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Basic Outputs Meta 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -230,9 +218,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -244,9 +230,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
@@ -274,9 +258,7 @@ export default MyBooleanAttribute;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicChildComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -303,9 +285,7 @@ export default MyBasicChildComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicFor 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -342,9 +322,7 @@ export default MyBasicForComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
 
@@ -404,9 +382,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicRefAssignment 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useRef } from \\"preact/hooks\\";
 
@@ -430,9 +406,7 @@ export default MyBasicRefAssignmentComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > BasicRefPrevious 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -476,9 +450,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Button 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Button(props) {
@@ -512,9 +484,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Javascript Test > Columns 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Column(props) {
@@ -579,9 +549,7 @@ export default Column;
 `;
 
 exports[`Preact > jsx > Javascript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function ContentSlotCode(props) {
@@ -603,9 +571,7 @@ export default ContentSlotCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > ContentSlotJSX 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -660,9 +626,7 @@ export default ContentSlotJsxCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > CustomCode 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -734,9 +698,7 @@ export default CustomCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > Embed 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -808,9 +770,7 @@ export default CustomCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > Form 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
@@ -1088,9 +1048,7 @@ export default FormComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Image 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -1194,9 +1152,7 @@ export default Image;
 `;
 
 exports[`Preact > jsx > Javascript Test > Image State 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1221,9 +1177,7 @@ export default ImgStateComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Img 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1247,9 +1201,7 @@ export default ImgComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Input 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1278,9 +1230,7 @@ export default FormInputComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > InputParent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -1303,9 +1253,7 @@ export default Stepper;
 `;
 
 exports[`Preact > jsx > Javascript Test > RawText 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function RawText(props) {
@@ -1322,9 +1270,7 @@ export default RawText;
 `;
 
 exports[`Preact > jsx > Javascript Test > Section 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SectionComponent(props) {
@@ -1349,9 +1295,7 @@ export default SectionComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > Select 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1382,9 +1326,7 @@ export default SelectComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > SlotDefault 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SlotCode(props) {
@@ -1400,9 +1342,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > SlotHtml 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1419,9 +1359,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > SlotJsx 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1438,9 +1376,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > SlotNamed 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SlotCode(props) {
@@ -1460,9 +1396,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > Stamped.io 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 import { kebabCase, snakeCase } from \\"lodash\\";
@@ -1571,9 +1505,7 @@ export default SmileReviews;
 `;
 
 exports[`Preact > jsx > Javascript Test > Submit 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SubmitButton(props) {
@@ -1589,9 +1521,7 @@ export default SubmitButton;
 `;
 
 exports[`Preact > jsx > Javascript Test > Text 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import { Builder } from \\"@builder.io/sdk\\";
@@ -1621,9 +1551,7 @@ export default Text;
 `;
 
 exports[`Preact > jsx > Javascript Test > Textarea 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Textarea(props) {
@@ -1643,9 +1571,7 @@ export default Textarea;
 `;
 
 exports[`Preact > jsx > Javascript Test > Video 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Video(props) {
@@ -1678,9 +1604,7 @@ export default Video;
 `;
 
 exports[`Preact > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1708,9 +1632,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > basicForNoTagReference 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1747,9 +1669,7 @@ export default MyBasicForNoTagRefComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > basicForwardRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1780,9 +1700,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1813,9 +1731,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -1852,9 +1768,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -1877,9 +1791,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > class + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -1902,9 +1814,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > className + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -1927,9 +1837,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > className 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1950,9 +1858,7 @@ export default ClassNameCode;
 `;
 
 exports[`Preact > jsx > Javascript Test > classState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -1982,9 +1888,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > componentWithContext 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 import Context1 from \\"@dummy/1\\";
@@ -2019,9 +1923,7 @@ export default ComponentWithContext;
 `;
 
 exports[`Preact > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 import Context1 from \\"@dummy/1\\";
@@ -2060,9 +1962,7 @@ export default ComponentWithContext;
 `;
 
 exports[`Preact > jsx > Javascript Test > contentState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -2085,9 +1985,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Javascript Test > defaultProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Button(props) {
@@ -2134,9 +2032,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Button(props) {
@@ -2181,9 +2077,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Javascript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 const DEFAULT_VALUES = {
@@ -2205,9 +2099,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`Preact > jsx > Javascript Test > expressionState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -2224,9 +2116,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > import types 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 
@@ -2250,9 +2140,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Javascript Test > multipleOnUpdate 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -2272,9 +2160,7 @@ export default MultipleOnUpdate;
 `;
 
 exports[`Preact > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -2310,9 +2196,7 @@ export default MultipleOnUpdateWithDeps;
 `;
 
 exports[`Preact > jsx > Javascript Test > multipleSpreads 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -2329,9 +2213,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > nestedShow 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function NestedShow(props) {
@@ -2359,9 +2241,7 @@ export default NestedShow;
 `;
 
 exports[`Preact > jsx > Javascript Test > nestedStyles 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function NestedStyles(props) {
@@ -2404,9 +2284,7 @@ export default NestedStyles;
 `;
 
 exports[`Preact > jsx > Javascript Test > onInit & onMount 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -2427,9 +2305,7 @@ export default OnInit;
 `;
 
 exports[`Preact > jsx > Javascript Test > onInit 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -2458,9 +2334,7 @@ export default OnInit;
 `;
 
 exports[`Preact > jsx > Javascript Test > onMount 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -2483,9 +2357,7 @@ export default Comp;
 `;
 
 exports[`Preact > jsx > Javascript Test > onUpdate 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -2502,9 +2374,7 @@ export default OnUpdate;
 `;
 
 exports[`Preact > jsx > Javascript Test > onUpdateWithDeps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -2525,9 +2395,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`Preact > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 const b = 3;
@@ -2545,9 +2413,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > preserveTyping 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -2564,9 +2430,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > propsDestructure 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -2587,9 +2451,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > propsInterface 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -2606,9 +2468,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > propsType 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -2625,9 +2485,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > referencingFunInsideHook 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -2656,9 +2514,7 @@ export default OnUpdate;
 `;
 
 exports[`Preact > jsx > Javascript Test > renderBlock 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import { TARGET } from \\"../../constants/target.js\\";
@@ -2925,9 +2781,7 @@ export default RenderBlock;
 `;
 
 exports[`Preact > jsx > Javascript Test > renderContentExample 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext, useEffect } from \\"preact/hooks\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -2979,9 +2833,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function Button(props) {
@@ -3015,9 +2867,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Javascript Test > rootShow 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function RenderStyles(props) {
@@ -3039,9 +2889,7 @@ export default RenderStyles;
 `;
 
 exports[`Preact > jsx > Javascript Test > self-referencing component 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3063,9 +2911,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3091,9 +2937,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > showWithFor 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function NestedShow(props) {
@@ -3117,9 +2961,7 @@ export default NestedShow;
 `;
 
 exports[`Preact > jsx > Javascript Test > showWithRootText 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function ShowRootText(props) {
@@ -3139,9 +2981,7 @@ export default ShowRootText;
 `;
 
 exports[`Preact > jsx > Javascript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -3153,9 +2993,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -3167,9 +3005,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > spreadProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props) {
@@ -3181,9 +3017,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3211,9 +3045,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function StylePropClassAndCss(props) {
@@ -3239,9 +3071,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Preact > jsx > Javascript Test > subComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -3254,9 +3084,7 @@ export default SubComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > svgComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SvgComponent(props) {
@@ -3286,9 +3114,7 @@ export default SvgComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > typeDependency 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function TypeDependency(props) {
@@ -3300,9 +3126,7 @@ export default TypeDependency;
 `;
 
 exports[`Preact > jsx > Javascript Test > use-style 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3326,9 +3150,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3357,9 +3179,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -3383,9 +3203,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Javascript Test > useTarget 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -3405,9 +3223,7 @@ export default UseTargetComponent;
 `;
 
 exports[`Preact > jsx > Remove Internal mitosis package 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -3427,9 +3243,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > AdvancedRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -3497,9 +3311,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Basic 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -3545,9 +3357,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Basic Context 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useContext, useEffect } from \\"preact/hooks\\";
 import { createInjector, Injector, MyService } from \\"@dummy/injection-js\\";
@@ -3588,9 +3398,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Basic OnMount Update 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -3625,9 +3433,7 @@ export default MyBasicOnMountUpdateComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Basic Outputs 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -3647,9 +3453,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Basic Outputs Meta 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -3669,9 +3473,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -3683,9 +3485,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -3718,9 +3518,7 @@ export default MyBooleanAttribute;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicChildComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -3747,9 +3545,7 @@ export default MyBasicChildComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicFor 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -3786,9 +3582,7 @@ export default MyBasicForComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
 
@@ -3852,9 +3646,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicRefAssignment 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useRef } from \\"preact/hooks\\";
 
@@ -3882,9 +3674,7 @@ export default MyBasicRefAssignmentComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > BasicRefPrevious 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -3932,9 +3722,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Button 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ButtonProps {
@@ -3975,9 +3763,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Typescript Test > Columns 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Column = {
@@ -4057,9 +3843,7 @@ export default Column;
 `;
 
 exports[`Preact > jsx > Typescript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -4087,9 +3871,7 @@ export default ContentSlotCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > ContentSlotJSX 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -4149,9 +3931,7 @@ export default ContentSlotJsxCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > CustomCode 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -4228,9 +4008,7 @@ export default CustomCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > Embed 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -4307,9 +4085,7 @@ export default CustomCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > Form 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef } from \\"preact/hooks\\";
 
@@ -4618,9 +4394,7 @@ export default FormComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Image 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useRef, useEffect } from \\"preact/hooks\\";
 
@@ -4743,9 +4517,7 @@ export default Image;
 `;
 
 exports[`Preact > jsx > Typescript Test > Image State 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -4770,9 +4542,7 @@ export default ImgStateComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Img 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ImgProps {
@@ -4814,9 +4584,7 @@ export default ImgComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Input 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface FormInputProps {
@@ -4857,9 +4625,7 @@ export default FormInputComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > InputParent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -4882,9 +4648,7 @@ export default Stepper;
 `;
 
 exports[`Preact > jsx > Typescript Test > RawText 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface RawTextProps {
@@ -4906,9 +4670,7 @@ export default RawText;
 `;
 
 exports[`Preact > jsx > Typescript Test > Section 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface SectionProps {
@@ -4939,9 +4701,7 @@ export default SectionComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > Select 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface FormSelectProps {
@@ -4984,9 +4744,7 @@ export default SelectComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > SlotDefault 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -5006,9 +4764,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > SlotHtml 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -5029,9 +4785,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > SlotJsx 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -5052,9 +4806,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > SlotNamed 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -5078,9 +4830,7 @@ export default SlotCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > Stamped.io 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -5194,9 +4944,7 @@ export default SmileReviews;
 `;
 
 exports[`Preact > jsx > Typescript Test > Submit 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ButtonProps {
@@ -5217,9 +4965,7 @@ export default SubmitButton;
 `;
 
 exports[`Preact > jsx > Typescript Test > Text 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5258,9 +5004,7 @@ export default Text;
 `;
 
 exports[`Preact > jsx > Typescript Test > Textarea 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface TextareaProps {
@@ -5288,9 +5032,7 @@ export default Textarea;
 `;
 
 exports[`Preact > jsx > Typescript Test > Video 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface VideoProps {
@@ -5349,9 +5091,7 @@ export default Video;
 `;
 
 exports[`Preact > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5379,9 +5119,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > basicForNoTagReference 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5418,9 +5156,7 @@ export default MyBasicForNoTagRefComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > basicForwardRef 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5456,9 +5192,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5494,9 +5228,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -5533,9 +5265,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -5558,9 +5288,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > class + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -5583,9 +5311,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > className + css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -5608,9 +5334,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > className 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5637,9 +5361,7 @@ export default ClassNameCode;
 `;
 
 exports[`Preact > jsx > Typescript Test > classState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5669,9 +5391,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > componentWithContext 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 
@@ -5711,9 +5431,7 @@ export default ComponentWithContext;
 `;
 
 exports[`Preact > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 
@@ -5757,9 +5475,7 @@ export default ComponentWithContext;
 `;
 
 exports[`Preact > jsx > Typescript Test > contentState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext } from \\"preact/hooks\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -5782,9 +5498,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Typescript Test > defaultProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ButtonProps {
@@ -5841,9 +5555,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ButtonProps {
@@ -5896,9 +5608,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Typescript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Props = {
@@ -5924,9 +5634,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`Preact > jsx > Typescript Test > expressionState 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -5943,9 +5651,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > import types 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type RenderContentProps = {
@@ -5976,9 +5682,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Typescript Test > multipleOnUpdate 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -5998,9 +5702,7 @@ export default MultipleOnUpdate;
 `;
 
 exports[`Preact > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -6036,9 +5738,7 @@ export default MultipleOnUpdateWithDeps;
 `;
 
 exports[`Preact > jsx > Typescript Test > multipleSpreads 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -6055,9 +5755,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > nestedShow 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 interface Props {
@@ -6090,9 +5788,7 @@ export default NestedShow;
 `;
 
 exports[`Preact > jsx > Typescript Test > nestedStyles 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function NestedStyles(props: any) {
@@ -6135,9 +5831,7 @@ export default NestedStyles;
 `;
 
 exports[`Preact > jsx > Typescript Test > onInit & onMount 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -6158,9 +5852,7 @@ export default OnInit;
 `;
 
 exports[`Preact > jsx > Typescript Test > onInit 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -6193,9 +5885,7 @@ export default OnInit;
 `;
 
 exports[`Preact > jsx > Typescript Test > onMount 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -6218,9 +5908,7 @@ export default Comp;
 `;
 
 exports[`Preact > jsx > Typescript Test > onUpdate 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -6237,9 +5925,7 @@ export default OnUpdate;
 `;
 
 exports[`Preact > jsx > Typescript Test > onUpdateWithDeps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -6264,9 +5950,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`Preact > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Types = {
@@ -6294,9 +5978,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > preserveTyping 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export type A = \\"test\\";
@@ -6326,9 +6008,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > propsDestructure 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -6354,9 +6034,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > propsInterface 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 interface Person {
@@ -6378,9 +6056,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > propsType 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 type Person = {
@@ -6402,9 +6078,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > referencingFunInsideHook 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -6433,9 +6107,7 @@ export default OnUpdate;
 `;
 
 exports[`Preact > jsx > Typescript Test > renderBlock 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -6715,9 +6387,7 @@ export default RenderBlock;
 `;
 
 exports[`Preact > jsx > Typescript Test > renderContentExample 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useContext, useEffect } from \\"preact/hooks\\";
 
@@ -6777,9 +6447,7 @@ export default RenderContent;
 `;
 
 exports[`Preact > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface ButtonProps {
@@ -6820,9 +6488,7 @@ export default Button;
 `;
 
 exports[`Preact > jsx > Typescript Test > rootShow 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export interface RenderStylesProps {
@@ -6848,9 +6514,7 @@ export default RenderStyles;
 `;
 
 exports[`Preact > jsx > Typescript Test > self-referencing component 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -6872,9 +6536,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -6900,9 +6562,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > showWithFor 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 interface Props {
@@ -6931,9 +6591,7 @@ export default NestedShow;
 `;
 
 exports[`Preact > jsx > Typescript Test > showWithRootText 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 interface Props {
@@ -6957,9 +6615,7 @@ export default ShowRootText;
 `;
 
 exports[`Preact > jsx > Typescript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -6971,9 +6627,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -6985,9 +6639,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > spreadProps 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyBasicComponent(props: any) {
@@ -6999,9 +6651,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -7029,9 +6679,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function StylePropClassAndCss(props: any) {
@@ -7057,9 +6705,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Preact > jsx > Typescript Test > subComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -7072,9 +6718,7 @@ export default SubComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > svgComponent 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function SvgComponent(props: any) {
@@ -7104,9 +6748,7 @@ export default SvgComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > typeDependency 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 export type TypeDependencyProps = {
@@ -7125,9 +6767,7 @@ export default TypeDependency;
 `;
 
 exports[`Preact > jsx > Typescript Test > use-style 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -7151,9 +6791,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -7182,9 +6820,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -7208,9 +6844,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > jsx > Typescript Test > useTarget 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7230,9 +6864,7 @@ export default UseTargetComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > basic 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7252,9 +6884,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > bindGroup 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7326,9 +6956,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > bindProperty 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7343,9 +6971,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > classDirective 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7368,20 +6994,18 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > context 1`] = `
-"'>' expected. (34:13)
-  32 | return (
-  33 |
-> 34 | <'activeTab'.Provider  value={activeTab}><div>{activeTab}</div></'activeTab'.Provider>
+"'>' expected. (32:13)
+  30 | return (
+  31 |
+> 32 | <'activeTab'.Provider  value={activeTab}><div>{activeTab}</div></'activeTab'.Provider>
      |             ^
-  35 |
-  36 |
-  37 |"
+  33 |
+  34 |
+  35 |"
 `;
 
 exports[`Preact > svelte > Javascript Test > each 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7402,9 +7026,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > eventHandlers 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -7426,9 +7048,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > html 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7443,9 +7063,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > ifElse 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7472,9 +7090,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > imports 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import Button from \\"./Button\\";
@@ -7496,9 +7112,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > lifecycleHooks 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -7525,9 +7139,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > reactive 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7552,9 +7164,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > reactiveWithFn 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -7596,9 +7206,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > slots 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -7615,9 +7223,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > style 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props) {
@@ -7643,9 +7249,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Javascript Test > textExpressions 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7670,9 +7274,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > basic 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7692,9 +7294,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > bindGroup 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7766,9 +7366,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > bindProperty 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7783,9 +7381,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > classDirective 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7808,20 +7404,18 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > context 1`] = `
-"'>' expected. (34:13)
-  32 | return (
-  33 |
-> 34 | <'activeTab'.Provider  value={activeTab}><div>{activeTab}</div></'activeTab'.Provider>
+"'>' expected. (32:13)
+  30 | return (
+  31 |
+> 32 | <'activeTab'.Provider  value={activeTab}><div>{activeTab}</div></'activeTab'.Provider>
      |             ^
-  35 |
-  36 |
-  37 |"
+  33 |
+  34 |
+  35 |"
 `;
 
 exports[`Preact > svelte > Typescript Test > each 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7842,9 +7436,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > eventHandlers 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -7866,9 +7458,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > html 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7883,9 +7473,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > ifElse 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7912,9 +7500,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > imports 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 import Button from \\"./Button\\";
@@ -7936,9 +7522,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > lifecycleHooks 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useEffect } from \\"preact/hooks\\";
 
@@ -7965,9 +7549,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > reactive 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 
@@ -7992,9 +7574,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > reactiveWithFn 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState, useEffect } from \\"preact/hooks\\";
 
@@ -8036,9 +7616,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > slots 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -8055,9 +7633,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > style 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 
 function MyComponent(props: any) {
@@ -8083,9 +7659,7 @@ export default MyComponent;
 `;
 
 exports[`Preact > svelte > Typescript Test > textExpressions 1`] = `
-"\\"use client\\";
-
-/** @jsx h */
+"/** @jsx h */
 import { h, Fragment } from \\"preact\\";
 import { useState } from \\"preact/hooks\\";
 

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`React Native > jsx > Javascript Test > AdvancedRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -72,8 +71,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Basic 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -117,8 +115,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Basic Context 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -166,8 +163,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Basic OnMount Update 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -204,8 +200,7 @@ export default MyBasicOnMountUpdateComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Basic Outputs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -232,8 +227,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Basic Outputs Meta 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -260,8 +254,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -280,8 +273,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -316,8 +308,7 @@ export default MyBooleanAttribute;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicChildComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -351,8 +342,7 @@ export default MyBasicChildComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -398,8 +388,7 @@ export default MyBasicForComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -465,8 +454,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicRefAssignment 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -499,8 +487,7 @@ export default MyBasicRefAssignmentComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > BasicRefPrevious 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -554,8 +541,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -596,8 +582,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Javascript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -651,8 +636,7 @@ export default Column;
 `;
 
 exports[`React Native > jsx > Javascript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -681,8 +665,7 @@ export default ContentSlotCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > ContentSlotJSX 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -743,8 +726,7 @@ export default ContentSlotJsxCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > CustomCode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -815,8 +797,7 @@ export default CustomCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > Embed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -887,8 +868,7 @@ export default CustomCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > Form 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1159,8 +1139,7 @@ export default FormComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Image 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1266,8 +1245,7 @@ export default Image;
 `;
 
 exports[`React Native > jsx > Javascript Test > Image State 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1299,8 +1277,7 @@ export default ImgStateComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1331,8 +1308,7 @@ export default ImgComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Input 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1368,8 +1344,7 @@ export default FormInputComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > InputParent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1399,8 +1374,7 @@ export default Stepper;
 `;
 
 exports[`React Native > jsx > Javascript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1419,8 +1393,7 @@ export default RawText;
 `;
 
 exports[`React Native > jsx > Javascript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1452,8 +1425,7 @@ export default SectionComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1491,8 +1463,7 @@ export default SelectComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1519,8 +1490,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1544,8 +1514,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1569,8 +1538,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1597,8 +1565,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > Stamped.io 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1700,8 +1667,7 @@ export default SmileReviews;
 `;
 
 exports[`React Native > jsx > Javascript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1724,8 +1690,7 @@ export default SubmitButton;
 `;
 
 exports[`React Native > jsx > Javascript Test > Text 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1762,8 +1727,7 @@ export default Text;
 `;
 
 exports[`React Native > jsx > Javascript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1790,8 +1754,7 @@ export default Textarea;
 `;
 
 exports[`React Native > jsx > Javascript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1831,8 +1794,7 @@ export default Video;
 `;
 
 exports[`React Native > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1867,8 +1829,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > basicForNoTagReference 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1917,8 +1878,7 @@ export default MyBasicForNoTagRefComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > basicForwardRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1953,8 +1913,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -1989,8 +1948,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2034,8 +1992,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2060,8 +2017,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2086,8 +2042,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2112,8 +2067,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > className 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2145,8 +2099,7 @@ export default ClassNameCode;
 `;
 
 exports[`React Native > jsx > Javascript Test > classState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2178,8 +2131,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > componentWithContext 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2223,8 +2175,7 @@ export default ComponentWithContext;
 `;
 
 exports[`React Native > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2272,8 +2223,7 @@ export default ComponentWithContext;
 `;
 
 exports[`React Native > jsx > Javascript Test > contentState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2305,8 +2255,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Javascript Test > defaultProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2360,8 +2309,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2413,8 +2361,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Javascript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2442,8 +2389,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`React Native > jsx > Javascript Test > expressionState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2471,8 +2417,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2503,8 +2448,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Javascript Test > multipleOnUpdate 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2531,8 +2475,7 @@ export default MultipleOnUpdate;
 `;
 
 exports[`React Native > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2575,8 +2518,7 @@ export default MultipleOnUpdateWithDeps;
 `;
 
 exports[`React Native > jsx > Javascript Test > multipleSpreads 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2600,8 +2542,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2642,8 +2583,7 @@ export default NestedShow;
 `;
 
 exports[`React Native > jsx > Javascript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2679,8 +2619,7 @@ export default NestedStyles;
 `;
 
 exports[`React Native > jsx > Javascript Test > onInit & onMount 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2708,8 +2647,7 @@ export default OnInit;
 `;
 
 exports[`React Native > jsx > Javascript Test > onInit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2745,8 +2683,7 @@ export default OnInit;
 `;
 
 exports[`React Native > jsx > Javascript Test > onMount 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2776,8 +2713,7 @@ export default Comp;
 `;
 
 exports[`React Native > jsx > Javascript Test > onUpdate 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2801,8 +2737,7 @@ export default OnUpdate;
 `;
 
 exports[`React Native > jsx > Javascript Test > onUpdateWithDeps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2830,8 +2765,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`React Native > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2856,8 +2790,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2881,8 +2814,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > propsDestructure 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2911,8 +2843,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2936,8 +2867,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2961,8 +2891,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > referencingFunInsideHook 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -2998,8 +2927,7 @@ export default OnUpdate;
 `;
 
 exports[`React Native > jsx > Javascript Test > renderBlock 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3273,8 +3201,7 @@ export default RenderBlock;
 `;
 
 exports[`React Native > jsx > Javascript Test > renderContentExample 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3332,8 +3259,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3374,8 +3300,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Javascript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3408,8 +3333,7 @@ export default RenderStyles;
 `;
 
 exports[`React Native > jsx > Javascript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3438,8 +3362,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3474,8 +3397,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3510,8 +3432,7 @@ export default NestedShow;
 `;
 
 exports[`React Native > jsx > Javascript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3542,8 +3463,7 @@ export default ShowRootText;
 `;
 
 exports[`React Native > jsx > Javascript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3562,8 +3482,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3582,8 +3501,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3602,8 +3520,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3633,8 +3550,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3657,8 +3573,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`React Native > jsx > Javascript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3678,8 +3593,7 @@ export default SubComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3716,8 +3630,7 @@ export default SvgComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3740,8 +3653,7 @@ export default TypeDependency;
 `;
 
 exports[`React Native > jsx > Javascript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3766,8 +3678,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3794,8 +3705,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3820,8 +3730,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Javascript Test > useTarget 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3852,8 +3761,7 @@ export default UseTargetComponent;
 `;
 
 exports[`React Native > jsx > Remove Internal mitosis package 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3881,8 +3789,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > AdvancedRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -3956,8 +3863,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Basic 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4005,8 +3911,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Basic Context 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4054,8 +3959,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Basic OnMount Update 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4097,8 +4001,7 @@ export default MyBasicOnMountUpdateComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Basic Outputs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4125,8 +4028,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Basic Outputs Meta 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4153,8 +4055,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4173,8 +4074,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4214,8 +4114,7 @@ export default MyBooleanAttribute;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicChildComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4249,8 +4148,7 @@ export default MyBasicChildComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4296,8 +4194,7 @@ export default MyBasicForComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4367,8 +4264,7 @@ export default MyBasicRefComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicRefAssignment 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4405,8 +4301,7 @@ export default MyBasicRefAssignmentComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > BasicRefPrevious 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4464,8 +4359,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4513,8 +4407,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Typescript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4583,8 +4476,7 @@ export default Column;
 `;
 
 exports[`React Native > jsx > Typescript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4619,8 +4511,7 @@ export default ContentSlotCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > ContentSlotJSX 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4686,8 +4577,7 @@ export default ContentSlotJsxCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > CustomCode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4763,8 +4653,7 @@ export default CustomCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > Embed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -4840,8 +4729,7 @@ export default CustomCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > Form 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5143,8 +5031,7 @@ export default FormComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Image 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5269,8 +5156,7 @@ export default Image;
 `;
 
 exports[`React Native > jsx > Typescript Test > Image State 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5302,8 +5188,7 @@ export default ImgStateComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5352,8 +5237,7 @@ export default ImgComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Input 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5401,8 +5285,7 @@ export default FormInputComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > InputParent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5432,8 +5315,7 @@ export default Stepper;
 `;
 
 exports[`React Native > jsx > Typescript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5457,8 +5339,7 @@ export default RawText;
 `;
 
 exports[`React Native > jsx > Typescript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5496,8 +5377,7 @@ export default SectionComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5547,8 +5427,7 @@ export default SelectComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5579,8 +5458,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5608,8 +5486,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5637,8 +5514,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5669,8 +5545,7 @@ export default SlotCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > Stamped.io 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5777,8 +5652,7 @@ export default SmileReviews;
 `;
 
 exports[`React Native > jsx > Typescript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5806,8 +5680,7 @@ export default SubmitButton;
 `;
 
 exports[`React Native > jsx > Typescript Test > Text 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5853,8 +5726,7 @@ export default Text;
 `;
 
 exports[`React Native > jsx > Typescript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5889,8 +5761,7 @@ export default Textarea;
 `;
 
 exports[`React Native > jsx > Typescript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5956,8 +5827,7 @@ export default Video;
 `;
 
 exports[`React Native > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -5992,8 +5862,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > basicForNoTagReference 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6042,8 +5911,7 @@ export default MyBasicForNoTagRefComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > basicForwardRef 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6083,8 +5951,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6124,8 +5991,7 @@ export default MyBasicForwardRefComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6169,8 +6035,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6195,8 +6060,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6221,8 +6085,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6247,8 +6110,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > className 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6286,8 +6148,7 @@ export default ClassNameCode;
 `;
 
 exports[`React Native > jsx > Typescript Test > classState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6319,8 +6180,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > componentWithContext 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6369,8 +6229,7 @@ export default ComponentWithContext;
 `;
 
 exports[`React Native > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6423,8 +6282,7 @@ export default ComponentWithContext;
 `;
 
 exports[`React Native > jsx > Typescript Test > contentState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6456,8 +6314,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Typescript Test > defaultProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6521,8 +6378,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6582,8 +6438,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Typescript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6615,8 +6470,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`React Native > jsx > Typescript Test > expressionState 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6644,8 +6498,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6683,8 +6536,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Typescript Test > multipleOnUpdate 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6711,8 +6563,7 @@ export default MultipleOnUpdate;
 `;
 
 exports[`React Native > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6755,8 +6606,7 @@ export default MultipleOnUpdateWithDeps;
 `;
 
 exports[`React Native > jsx > Typescript Test > multipleSpreads 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6780,8 +6630,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6827,8 +6676,7 @@ export default NestedShow;
 `;
 
 exports[`React Native > jsx > Typescript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6864,8 +6712,7 @@ export default NestedStyles;
 `;
 
 exports[`React Native > jsx > Typescript Test > onInit & onMount 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6893,8 +6740,7 @@ export default OnInit;
 `;
 
 exports[`React Native > jsx > Typescript Test > onInit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6934,8 +6780,7 @@ export default OnInit;
 `;
 
 exports[`React Native > jsx > Typescript Test > onMount 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6965,8 +6810,7 @@ export default Comp;
 `;
 
 exports[`React Native > jsx > Typescript Test > onUpdate 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -6990,8 +6834,7 @@ export default OnUpdate;
 `;
 
 exports[`React Native > jsx > Typescript Test > onUpdateWithDeps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7023,8 +6866,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`React Native > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7059,8 +6901,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7097,8 +6938,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > propsDestructure 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7132,8 +6972,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7162,8 +7001,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7192,8 +7030,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > referencingFunInsideHook 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7229,8 +7066,7 @@ export default OnUpdate;
 `;
 
 exports[`React Native > jsx > Typescript Test > renderBlock 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7517,8 +7353,7 @@ export default RenderBlock;
 `;
 
 exports[`React Native > jsx > Typescript Test > renderContentExample 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7584,8 +7419,7 @@ export default RenderContent;
 `;
 
 exports[`React Native > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7633,8 +7467,7 @@ export default Button;
 `;
 
 exports[`React Native > jsx > Typescript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7671,8 +7504,7 @@ export default RenderStyles;
 `;
 
 exports[`React Native > jsx > Typescript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7701,8 +7533,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7737,8 +7568,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7778,8 +7608,7 @@ export default NestedShow;
 `;
 
 exports[`React Native > jsx > Typescript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7814,8 +7643,7 @@ export default ShowRootText;
 `;
 
 exports[`React Native > jsx > Typescript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7834,8 +7662,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7854,8 +7681,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7874,8 +7700,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7905,8 +7730,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7929,8 +7753,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`React Native > jsx > Typescript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7950,8 +7773,7 @@ export default SubComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -7988,8 +7810,7 @@ export default SvgComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8019,8 +7840,7 @@ export default TypeDependency;
 `;
 
 exports[`React Native > jsx > Typescript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8045,8 +7865,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8073,8 +7892,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8099,8 +7917,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > jsx > Typescript Test > useTarget 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8131,8 +7948,7 @@ export default UseTargetComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > basic 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8159,8 +7975,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > bindGroup 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8239,8 +8054,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > bindProperty 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8262,8 +8076,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > classDirective 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8287,19 +8100,18 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > context 1`] = `
-"'>' expected. (34:13)
-  32 | return (
-  33 |
-> 34 | <'activeTab'.Provider  value={activeTab}><View><Text>{activeTab}</Text></View></'activeTab'.Provider>
+"'>' expected. (32:13)
+  30 | return (
+  31 |
+> 32 | <'activeTab'.Provider  value={activeTab}><View><Text>{activeTab}</Text></View></'activeTab'.Provider>
      |             ^
-  35 |
-  36 |
-  37 |"
+  33 |
+  34 |
+  35 |"
 `;
 
 exports[`React Native > svelte > Javascript Test > each 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8329,8 +8141,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > eventHandlers 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8365,8 +8176,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > html 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8388,8 +8198,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > ifElse 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8427,8 +8236,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > imports 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8457,8 +8265,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > lifecycleHooks 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8492,8 +8299,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > reactive 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8525,8 +8331,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > reactiveWithFn 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8575,8 +8380,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8604,8 +8408,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8626,8 +8429,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Javascript Test > textExpressions 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8659,8 +8461,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > basic 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8687,8 +8488,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > bindGroup 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8767,8 +8567,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > bindProperty 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8790,8 +8589,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > classDirective 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8815,19 +8613,18 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > context 1`] = `
-"'>' expected. (34:13)
-  32 | return (
-  33 |
-> 34 | <'activeTab'.Provider  value={activeTab}><View><Text>{activeTab}</Text></View></'activeTab'.Provider>
+"'>' expected. (32:13)
+  30 | return (
+  31 |
+> 32 | <'activeTab'.Provider  value={activeTab}><View><Text>{activeTab}</Text></View></'activeTab'.Provider>
      |             ^
-  35 |
-  36 |
-  37 |"
+  33 |
+  34 |
+  35 |"
 `;
 
 exports[`React Native > svelte > Typescript Test > each 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8857,8 +8654,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > eventHandlers 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8893,8 +8689,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > html 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8916,8 +8711,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > ifElse 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8955,8 +8749,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > imports 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -8985,8 +8778,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > lifecycleHooks 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -9020,8 +8812,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > reactive 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -9053,8 +8844,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > reactiveWithFn 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -9103,8 +8893,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -9132,8 +8921,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,
@@ -9154,8 +8942,7 @@ export default MyComponent;
 `;
 
 exports[`React Native > svelte > Typescript Test > textExpressions 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import {
   FlatList,
   ScrollView,

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -218,8 +218,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React > jsx > Javascript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return <input autoCapitalize=\\"on\\" autoComplete=\\"on\\" spellCheck={true} />;
@@ -230,8 +229,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 function MyBooleanAttribute(props) {
@@ -450,8 +448,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`React > jsx > Javascript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function Button(props) {
   return (
@@ -549,8 +546,7 @@ export default Column;
 `;
 
 exports[`React > jsx > Javascript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function ContentSlotCode(props) {
   return (
@@ -1177,8 +1173,7 @@ export default ImgStateComponent;
 `;
 
 exports[`React > jsx > Javascript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function ImgComponent(props) {
@@ -1253,8 +1248,7 @@ export default Stepper;
 `;
 
 exports[`React > jsx > Javascript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function RawText(props) {
   return (
@@ -1270,8 +1264,7 @@ export default RawText;
 `;
 
 exports[`React > jsx > Javascript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SectionComponent(props) {
   return (
@@ -1295,8 +1288,7 @@ export default SectionComponent;
 `;
 
 exports[`React > jsx > Javascript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function SelectComponent(props) {
@@ -1326,8 +1318,7 @@ export default SelectComponent;
 `;
 
 exports[`React > jsx > Javascript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SlotCode(props) {
   return (
@@ -1342,8 +1333,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Javascript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
@@ -1359,8 +1349,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Javascript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
@@ -1376,8 +1365,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Javascript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SlotCode(props) {
   return (
@@ -1505,8 +1493,7 @@ export default SmileReviews;
 `;
 
 exports[`React > jsx > Javascript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SubmitButton(props) {
   return (
@@ -1551,8 +1538,7 @@ export default Text;
 `;
 
 exports[`React > jsx > Javascript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function Textarea(props) {
   return (
@@ -1571,8 +1557,7 @@ export default Textarea;
 `;
 
 exports[`React > jsx > Javascript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function Video(props) {
   return (
@@ -1772,8 +1757,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`React > jsx > Javascript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -1795,8 +1779,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -1818,8 +1801,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2081,8 +2063,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Javascript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 const DEFAULT_VALUES = {
   name: \\"Sami\\",
@@ -2217,8 +2198,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function NestedShow(props) {
   return (
@@ -2245,8 +2225,7 @@ export default NestedShow;
 `;
 
 exports[`React > jsx > Javascript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function NestedStyles(props) {
   return (
@@ -2399,8 +2378,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`React > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 const b = 3;
 const foo = () => {};
@@ -2417,8 +2395,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2455,8 +2432,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2472,8 +2448,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2837,8 +2812,7 @@ export default RenderContent;
 `;
 
 exports[`React > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function Button(props) {
   return (
@@ -2871,8 +2845,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Javascript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function RenderStyles(props) {
   return (
@@ -2893,8 +2866,7 @@ export default RenderStyles;
 `;
 
 exports[`React > jsx > Javascript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -2915,8 +2887,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -2941,8 +2912,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function NestedShow(props) {
   return (
@@ -2965,8 +2935,7 @@ export default NestedShow;
 `;
 
 exports[`React > jsx > Javascript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function ShowRootText(props) {
   return <>{props.conditionA ? <>ContentA</> : <div>else-condition-A</div>}</>;
@@ -2977,8 +2946,7 @@ export default ShowRootText;
 `;
 
 exports[`React > jsx > Javascript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return <input {...attrs} />;
@@ -2989,8 +2957,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return <input {...props.nested} />;
@@ -3001,8 +2968,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props) {
   return <input {...props} />;
@@ -3013,8 +2979,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Javascript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -3041,8 +3006,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function StylePropClassAndCss(props) {
   return (
@@ -3067,8 +3031,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`React > jsx > Javascript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props) {
@@ -3080,8 +3043,7 @@ export default SubComponent;
 `;
 
 exports[`React > jsx > Javascript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SvgComponent(props) {
   return (
@@ -3110,8 +3072,7 @@ export default SvgComponent;
 `;
 
 exports[`React > jsx > Javascript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function TypeDependency(props) {
   return <div>{props.foo}</div>;
@@ -3122,8 +3083,7 @@ export default TypeDependency;
 `;
 
 exports[`React > jsx > Javascript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -3146,8 +3106,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -3175,8 +3134,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -3474,8 +3432,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`React > jsx > Typescript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return <input autoCapitalize=\\"on\\" autoComplete=\\"on\\" spellCheck={true} />;
@@ -3486,8 +3443,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   children: any;
@@ -3723,8 +3679,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`React > jsx > Typescript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -3844,8 +3799,7 @@ export default Column;
 `;
 
 exports[`React > jsx > Typescript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -4543,8 +4497,7 @@ export default ImgStateComponent;
 `;
 
 exports[`React > jsx > Typescript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ImgProps {
   attributes?: any;
@@ -4649,8 +4602,7 @@ export default Stepper;
 `;
 
 exports[`React > jsx > Typescript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface RawTextProps {
   attributes?: any;
@@ -4671,8 +4623,7 @@ export default RawText;
 `;
 
 exports[`React > jsx > Typescript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface SectionProps {
   maxWidth?: number;
@@ -4702,8 +4653,7 @@ export default SectionComponent;
 `;
 
 exports[`React > jsx > Typescript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface FormSelectProps {
   options?: {
@@ -4745,8 +4695,7 @@ export default SelectComponent;
 `;
 
 exports[`React > jsx > Typescript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4765,8 +4714,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Typescript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4786,8 +4734,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Typescript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4807,8 +4754,7 @@ export default SlotCode;
 `;
 
 exports[`React > jsx > Typescript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4945,8 +4891,7 @@ export default SmileReviews;
 `;
 
 exports[`React > jsx > Typescript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -5005,8 +4950,7 @@ export default Text;
 `;
 
 exports[`React > jsx > Typescript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface TextareaProps {
   attributes?: any;
@@ -5033,8 +4977,7 @@ export default Textarea;
 `;
 
 exports[`React > jsx > Typescript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface VideoProps {
   attributes?: any;
@@ -5270,8 +5213,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`React > jsx > Typescript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return (
@@ -5293,8 +5235,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return (
@@ -5316,8 +5257,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return (
@@ -5613,8 +5553,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Typescript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   name: string;
@@ -5760,8 +5699,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -5793,8 +5731,7 @@ export default NestedShow;
 `;
 
 exports[`React > jsx > Typescript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function NestedStyles(props: any) {
   return (
@@ -5955,8 +5892,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`React > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Types = {
   s: any[];
@@ -5983,8 +5919,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export type A = \\"test\\";
 export interface C {
@@ -6039,8 +5974,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Person {
   name: string;
@@ -6061,8 +5995,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Person = {
   name: string;
@@ -6452,8 +6385,7 @@ export default RenderContent;
 `;
 
 exports[`React > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -6493,8 +6425,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Typescript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface RenderStylesProps {
   foo: string;
@@ -6519,8 +6450,7 @@ export default RenderStyles;
 `;
 
 exports[`React > jsx > Typescript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -6541,8 +6471,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -6567,8 +6496,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -6596,8 +6524,7 @@ export default NestedShow;
 `;
 
 exports[`React > jsx > Typescript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -6612,8 +6539,7 @@ export default ShowRootText;
 `;
 
 exports[`React > jsx > Typescript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return <input {...attrs} />;
@@ -6624,8 +6550,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return <input {...props.nested} />;
@@ -6636,8 +6561,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyBasicComponent(props: any) {
   return <input {...props} />;
@@ -6648,8 +6572,7 @@ export default MyBasicComponent;
 `;
 
 exports[`React > jsx > Typescript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -6676,8 +6599,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function StylePropClassAndCss(props: any) {
   return (
@@ -6702,8 +6624,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`React > jsx > Typescript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props: any) {
@@ -6715,8 +6636,7 @@ export default SubComponent;
 `;
 
 exports[`React > jsx > Typescript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function SvgComponent(props: any) {
   return (
@@ -6745,8 +6665,7 @@ export default SvgComponent;
 `;
 
 exports[`React > jsx > Typescript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export type TypeDependencyProps = {
   foo: Foo;
@@ -6764,8 +6683,7 @@ export default TypeDependency;
 `;
 
 exports[`React > jsx > Typescript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -6788,8 +6706,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -6817,8 +6734,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -7418,8 +7334,7 @@ export default MyComponent;
 `;
 
 exports[`React > svelte > Javascript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -7435,8 +7350,7 @@ export default MyComponent;
 `;
 
 exports[`React > svelte > Javascript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props) {
   return (
@@ -7828,8 +7742,7 @@ export default MyComponent;
 `;
 
 exports[`React > svelte > Typescript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (
@@ -7845,8 +7758,7 @@ export default MyComponent;
 `;
 
 exports[`React > svelte > Typescript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function MyComponent(props: any) {
   return (

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -481,8 +481,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Javascript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 function Column(props) {
   function getColumns() {
@@ -2101,8 +2100,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Javascript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 
 function RenderContent(props) {
@@ -3719,8 +3717,7 @@ export default Button;
 `;
 
 exports[`React > jsx > Typescript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Column = {
   content: any; // TODO: Implement this when support for dynamic CSS lands
@@ -5595,8 +5592,7 @@ export default MyComponent;
 `;
 
 exports[`React > jsx > Typescript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type RenderContentProps = {
   options?: GetContentOptions;

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -1192,7 +1192,8 @@ export default ImgComponent;
 `;
 
 exports[`RSC > jsx > Javascript Test > Input 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function FormInputComponent(props) {
@@ -1220,13 +1221,14 @@ export default FormInputComponent;
 `;
 
 exports[`RSC > jsx > Javascript Test > InputParent 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props) {
-  const handleChange = function handleChange(value) {
+  function handleChange(value) {
     console.log(value);
-  };
+  }
 
   return (
     <FormInputComponent
@@ -1965,7 +1967,8 @@ export default RenderContent;
 `;
 
 exports[`RSC > jsx > Javascript Test > defaultProps 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 
 function Button(props) {
   return (
@@ -2011,7 +2014,8 @@ export default Button;
 `;
 
 exports[`RSC > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 
 function Button(props) {
   return (
@@ -4264,7 +4268,8 @@ export default ImgComponent;
 `;
 
 exports[`RSC > jsx > Typescript Test > Input 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 
 export interface FormInputProps {
   type?: string;
@@ -4304,13 +4309,14 @@ export default FormInputComponent;
 `;
 
 exports[`RSC > jsx > Typescript Test > InputParent 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props: any) {
-  const handleChange = function handleChange(value: string) {
+  function handleChange(value: string) {
     console.log(value);
-  };
+  }
 
   return (
     <FormInputComponent
@@ -5167,7 +5173,8 @@ export default RenderContent;
 `;
 
 exports[`RSC > jsx > Typescript Test > defaultProps 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -5223,7 +5230,8 @@ export default Button;
 `;
 
 exports[`RSC > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
-"import * as React from \\"react\\";
+"\\"use client\\";
+import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -6391,14 +6399,25 @@ export default MyComponent;
 `;
 
 exports[`RSC > svelte > Javascript Test > eventHandlers 1`] = `
-"'(' expected. (13:30)
-  11 |
-  12 |   function MyComponent(props) {
-> 13 |   const log = log = function function log(msg = 'hello') {
-     |                              ^
-  14 | console.log(msg);
-  15 | }
-  16 |"
+"\\"use client\\";
+import * as React from \\"react\\";
+
+function MyComponent(props) {
+  function log(msg = \\"hello\\") {
+    console.log(msg);
+  }
+
+  return (
+    <div>
+      <button onClick={(a) => log(\\"hi\\")}>Log</button>
+      <button onClick={(event) => log(event)}>Log</button>
+      <button onClick={(event) => log(event)}>Log</button>
+    </div>
+  );
+}
+
+export default MyComponent;
+"
 `;
 
 exports[`RSC > svelte > Javascript Test > html 1`] = `
@@ -6788,14 +6807,25 @@ export default MyComponent;
 `;
 
 exports[`RSC > svelte > Typescript Test > eventHandlers 1`] = `
-"'(' expected. (13:30)
-  11 |
-  12 |   function MyComponent(props:any) {
-> 13 |   const log = log = function function log(msg = 'hello') {
-     |                              ^
-  14 | console.log(msg);
-  15 | }
-  16 |"
+"\\"use client\\";
+import * as React from \\"react\\";
+
+function MyComponent(props: any) {
+  function log(msg = \\"hello\\") {
+    console.log(msg);
+  }
+
+  return (
+    <div>
+      <button onClick={(a) => log(\\"hi\\")}>Log</button>
+      <button onClick={(event) => log(event)}>Log</button>
+      <button onClick={(event) => log(event)}>Log</button>
+    </div>
+  );
+}
+
+export default MyComponent;
+"
 `;
 
 exports[`RSC > svelte > Typescript Test > html 1`] = `

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -493,8 +493,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Javascript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function Column(props) {
@@ -2122,8 +2121,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 import \\"@tarojs/components\\";
 
@@ -3791,8 +3789,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Typescript Test > Columns 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Column = {
   content: any; // TODO: Implement this when support for dynamic CSS lands
@@ -5689,8 +5686,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > import types 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type RenderContentProps = {
   options?: GetContentOptions;

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -223,8 +223,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -236,8 +235,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 import { View, Text } from \\"@tarojs/components\\";
 
@@ -461,8 +459,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text, Button } from \\"@tarojs/components\\";
 
 function Button(props) {
@@ -562,8 +559,7 @@ export default Column;
 `;
 
 exports[`Taro > jsx > Javascript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function ContentSlotCode(props) {
@@ -1176,8 +1172,7 @@ export default ImgStateComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 import { Image } from \\"@tarojs/components\\";
 
@@ -1255,8 +1250,7 @@ export default Stepper;
 `;
 
 exports[`Taro > jsx > Javascript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Text } from \\"@tarojs/components\\";
 
 function RawText(props) {
@@ -1268,8 +1262,7 @@ export default RawText;
 `;
 
 exports[`Taro > jsx > Javascript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function SectionComponent(props) {
@@ -1294,8 +1287,7 @@ export default SectionComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 import { View, Text } from \\"@tarojs/components\\";
 
@@ -1326,8 +1318,7 @@ export default SelectComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function SlotCode(props) {
@@ -1339,8 +1330,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Javascript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 import { View } from \\"@tarojs/components\\";
 
@@ -1357,8 +1347,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Javascript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 import { View } from \\"@tarojs/components\\";
 
@@ -1375,8 +1364,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Javascript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function SlotCode(props) {
@@ -1506,8 +1494,7 @@ export default SmileReviews;
 `;
 
 exports[`Taro > jsx > Javascript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function SubmitButton(props) {
@@ -1554,8 +1541,7 @@ export default Text;
 `;
 
 exports[`Taro > jsx > Javascript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Textarea } from \\"@tarojs/components\\";
 
 function Textarea(props) {
@@ -1575,8 +1561,7 @@ export default Textarea;
 `;
 
 exports[`Taro > jsx > Javascript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function Video(props) {
@@ -1782,8 +1767,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -1806,8 +1790,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -1830,8 +1813,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -2101,8 +2083,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Javascript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 const DEFAULT_VALUES = {
   name: \\"Sami\\",
@@ -2242,8 +2223,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function NestedShow(props) {
@@ -2271,8 +2251,7 @@ export default NestedShow;
 `;
 
 exports[`Taro > jsx > Javascript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function NestedStyles(props) {
@@ -2430,8 +2409,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`Taro > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 const b = 3;
 const foo = () => {};
@@ -2448,8 +2426,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -2488,8 +2465,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -2506,8 +2482,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -2877,8 +2852,7 @@ export default RenderContent;
 `;
 
 exports[`Taro > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text, Button } from \\"@tarojs/components\\";
 
 function Button(props) {
@@ -2912,8 +2886,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Javascript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function RenderStyles(props) {
@@ -2935,8 +2908,7 @@ export default RenderStyles;
 `;
 
 exports[`Taro > jsx > Javascript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -2958,8 +2930,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -2985,8 +2956,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function NestedShow(props) {
@@ -3010,8 +2980,7 @@ export default NestedShow;
 `;
 
 exports[`Taro > jsx > Javascript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function ShowRootText(props) {
@@ -3025,8 +2994,7 @@ export default ShowRootText;
 `;
 
 exports[`Taro > jsx > Javascript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -3038,8 +3006,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -3051,8 +3018,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props) {
@@ -3064,8 +3030,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -3093,8 +3058,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function StylePropClassAndCss(props) {
@@ -3117,8 +3081,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Taro > jsx > Javascript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import Foo from \\"./foo-sub-component\\";
 import \\"@tarojs/components\\";
 
@@ -3131,8 +3094,7 @@ export default SubComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function SvgComponent(props) {
@@ -3162,8 +3124,7 @@ export default SvgComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function TypeDependency(props) {
@@ -3175,8 +3136,7 @@ export default TypeDependency;
 `;
 
 exports[`Taro > jsx > Javascript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -3200,8 +3160,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -3230,8 +3189,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Javascript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -3535,8 +3493,7 @@ export default MyBasicOutputsComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > BasicAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -3548,8 +3505,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   children: any;
@@ -3793,8 +3749,7 @@ export default MyPreviousComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > Button 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -3918,8 +3873,7 @@ export default Column;
 `;
 
 exports[`Taro > jsx > Typescript Test > ContentSlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -4606,8 +4560,7 @@ export default ImgStateComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > Img 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ImgProps {
   attributes?: any;
@@ -4715,8 +4668,7 @@ export default Stepper;
 `;
 
 exports[`Taro > jsx > Typescript Test > RawText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface RawTextProps {
   attributes?: any;
@@ -4734,8 +4686,7 @@ export default RawText;
 `;
 
 exports[`Taro > jsx > Typescript Test > Section 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface SectionProps {
   maxWidth?: number;
@@ -4767,8 +4718,7 @@ export default SectionComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > Select 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface FormSelectProps {
   options?: {
@@ -4811,8 +4761,7 @@ export default SelectComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > SlotDefault 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4828,8 +4777,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Typescript Test > SlotHtml 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4850,8 +4798,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Typescript Test > SlotJsx 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -4872,8 +4819,7 @@ export default SlotCode;
 `;
 
 exports[`Taro > jsx > Typescript Test > SlotNamed 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   [key: string]: string;
@@ -5012,8 +4958,7 @@ export default SmileReviews;
 `;
 
 exports[`Taro > jsx > Typescript Test > Submit 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -5075,8 +5020,7 @@ export default Text;
 `;
 
 exports[`Taro > jsx > Typescript Test > Textarea 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface TextareaProps {
   attributes?: any;
@@ -5105,8 +5049,7 @@ export default Textarea;
 `;
 
 exports[`Taro > jsx > Typescript Test > Video 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface VideoProps {
   attributes?: any;
@@ -5351,8 +5294,7 @@ export default MyBasicOnUpdateReturnComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > class + ClassName + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -5375,8 +5317,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > class + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -5399,8 +5340,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > className + css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -5706,8 +5646,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Typescript Test > defaultValsWithTypes 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Props = {
   name: string;
@@ -5858,8 +5797,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > nestedShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -5893,8 +5831,7 @@ export default NestedShow;
 `;
 
 exports[`Taro > jsx > Typescript Test > nestedStyles 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function NestedStyles(props: any) {
@@ -6060,8 +5997,7 @@ export default OnUpdateWithDeps;
 `;
 
 exports[`Taro > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Types = {
   s: any[];
@@ -6089,8 +6025,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > preserveTyping 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export type A = \\"test\\";
 export interface C {
@@ -6148,8 +6083,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > propsInterface 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Person {
   name: string;
@@ -6172,8 +6106,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > propsType 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 type Person = {
   name: string;
@@ -6569,8 +6502,7 @@ export default RenderContent;
 `;
 
 exports[`Taro > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -6612,8 +6544,7 @@ export default Button;
 `;
 
 exports[`Taro > jsx > Typescript Test > rootShow 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export interface RenderStylesProps {
   foo: string;
@@ -6640,8 +6571,7 @@ export default RenderStyles;
 `;
 
 exports[`Taro > jsx > Typescript Test > self-referencing component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -6663,8 +6593,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > self-referencing component with children 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -6690,8 +6619,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > showWithFor 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -6721,8 +6649,7 @@ export default NestedShow;
 `;
 
 exports[`Taro > jsx > Typescript Test > showWithRootText 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 interface Props {
   conditionA: boolean;
@@ -6741,8 +6668,7 @@ export default ShowRootText;
 `;
 
 exports[`Taro > jsx > Typescript Test > spreadAttrs 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -6754,8 +6680,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > spreadNestedProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -6767,8 +6692,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > spreadProps 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyBasicComponent(props: any) {
@@ -6780,8 +6704,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > styleClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -6809,8 +6732,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > stylePropClassAndCss 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function StylePropClassAndCss(props: any) {
@@ -6833,8 +6755,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Taro > jsx > Typescript Test > subComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import Foo from \\"./foo-sub-component\\";
 import \\"@tarojs/components\\";
 
@@ -6847,8 +6768,7 @@ export default SubComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > svgComponent 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View } from \\"@tarojs/components\\";
 
 function SvgComponent(props: any) {
@@ -6878,8 +6798,7 @@ export default SvgComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > typeDependency 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 
 export type TypeDependencyProps = {
   foo: Foo;
@@ -6898,8 +6817,7 @@ export default TypeDependency;
 `;
 
 exports[`Taro > jsx > Typescript Test > use-style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -6923,8 +6841,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > use-style-and-css 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -6953,8 +6870,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > jsx > Typescript Test > use-style-outside-component 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Button, View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -7347,8 +7263,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > svelte > Javascript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -7365,8 +7280,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > svelte > Javascript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyComponent(props) {
@@ -7766,8 +7680,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > svelte > Typescript Test > slots 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { View, Text } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {
@@ -7784,8 +7697,7 @@ export default MyComponent;
 `;
 
 exports[`Taro > svelte > Typescript Test > style 1`] = `
-"\\"use client\\";
-import * as React from \\"react\\";
+"import * as React from \\"react\\";
 import { Input } from \\"@tarojs/components\\";
 
 function MyComponent(props: any) {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -306,7 +306,7 @@ const needsUseClient = (json: MitosisComponent) => {
   });
 
   return foundEventListener;
-}
+};
 
 const _componentToReact = (
   json: MitosisComponent,
@@ -521,7 +521,12 @@ const _componentToReact = (
   const isRsc = options.rsc && json.meta.useMetadata?.rsc?.componentType === 'server';
   const isNative = options.type === 'native';
   const isPreact = options.preact;
-  const shouldAddUseClientDirective = options.addUseClientDirectiveIfNeeded && !isRsc && !isNative && !isPreact && needsUseClient(json);
+  const shouldAddUseClientDirective =
+    options.addUseClientDirectiveIfNeeded &&
+    !isRsc &&
+    !isNative &&
+    !isPreact &&
+    needsUseClient(json);
 
   const str = dedent`
   ${shouldAddUseClientDirective ? `'use client';` : ''}

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -285,7 +285,6 @@ const getPropsDefinition = ({ json }: { json: MitosisComponent }) => {
   return `${json.name}.defaultProps = {${defaultPropsString}};`;
 };
 
-
 const _componentToReact = (
   json: MitosisComponent,
   options: ToReactOptions,

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -2,7 +2,6 @@ import { types } from '@babel/core';
 import hash from 'hash-sum';
 import json5 from 'json5';
 import { format } from 'prettier/standalone';
-import { isMitosisNode } from 'src/helpers/is-mitosis-node';
 import traverse from 'traverse';
 import { createSingleBinding } from '../../helpers/bindings';
 import { createMitosisNode } from '../../helpers/create-mitosis-node';
@@ -16,6 +15,7 @@ import {
 } from '../../helpers/get-state-object-string';
 import { gettersToFunctions } from '../../helpers/getters-to-functions';
 import { handleMissingState } from '../../helpers/handle-missing-state';
+import { isMitosisNode } from '../../helpers/is-mitosis-node';
 import { isRootTextNode } from '../../helpers/is-root-text-node';
 import { mapRefs } from '../../helpers/map-refs';
 import { initializeOptions } from '../../helpers/merge-options';

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -286,6 +286,9 @@ const getPropsDefinition = ({ json }: { json: MitosisComponent }) => {
   return `${json.name}.defaultProps = {${defaultPropsString}};`;
 };
 
+// Test if a react component is a client component and needs
+// "use client" by seeing if it has any client-only features
+// like refs, effects, state, or event listeners
 const needsUseClient = (json: MitosisComponent) => {
   if (json.hooks.onMount?.code) return true;
   if (json.hooks.onUnMount?.code) return true;

--- a/packages/core/src/generators/rsc.ts
+++ b/packages/core/src/generators/rsc.ts
@@ -53,16 +53,26 @@ const RSC_TRANSFORM_PLUGIN: Plugin = () => ({
   },
 });
 
-const checkIfIsRsc = (json: MitosisComponent) => {
-  if (json.hooks.onMount) return false;
-  if (json.hooks.onUnMount) return false;
-  if (json.hooks.onUpdate) return false;
-  if (Object.keys(json.refs).length) return false;
-  if (Object.keys(json.context.get).length) return false;
-  if (Object.keys(json.context.set).length) return false;
-  if (Object.values(json.state).filter((s) => s?.type === 'property').length) return false;
+export const checkIfIsClientComponent = (json: MitosisComponent) => {
+  if (json.hooks.onMount?.code) return true;
+  if (json.hooks.onUnMount?.code) return true;
+  if (json.hooks.onUpdate?.length) return true;
+  if (Object.keys(json.refs).length) return true;
+  if (Object.keys(json.context.set).length) return true;
+  if (Object.keys(json.context.get).length) return true;
+  if (Object.values(json.state).filter((s) => s?.type === 'property').length) return true;
 
-  return true;
+  let foundEventListener = false;
+  traverse(json).forEach(function (node) {
+    if (isMitosisNode(node)) {
+      if (Object.keys(node.bindings).filter((item) => item.startsWith('on')).length) {
+        foundEventListener = true;
+        this.stop();
+      }
+    }
+  });
+
+  return foundEventListener;
 };
 
 const RscOptions: Partial<ToRscOptions> = {
@@ -75,7 +85,7 @@ export const componentToRsc: TranspilerGenerator<Partial<ToRscOptions>> =
   ({ component, path }) => {
     if (
       !checkIsDefined(component.meta.useMetadata?.rsc?.componentType) &&
-      checkIfIsRsc(component)
+      !checkIfIsClientComponent(component)
     ) {
       component.meta.useMetadata = {
         ...component.meta.useMetadata,


### PR DESCRIPTION
for react, we are blanket adding "use client" nearly everywhere. in most cases, we do not want this. react native and preact should never have it, and any component without client only hooks or event listeners shouldn't have it either