### PR TITLE
chore: remove use of soon to be deprecated method

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,7 @@
     "@builder.io/react": "^1.1.50",
     "astring": "^1.8.3",
     "csstype": "^3.0.4",
+    "estree-walker": "^3.0.3",
     "fp-ts": "^2.11.10",
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",

--- a/packages/core/src/parsers/svelte/html/index.ts
+++ b/packages/core/src/parsers/svelte/html/index.ts
@@ -1,4 +1,4 @@
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 import type { MitosisNode } from '../../../types/mitosis-node';
 
 import { parseEach } from './each';

--- a/packages/core/src/parsers/svelte/instance/functions.ts
+++ b/packages/core/src/parsers/svelte/instance/functions.ts
@@ -2,7 +2,7 @@ import { isAssignmentExpression, isIdentifier, isUpdateExpression } from '@babel
 import { generate } from 'astring';
 import type { CallExpression, FunctionDeclaration, Identifier } from 'estree';
 import { capitalize } from 'lodash';
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 import { stripQuotes } from '../helpers/string';
 
 import type { SveltosisComponent } from '../types';

--- a/packages/core/src/parsers/svelte/instance/index.ts
+++ b/packages/core/src/parsers/svelte/instance/index.ts
@@ -1,5 +1,5 @@
 import { generate } from 'astring';
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 
 import { parseGetContext, parseHasContext, parseSetContext } from './context';
 import { parseMemberExpression } from './expressions';

--- a/packages/core/src/parsers/svelte/module/index.ts
+++ b/packages/core/src/parsers/svelte/module/index.ts
@@ -1,5 +1,5 @@
 import { generate } from 'astring';
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 
 import type { BaseNode, ExportNamedDeclaration, Identifier, VariableDeclaration } from 'estree';
 import type { Ast } from 'svelte/types/compiler/interfaces';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,6 +2351,7 @@ __metadata:
     astring: ^1.8.3
     concurrently: ^8.2.2
     csstype: ^3.0.4
+    estree-walker: ^3.0.3
     fp-ts: ^2.11.10
     fs-extra-promise: ^1.0.1
     hash-sum: ^2.0.0


### PR DESCRIPTION
We've removed this method from Svelte 5