### PR TITLE
Fix/comments with quotes

### DIFF
--- a/packages/core/src/__tests__/data/comments-with-quotes.raw.tsx
+++ b/packages/core/src/__tests__/data/comments-with-quotes.raw.tsx
@@ -1,0 +1,29 @@
+import { useStore } from "@builder.io/mitosis";
+
+export default function MyComponent(props) {
+  const state = useStore({
+    name: "Steve",
+    // can't be compiled
+    handleFn() {}
+  });
+
+    function doSomething() {
+    console.log("This is a aa");
+  }
+
+  
+  return (
+    <div>
+      <input
+        css={{
+          color: "red",
+        }}
+        value={state.name}
+        onChange={(event) => { state.name = event.target.value }}
+        onClick={() => doSomething()}
+      />
+      Hello
+      {state.name}! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/test-generator.ts
+++ b/packages/core/src/__tests__/test-generator.ts
@@ -34,6 +34,7 @@ const basicForwardRefMetadata = getRawFile('./data/basic-forwardRef-metadata.raw
 const basicRefPrevious = getRawFile('./data/basic-ref-usePrevious.raw.tsx');
 const basicRefAssignment = getRawFile('./data/basic-ref-assignment.raw.tsx');
 const propsDestructure = getRawFile('./data/basic-props-destructure.raw.tsx');
+const commentsWithQuotes = getRawFile('./data/comments-with-quotes.raw.tsx');
 const nestedStyles = getRawFile('./data/nested-styles.raw.tsx');
 const preserveExportOrLocalStatement = getRawFile(
   './data/basic-preserve-export-or-local-statement.raw.tsx',
@@ -203,6 +204,7 @@ const BASIC_TESTS: Tests = {
   spreadAttrs,
   spreadNestedProps,
   spreadProps,
+  commentsWithQuotes, 
   renderContentExample,
   arrowFunctionInUseStore,
   expressionState,

--- a/packages/core/src/parsers/jsx/helpers.ts
+++ b/packages/core/src/parsers/jsx/helpers.ts
@@ -13,8 +13,8 @@ export const uncapitalize = (str: string) => {
   return str[0].toLowerCase() + str.slice(1);
 };
 
-export const parseCode = (node: babel.types.Node) => {
-  return generate(node).code;
+export const parseCode = (node: babel.types.Node, opts?: babel.GeneratorOptions) => {
+  return generate(node, opts).code;
 };
 
 export const parseCodeJson = (node: babel.types.Node) => {

--- a/packages/core/src/parsers/jsx/state.ts
+++ b/packages/core/src/parsers/jsx/state.ts
@@ -226,22 +226,22 @@ export const parseStateObjectToMitosisState = (
   isState: boolean = true, // parse state or defaultProps
 ): MitosisState => {
   const state: MitosisState = {};
-  object.properties.forEach((x) => {
-    if (types.isSpreadElement(x)) {
-      throw new Error('Parse Error: Mitosis cannot consume spread element in state object: ' + x);
+  object.properties.forEach((node) => {
+    if (types.isSpreadElement(node)) {
+      throw new Error('Parse Error: Mitosis cannot consume spread element in state object: ' + node);
     }
 
-    if (types.isPrivateName(x.key)) {
-      throw new Error('Parse Error: Mitosis cannot consume private name in state object: ' + x.key);
+    if (types.isPrivateName(node.key)) {
+      throw new Error('Parse Error: Mitosis cannot consume private name in state object: ' + node.key);
     }
 
-    if (!types.isIdentifier(x.key)) {
+    if (!types.isIdentifier(node.key)) {
       throw new Error(
-        'Parse Error: Mitosis cannot consume non-identifier key in state object: ' + x.key,
+        'Parse Error: Mitosis cannot consume non-identifier key in state object: ' + node.key,
       );
     }
 
-    state[x.key.name] = isState ? processStateObjectSlice(x) : processDefaultPropsSlice(x);
+    state[node.key.name] = isState ? processStateObjectSlice(node) : processDefaultPropsSlice(node);
   });
 
   return state;

--- a/packages/core/src/parsers/jsx/state.ts
+++ b/packages/core/src/parsers/jsx/state.ts
@@ -169,7 +169,7 @@ const processStateObjectSlice = (
       };
     }
   } else if (types.isObjectMethod(item)) {
-    const n = parseCode({ ...item, returnType: null }).trim();
+    const n = parseCode({ ...item, returnType: null }, { comments: false }).trim();
 
     const isGetter = item.kind === 'get';
 


### PR DESCRIPTION
## Description

Add a short description of:
- Passed `{ comments: false }` to `parseCode`, 
- The reason was adding quotes in a comment would break the parser, more context check #613 and #250 (#250 is more broad, this fix is focused on #613)

