### PR TITLE
chore: stop GitHub highlighting comments in json as errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+*.json linguist-language=JSON-with-Comments
+
 /.yarn/releases/** binary
 /.yarn/plugins/** binary


### PR DESCRIPTION
GitHub also highlights comments in json as errors by default.  Adding the following to  `.gitattributes` stops that.

```
*.json  linguist-language=JSON-with-Comments
```

Makes project readme prettier on github.

Other possibilities discussed here:
https://github.com/microsoft/rushstack/issues/1088
