### PR TITLE
fix: remove unnecessary import of "solid-styled-components"

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -60,8 +60,6 @@ export default MyBasicRefComponent;
 exports[`Solid > jsx > Javascript Test > AdvancedRef 2`] = `
 "import { Show, on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicRefComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -201,8 +199,6 @@ export default MyBasicForShowComponent;
 exports[`Solid > jsx > Javascript Test > Basic 3`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 export const DEFAULT_VALUES = {
   name: \\"Steve\\",
 };
@@ -242,8 +238,6 @@ export default MyBasicComponent;
 
 exports[`Solid > jsx > Javascript Test > Basic 4`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForShowComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
@@ -318,8 +312,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > Basic Context 2`] = `
 "import { useContext, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
 
 function MyBasicComponent(props) {
@@ -381,8 +373,6 @@ export default MyBasicOnMountUpdateComponent;
 exports[`Solid > jsx > Javascript Test > Basic OnMount Update 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOnMountUpdateComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -427,8 +417,6 @@ export default MyBasicOutputsComponent;
 exports[`Solid > jsx > Javascript Test > Basic Outputs 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOutputsComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -469,8 +457,6 @@ export default MyBasicOutputsComponent;
 exports[`Solid > jsx > Javascript Test > Basic Outputs Meta 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOutputsComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -500,9 +486,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > BasicAttribute 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <input autocapitalize=\\"on\\" autocomplete=\\"on\\" spellcheck={true} />
@@ -539,8 +523,6 @@ export default MyBooleanAttribute;
 
 exports[`Solid > jsx > Javascript Test > BasicBooleanAttribute 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
@@ -598,8 +580,6 @@ export default MyBasicChildComponent;
 
 exports[`Solid > jsx > Javascript Test > BasicChildComponent 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
 import MyBasicComponent from \\"./basic.raw\\";
@@ -670,8 +650,6 @@ export default MyBasicForComponent;
 
 exports[`Solid > jsx > Javascript Test > BasicFor 2`] = `
 "import { For, onMount, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
@@ -767,8 +745,6 @@ export default MyBasicRefComponent;
 exports[`Solid > jsx > Javascript Test > BasicRef 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicRefComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -846,8 +822,6 @@ export default MyBasicRefAssignmentComponent;
 exports[`Solid > jsx > Javascript Test > BasicRefAssignment 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicRefAssignmentComponent(props) {
   function handlerClick(event) {
     event.preventDefault();
@@ -910,8 +884,6 @@ export default MyPreviousComponent;
 
 exports[`Solid > jsx > Javascript Test > BasicRefPrevious 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 export function usePrevious(value) {
   // The ref object is a generic container whose current property is mutable ...
@@ -982,8 +954,6 @@ export default Button;
 
 exports[`Solid > jsx > Javascript Test > Button 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function Button(props) {
   return (
@@ -1085,8 +1055,6 @@ export default Column;
 exports[`Solid > jsx > Javascript Test > Columns 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Column(props) {
   function getColumns() {
     return props.columns || [];
@@ -1172,9 +1140,7 @@ export default ContentSlotCode;
 `;
 
 exports[`Solid > jsx > Javascript Test > ContentSlotHtml 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function ContentSlotCode(props) {
+"function ContentSlotCode(props) {
   return (
     <>
       <div>
@@ -1237,8 +1203,6 @@ export default ContentSlotJsxCode;
 
 exports[`Solid > jsx > Javascript Test > ContentSlotJSX 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function ContentSlotJsxCode(props) {
   const [name, setName] = createSignal(\\"king\\");
@@ -1353,8 +1317,6 @@ export default CustomCode;
 
 exports[`Solid > jsx > Javascript Test > CustomCode 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function CustomCode(props) {
   const [scriptsInserted, setScriptsInserted] = createSignal([]);
@@ -1499,8 +1461,6 @@ export default CustomCode;
 
 exports[`Solid > jsx > Javascript Test > Embed 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function CustomCode(props) {
   const [scriptsInserted, setScriptsInserted] = createSignal([]);
@@ -1878,8 +1838,6 @@ export default FormComponent;
 
 exports[`Solid > jsx > Javascript Test > Form 2`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import { Builder, builder } from \\"@builder.io/sdk\\";
 import {
@@ -2272,8 +2230,6 @@ export default Image;
 exports[`Solid > jsx > Javascript Test > Image 2`] = `
 "import { Show, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Image(props) {
   const [scrollListener, setScrollListener] = createSignal(null);
 
@@ -2393,8 +2349,6 @@ export default ImgStateComponent;
 exports[`Solid > jsx > Javascript Test > Image State 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function ImgStateComponent(props) {
   const [canShow, setCanShow] = createSignal(true);
 
@@ -2445,9 +2399,7 @@ export default ImgComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > Img 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import { Builder } from \\"@builder.io/sdk\\";
+"import { Builder } from \\"@builder.io/sdk\\";
 
 function ImgComponent(props) {
   return (
@@ -2498,9 +2450,7 @@ export default FormInputComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > Input 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import { Builder } from \\"@builder.io/sdk\\";
+"import { Builder } from \\"@builder.io/sdk\\";
 
 function FormInputComponent(props) {
   return (
@@ -2554,8 +2504,6 @@ export default Stepper;
 exports[`Solid > jsx > Javascript Test > InputParent 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props) {
@@ -2593,9 +2541,7 @@ export default RawText;
 `;
 
 exports[`Solid > jsx > Javascript Test > RawText 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function RawText(props) {
+"function RawText(props) {
   return (
     <>
       <span
@@ -2666,9 +2612,7 @@ export default SectionStateComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > Section 3`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SectionComponent(props) {
+"function SectionComponent(props) {
   return (
     <>
       <section
@@ -2693,8 +2637,6 @@ export default SectionComponent;
 
 exports[`Solid > jsx > Javascript Test > Section 4`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function SectionStateComponent(props) {
   const [max, setMax] = createSignal(42);
@@ -2767,8 +2709,6 @@ export default SelectComponent;
 exports[`Solid > jsx > Javascript Test > Select 2`] = `
 "import { For } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import { Builder } from \\"@builder.io/sdk\\";
 
 function SelectComponent(props) {
@@ -2820,9 +2760,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Javascript Test > SlotDefault 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SlotCode(props) {
+"function SlotCode(props) {
   return (
     <>
       <div>
@@ -2856,9 +2794,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Javascript Test > SlotHtml 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
   return (
@@ -2892,9 +2828,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Javascript Test > SlotJsx 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import ContentSlotCode from \\"./content-slot-jsx.raw\\";
+"import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
   return (
@@ -2926,9 +2860,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Javascript Test > SlotNamed 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SlotCode(props) {
+"function SlotCode(props) {
   return (
     <>
       <div>
@@ -3056,8 +2988,6 @@ export default SmileReviews;
 exports[`Solid > jsx > Javascript Test > Stamped.io 2`] = `
 "import { Show, For, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import { kebabCase, snakeCase } from \\"lodash\\";
 
 function SmileReviews(props) {
@@ -3176,9 +3106,7 @@ export default SubmitButton;
 `;
 
 exports[`Solid > jsx > Javascript Test > Submit 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SubmitButton(props) {
+"function SubmitButton(props) {
   return (
     <>
       <button type=\\"submit\\" {...props.attributes}>
@@ -3222,8 +3150,6 @@ export default Text;
 
 exports[`Solid > jsx > Javascript Test > Text 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -3270,9 +3196,7 @@ export default Textarea;
 `;
 
 exports[`Solid > jsx > Javascript Test > Textarea 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function Textarea(props) {
+"function Textarea(props) {
   return (
     <>
       <textarea
@@ -3321,9 +3245,7 @@ export default Video;
 `;
 
 exports[`Solid > jsx > Javascript Test > Video 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function Video(props) {
+"function Video(props) {
   return (
     <>
       <video
@@ -3382,8 +3304,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Javascript Test > arrowFunctionInUseStore 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [name, setName] = createSignal(\\"steve\\");
@@ -3451,8 +3371,6 @@ export default MyBasicForNoTagRefComponent;
 exports[`Solid > jsx > Javascript Test > basicForNoTagReference 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 import { Dynamic } from \\"solid-js/web\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForNoTagRefComponent(props) {
   const [name, setName] = createSignal(\\"VincentW\\");
@@ -3529,8 +3447,6 @@ export default MyBasicOnUpdateReturnComponent;
 exports[`Solid > jsx > Javascript Test > basicOnUpdateReturn 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOnUpdateReturnComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -3589,9 +3505,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > class + ClassName + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div class=\\"test2 test div-6b6c27cc\\">
@@ -3633,9 +3547,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > class + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div class=\\"test div-fb8d32e6\\">
@@ -3677,9 +3589,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > className + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div class=\\"test div-fb8d32e6\\">
@@ -3718,8 +3628,6 @@ export default ClassNameCode;
 
 exports[`Solid > jsx > Javascript Test > className 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function ClassNameCode(props) {
   const [bindings, setBindings] = createSignal(\\"a binding\\");
@@ -3772,8 +3680,6 @@ export default MyBasicComponent;
 
 exports[`Solid > jsx > Javascript Test > classState 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicComponent(props) {
   const [classState, setClassState] = createSignal(\\"testClassName\\");
@@ -3838,8 +3744,6 @@ export default ComponentWithContext;
 
 exports[`Solid > jsx > Javascript Test > componentWithContext 2`] = `
 "import { useContext } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
@@ -3916,8 +3820,6 @@ export default ComponentWithContext;
 exports[`Solid > jsx > Javascript Test > componentWithContextMultiRoot 2`] = `
 "import { useContext } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
 
@@ -3975,9 +3877,7 @@ export default RenderContent;
 `;
 
 exports[`Solid > jsx > Javascript Test > contentState 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import BuilderContext from \\"@dummy/context.js\\";
+"import BuilderContext from \\"@dummy/context.js\\";
 
 function RenderContent(props) {
   return (
@@ -4032,8 +3932,6 @@ export default Button;
 
 exports[`Solid > jsx > Javascript Test > defaultProps 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function Button(props) {
   return (
@@ -4101,8 +3999,6 @@ export default Button;
 exports[`Solid > jsx > Javascript Test > defaultPropsOutsideComponent 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Button(props) {
   return (
     <>
@@ -4154,9 +4050,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`Solid > jsx > Javascript Test > defaultValsWithTypes 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-const DEFAULT_VALUES = {
+"const DEFAULT_VALUES = {
   name: \\"Sami\\",
 };
 
@@ -4193,8 +4087,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Javascript Test > expressionState 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [refToUse, setRefToUse] = createSignal(
@@ -4239,8 +4131,6 @@ export default RenderContent;
 exports[`Solid > jsx > Javascript Test > import types 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import RenderBlock from \\"./builder-render-block.raw\\";
 
 function RenderContent(props) {
@@ -4277,8 +4167,6 @@ export default MultipleOnUpdate;
 
 exports[`Solid > jsx > Javascript Test > multipleOnUpdate 2`] = `
 "import { on, createEffect } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MultipleOnUpdate(props) {
   return (
@@ -4331,8 +4219,6 @@ export default MultipleOnUpdateWithDeps;
 
 exports[`Solid > jsx > Javascript Test > multipleOnUpdateWithDeps 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MultipleOnUpdateWithDeps(props) {
   const [a, setA] = createSignal(\\"a\\");
@@ -4390,8 +4276,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > multipleSpreads 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicComponent(props) {
   const [attrs, setAttrs] = createSignal({
     hello: \\"world\\",
@@ -4427,8 +4311,6 @@ export default NestedShow;
 
 exports[`Solid > jsx > Javascript Test > nestedShow 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function NestedShow(props) {
   return (
@@ -4486,9 +4368,7 @@ export default NestedStyles;
 `;
 
 exports[`Solid > jsx > Javascript Test > nestedStyles 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function NestedStyles(props) {
+"function NestedStyles(props) {
   return (
     <>
       <div class=\\"div-7ff9918d\\">Hello world</div>
@@ -4564,8 +4444,6 @@ export default Embed;
 exports[`Solid > jsx > Javascript Test > onEvent 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Embed(props) {
   function foo(event) {
     console.log(\\"test2\\");
@@ -4617,8 +4495,6 @@ export default OnInit;
 exports[`Solid > jsx > Javascript Test > onInit & onMount 2`] = `
 "import { onMount } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function OnInit(props) {
   onMount(() => {
     console.log(\\"onMount\\");
@@ -4660,8 +4536,6 @@ export default OnInit;
 exports[`Solid > jsx > Javascript Test > onInit 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 export const defaultValues = {
   name: \\"PatrickJS\\",
 };
@@ -4700,8 +4574,6 @@ export default Comp;
 
 exports[`Solid > jsx > Javascript Test > onMount 2`] = `
 "import { onMount } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function Comp(props) {
   onMount(() => {
@@ -4743,8 +4615,6 @@ export default Comp;
 exports[`Solid > jsx > Javascript Test > onMountMultiple 2`] = `
 "import { onMount } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Comp(props) {
   onMount(() => {
     console.log(\\"Runs on mount\\");
@@ -4781,8 +4651,6 @@ export default OnUpdate;
 exports[`Solid > jsx > Javascript Test > onUpdate 2`] = `
 "import { on, createEffect } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function OnUpdate(props) {
   return (
     <>
@@ -4817,8 +4685,6 @@ export default OnUpdateWithDeps;
 
 exports[`Solid > jsx > Javascript Test > onUpdateWithDeps 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function OnUpdateWithDeps(props) {
   const [a, setA] = createSignal(\\"a\\");
@@ -4857,9 +4723,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > preserveExportOrLocalStatement 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-const b = 3;
+"const b = 3;
 const foo = () => {};
 export const a = 3;
 export const bar = () => {};
@@ -4892,9 +4756,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > preserveTyping 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div>
@@ -4931,8 +4793,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Javascript Test > propsDestructure 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicComponent(props) {
   const [name, setName] = createSignal(\\"Decadef20\\");
 
@@ -4966,9 +4826,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > propsInterface 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div>
@@ -4998,9 +4856,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > propsType 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <div>
@@ -5038,8 +4894,6 @@ export default OnUpdate;
 
 exports[`Solid > jsx > Javascript Test > referencingFunInsideHook 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function OnUpdate(props) {
   function foo(params) {}
@@ -5338,8 +5192,6 @@ export default RenderBlock;
 exports[`Solid > jsx > Javascript Test > renderBlock 2`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
 import { Dynamic } from \\"solid-js/web\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import { TARGET } from \\"../../constants/target.js\\";
 import { evaluate } from \\"../../functions/evaluate.js\\";
@@ -5666,8 +5518,6 @@ export default RenderContent;
 exports[`Solid > jsx > Javascript Test > renderContentExample 2`] = `
 "import { onMount, on, createEffect } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import BuilderContext from \\"@dummy/context.js\\";
 import {
   dispatchNewContentToVisualEditor,
@@ -5751,8 +5601,6 @@ export default Button;
 exports[`Solid > jsx > Javascript Test > rootFragmentMultiNode 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Button(props) {
   return (
     <>
@@ -5798,8 +5646,6 @@ export default RenderStyles;
 exports[`Solid > jsx > Javascript Test > rootShow 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function RenderStyles(props) {
   return (
     <>
@@ -5834,8 +5680,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Javascript Test > self-referencing component 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   return (
@@ -5877,8 +5721,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Javascript Test > self-referencing component with children 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   return (
@@ -5923,8 +5765,6 @@ export default NestedShow;
 exports[`Solid > jsx > Javascript Test > showWithFor 2`] = `
 "import { Show, For } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function NestedShow(props) {
   return (
     <>
@@ -5962,8 +5802,6 @@ export default ShowRootText;
 exports[`Solid > jsx > Javascript Test > showWithRootText 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function ShowRootText(props) {
   return (
     <>
@@ -5988,9 +5826,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > spreadAttrs 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <input {...attrs} />
@@ -6012,9 +5848,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > spreadNestedProps 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <input {...props.nested} />
@@ -6036,9 +5870,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > spreadProps 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props) {
+"function MyBasicComponent(props) {
   return (
     <>
       <input {...props} />
@@ -6076,9 +5908,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > styleClassAndCss 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <div
@@ -6127,9 +5957,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Solid > jsx > Javascript Test > stylePropClassAndCss 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function StylePropClassAndCss(props) {
+"function StylePropClassAndCss(props) {
   return (
     <>
       <div
@@ -6163,9 +5991,7 @@ export default SubComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > subComponent 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import Foo from \\"./foo-sub-component\\";
+"import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props) {
   return (
@@ -6212,9 +6038,7 @@ export default SvgComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > svgComponent 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SvgComponent(props) {
+"function SvgComponent(props) {
   return (
     <>
       <svg
@@ -6257,9 +6081,7 @@ export default TypeDependency;
 `;
 
 exports[`Solid > jsx > Javascript Test > typeDependency 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function TypeDependency(props) {
+"function TypeDependency(props) {
   return (
     <>
       <div>{props.foo}</div>
@@ -6296,9 +6118,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > use-style 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <button type=\\"button\\">Button</button>
@@ -6349,9 +6169,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > use-style-and-css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <button class=\\"button-11144e0c\\" type=\\"button\\">
@@ -6401,9 +6219,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Javascript Test > use-style-outside-component 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <button type=\\"button\\">Button</button>
@@ -6446,8 +6262,6 @@ export default UseTargetComponent;
 exports[`Solid > jsx > Javascript Test > useTarget 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function UseTargetComponent(props) {
   const [lastName, setLastName] = createSignal(\\"bar\\");
 
@@ -6489,8 +6303,6 @@ export default MyBasicComponent;
 
 exports[`Solid > jsx > Remove Internal mitosis package 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicComponent(props) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
@@ -6572,7 +6384,6 @@ export default MyBasicRefComponent;
 exports[`Solid > jsx > Typescript Test > AdvancedRef 2`] = `
 "import { Show, on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface Props {
   showInput: boolean;
 }
@@ -6719,7 +6530,6 @@ export default MyBasicForShowComponent;
 exports[`Solid > jsx > Typescript Test > Basic 3`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface MyBasicComponentProps {
   id: string;
 }
@@ -6763,8 +6573,6 @@ export default MyBasicComponent;
 
 exports[`Solid > jsx > Typescript Test > Basic 4`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForShowComponent(props: any) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
@@ -6839,8 +6647,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Typescript Test > Basic Context 2`] = `
 "import { useContext, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
 
 function MyBasicComponent(props: any) {
@@ -6907,7 +6713,6 @@ export default MyBasicOnMountUpdateComponent;
 exports[`Solid > jsx > Typescript Test > Basic OnMount Update 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface Props {
   hi: string;
   bye: string;
@@ -6957,8 +6762,6 @@ export default MyBasicOutputsComponent;
 exports[`Solid > jsx > Typescript Test > Basic Outputs 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOutputsComponent(props: any) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -6999,8 +6802,6 @@ export default MyBasicOutputsComponent;
 exports[`Solid > jsx > Typescript Test > Basic Outputs Meta 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOutputsComponent(props: any) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -7030,9 +6831,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > BasicAttribute 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <input autocapitalize=\\"on\\" autocomplete=\\"on\\" spellcheck={true} />
@@ -7075,7 +6874,6 @@ export default MyBooleanAttribute;
 exports[`Solid > jsx > Typescript Test > BasicBooleanAttribute 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   children: any;
   type: string;
@@ -7137,8 +6935,6 @@ export default MyBasicChildComponent;
 
 exports[`Solid > jsx > Typescript Test > BasicChildComponent 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
 import MyBasicComponent from \\"./basic.raw\\";
@@ -7209,8 +7005,6 @@ export default MyBasicForComponent;
 
 exports[`Solid > jsx > Typescript Test > BasicFor 2`] = `
 "import { For, onMount, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForComponent(props: any) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
@@ -7309,7 +7103,6 @@ export default MyBasicRefComponent;
 exports[`Solid > jsx > Typescript Test > BasicRef 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface Props {
   showInput: boolean;
 }
@@ -7395,7 +7188,6 @@ export default MyBasicRefAssignmentComponent;
 exports[`Solid > jsx > Typescript Test > BasicRefAssignment 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface Props {
   showInput: boolean;
 }
@@ -7467,7 +7259,6 @@ export default MyPreviousComponent;
 exports[`Solid > jsx > Typescript Test > BasicRefPrevious 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface Props {
   showInput: boolean;
 }
@@ -7549,7 +7340,6 @@ export default Button;
 exports[`Solid > jsx > Typescript Test > Button 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ButtonProps {
   attributes?: any;
   text?: string;
@@ -7671,7 +7461,6 @@ export default Column;
 exports[`Solid > jsx > Typescript Test > Columns 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Column = {
   content: any; // TODO: Implement this when support for dynamic CSS lands
 
@@ -7779,8 +7568,7 @@ export default ContentSlotCode;
 `;
 
 exports[`Solid > jsx > Typescript Test > ContentSlotHtml 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   [key: string]: string | JSX.Element;
   slotTesting: JSX.Element;
 };
@@ -7857,7 +7645,6 @@ export default ContentSlotJsxCode;
 exports[`Solid > jsx > Typescript Test > ContentSlotJSX 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   [key: string]: string | JSX.Element;
 };
@@ -7983,7 +7770,6 @@ export default CustomCode;
 exports[`Solid > jsx > Typescript Test > CustomCode 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface CustomCodeProps {
   code: string;
   replaceNodes?: boolean;
@@ -8138,7 +7924,6 @@ export default CustomCode;
 exports[`Solid > jsx > Typescript Test > Embed 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface CustomCodeProps {
   code: string;
   replaceNodes?: boolean;
@@ -8551,7 +8336,6 @@ export default FormComponent;
 exports[`Solid > jsx > Typescript Test > Form 2`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface FormProps {
   attributes?: any;
   name?: string;
@@ -8992,7 +8776,6 @@ export default Image;
 exports[`Solid > jsx > Typescript Test > Image 2`] = `
 "import { Show, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 // TODO: AMP Support?
 export interface ImageProps {
   _class?: string;
@@ -9131,8 +8914,6 @@ export default ImgStateComponent;
 exports[`Solid > jsx > Typescript Test > Image State 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function ImgStateComponent(props: any) {
   const [canShow, setCanShow] = createSignal(true);
 
@@ -9200,8 +8981,7 @@ export default ImgComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > Img 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface ImgProps {
+"export interface ImgProps {
   attributes?: any;
   imgSrc?: string;
   altText?: string;
@@ -9280,8 +9060,7 @@ export default FormInputComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > Input 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface FormInputProps {
+"export interface FormInputProps {
   type?: string;
   attributes?: any;
   name?: string;
@@ -9346,8 +9125,6 @@ export default Stepper;
 exports[`Solid > jsx > Typescript Test > InputParent 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props: any) {
@@ -9390,8 +9167,7 @@ export default RawText;
 `;
 
 exports[`Solid > jsx > Typescript Test > RawText 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface RawTextProps {
+"export interface RawTextProps {
   attributes?: any;
   text?: string; // builderBlock?: any;
 }
@@ -9479,8 +9255,7 @@ export default SectionStateComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > Section 3`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface SectionProps {
+"export interface SectionProps {
   maxWidth?: number;
   attributes?: any;
   children?: any;
@@ -9512,7 +9287,6 @@ export default SectionComponent;
 exports[`Solid > jsx > Typescript Test > Section 4`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface SectionProps {
   maxWidth?: number;
   attributes?: any;
@@ -9601,7 +9375,6 @@ export default SelectComponent;
 exports[`Solid > jsx > Typescript Test > Select 2`] = `
 "import { For } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface FormSelectProps {
   options?: {
     name?: string;
@@ -9668,8 +9441,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Typescript Test > SlotDefault 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   [key: string]: string;
 };
 
@@ -9711,8 +9483,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Typescript Test > SlotHtml 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   [key: string]: string;
 };
 
@@ -9754,8 +9525,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Typescript Test > SlotJsx 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   [key: string]: string;
 };
 
@@ -9795,8 +9565,7 @@ export default SlotCode;
 `;
 
 exports[`Solid > jsx > Typescript Test > SlotNamed 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   [key: string]: string;
 };
 
@@ -9932,7 +9701,6 @@ export default SmileReviews;
 exports[`Solid > jsx > Typescript Test > Stamped.io 2`] = `
 "import { Show, For, onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type SmileReviewsProps = {
   productId: string;
   apiKey: string;
@@ -10061,8 +9829,7 @@ export default SubmitButton;
 `;
 
 exports[`Solid > jsx > Typescript Test > Submit 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface ButtonProps {
+"export interface ButtonProps {
   attributes?: any;
   text?: string;
 }
@@ -10120,7 +9887,6 @@ export default Text;
 exports[`Solid > jsx > Typescript Test > Text 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface TextProps {
   attributes?: any;
   rtlMode: boolean;
@@ -10182,8 +9948,7 @@ export default Textarea;
 `;
 
 exports[`Solid > jsx > Typescript Test > Textarea 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface TextareaProps {
+"export interface TextareaProps {
   attributes?: any;
   name?: string;
   value?: string;
@@ -10266,8 +10031,7 @@ export default Video;
 `;
 
 exports[`Solid > jsx > Typescript Test > Video 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export interface VideoProps {
+"export interface VideoProps {
   attributes?: any;
   video?: string;
   autoPlay?: boolean;
@@ -10353,8 +10117,6 @@ export default MyComponent;
 exports[`Solid > jsx > Typescript Test > arrowFunctionInUseStore 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   const [name, setName] = createSignal(\\"steve\\");
 
@@ -10421,8 +10183,6 @@ export default MyBasicForNoTagRefComponent;
 exports[`Solid > jsx > Typescript Test > basicForNoTagReference 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 import { Dynamic } from \\"solid-js/web\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicForNoTagRefComponent(props: any) {
   const [name, setName] = createSignal(\\"VincentW\\");
@@ -10499,8 +10259,6 @@ export default MyBasicOnUpdateReturnComponent;
 exports[`Solid > jsx > Typescript Test > basicOnUpdateReturn 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicOnUpdateReturnComponent(props: any) {
   const [name, setName] = createSignal(\\"PatrickJS\\");
 
@@ -10559,9 +10317,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > class + ClassName + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <div class=\\"test2 test div-6b6c27cc\\">
@@ -10603,9 +10359,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > class + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <div class=\\"test div-fb8d32e6\\">
@@ -10647,9 +10401,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > className + css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <div class=\\"test div-fb8d32e6\\">
@@ -10696,7 +10448,6 @@ export default ClassNameCode;
 exports[`Solid > jsx > Typescript Test > className 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   [key: string]: string | JSX.Element;
   slotTesting: JSX.Element;
@@ -10755,8 +10506,6 @@ export default MyBasicComponent;
 
 exports[`Solid > jsx > Typescript Test > classState 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyBasicComponent(props: any) {
   const [classState, setClassState] = createSignal(\\"testClassName\\");
@@ -10826,7 +10575,6 @@ export default ComponentWithContext;
 exports[`Solid > jsx > Typescript Test > componentWithContext 2`] = `
 "import { useContext } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ComponentWithContextProps {
   content: string;
 }
@@ -10910,7 +10658,6 @@ export default ComponentWithContext;
 exports[`Solid > jsx > Typescript Test > componentWithContextMultiRoot 2`] = `
 "import { useContext } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ComponentWithContextProps {
   content: string;
 }
@@ -10972,9 +10719,7 @@ export default RenderContent;
 `;
 
 exports[`Solid > jsx > Typescript Test > contentState 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import BuilderContext from \\"@dummy/context.js\\";
+"import BuilderContext from \\"@dummy/context.js\\";
 
 function RenderContent(props: any) {
   return (
@@ -11040,7 +10785,6 @@ export default Button;
 exports[`Solid > jsx > Typescript Test > defaultProps 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ButtonProps {
   attributes?: any;
   text?: string;
@@ -11125,7 +10869,6 @@ export default Button;
 exports[`Solid > jsx > Typescript Test > defaultPropsOutsideComponent 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ButtonProps {
   attributes?: any;
   text?: string;
@@ -11189,8 +10932,7 @@ export default ComponentWithTypes;
 `;
 
 exports[`Solid > jsx > Typescript Test > defaultValsWithTypes 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Props = {
+"type Props = {
   name: string;
 };
 
@@ -11231,8 +10973,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Typescript Test > expressionState 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [refToUse, setRefToUse] = createSignal(
@@ -11284,7 +11024,6 @@ export default RenderContent;
 exports[`Solid > jsx > Typescript Test > import types 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type RenderContentProps = {
   options?: GetContentOptions;
   content: BuilderContent;
@@ -11328,8 +11067,6 @@ export default MultipleOnUpdate;
 
 exports[`Solid > jsx > Typescript Test > multipleOnUpdate 2`] = `
 "import { on, createEffect } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MultipleOnUpdate(props: any) {
   return (
@@ -11382,8 +11119,6 @@ export default MultipleOnUpdateWithDeps;
 
 exports[`Solid > jsx > Typescript Test > multipleOnUpdateWithDeps 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MultipleOnUpdateWithDeps(props: any) {
   const [a, setA] = createSignal(\\"a\\");
@@ -11441,8 +11176,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Typescript Test > multipleSpreads 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyBasicComponent(props: any) {
   const [attrs, setAttrs] = createSignal({
     hello: \\"world\\",
@@ -11484,7 +11217,6 @@ export default NestedShow;
 exports[`Solid > jsx > Typescript Test > nestedShow 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 interface Props {
   conditionA: boolean;
   conditionB: boolean;
@@ -11546,9 +11278,7 @@ export default NestedStyles;
 `;
 
 exports[`Solid > jsx > Typescript Test > nestedStyles 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function NestedStyles(props: any) {
+"function NestedStyles(props: any) {
   return (
     <>
       <div class=\\"div-7ff9918d\\">Hello world</div>
@@ -11624,8 +11354,6 @@ export default Embed;
 exports[`Solid > jsx > Typescript Test > onEvent 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Embed(props: any) {
   function foo(event) {
     console.log(\\"test2\\");
@@ -11677,8 +11405,6 @@ export default OnInit;
 exports[`Solid > jsx > Typescript Test > onInit & onMount 2`] = `
 "import { onMount } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function OnInit(props: any) {
   onMount(() => {
     console.log(\\"onMount\\");
@@ -11724,7 +11450,6 @@ export default OnInit;
 exports[`Solid > jsx > Typescript Test > onInit 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   name: string;
 };
@@ -11768,8 +11493,6 @@ export default Comp;
 exports[`Solid > jsx > Typescript Test > onMount 2`] = `
 "import { onMount } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Comp(props: any) {
   onMount(() => {
     console.log(\\"Runs on mount\\");
@@ -11810,8 +11533,6 @@ export default Comp;
 exports[`Solid > jsx > Typescript Test > onMountMultiple 2`] = `
 "import { onMount } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function Comp(props: any) {
   onMount(() => {
     console.log(\\"Runs on mount\\");
@@ -11847,8 +11568,6 @@ export default OnUpdate;
 
 exports[`Solid > jsx > Typescript Test > onUpdate 2`] = `
 "import { on, createEffect } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function OnUpdate(props: any) {
   return (
@@ -11889,7 +11608,6 @@ export default OnUpdateWithDeps;
 exports[`Solid > jsx > Typescript Test > onUpdateWithDeps 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   size: string;
 };
@@ -11941,8 +11659,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > preserveExportOrLocalStatement 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Types = {
+"type Types = {
   s: any[];
 };
 interface IPost {
@@ -11998,8 +11715,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > preserveTyping 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export type A = \\"test\\";
+"export type A = \\"test\\";
 export interface C {
   n: \\"test\\";
 }
@@ -12054,7 +11770,6 @@ export default MyBasicComponent;
 exports[`Solid > jsx > Typescript Test > propsDestructure 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   children: any;
   type: string;
@@ -12098,8 +11813,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > propsInterface 2`] = `
-"import { css } from \\"solid-styled-components\\";
-interface Person {
+"interface Person {
   name: string;
   age?: number;
 }
@@ -12139,8 +11853,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > propsType 2`] = `
-"import { css } from \\"solid-styled-components\\";
-type Person = {
+"type Person = {
   name: string;
   age?: number;
 };
@@ -12183,8 +11896,6 @@ export default OnUpdate;
 
 exports[`Solid > jsx > Typescript Test > referencingFunInsideHook 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function OnUpdate(props: any) {
   function foo(params) {}
@@ -12497,7 +12208,6 @@ exports[`Solid > jsx > Typescript Test > renderBlock 2`] = `
 "import { Show, For, createSignal } from \\"solid-js\\";
 import { Dynamic } from \\"solid-js/web\\";
 
-import { css } from \\"solid-styled-components\\";
 export type RenderBlockProps = {
   block: BuilderBlock;
   context: BuilderContextInterface;
@@ -12843,7 +12553,6 @@ export default RenderContent;
 exports[`Solid > jsx > Typescript Test > renderContentExample 2`] = `
 "import { onMount, on, createEffect } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 type Props = {
   customComponents: string[];
   content: {
@@ -12942,7 +12651,6 @@ export default Button;
 exports[`Solid > jsx > Typescript Test > rootFragmentMultiNode 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface ButtonProps {
   attributes?: any;
   text?: string;
@@ -12999,7 +12707,6 @@ export default RenderStyles;
 exports[`Solid > jsx > Typescript Test > rootShow 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 export interface RenderStylesProps {
   foo: string;
 }
@@ -13038,8 +12745,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Typescript Test > self-referencing component 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   return (
@@ -13081,8 +12786,6 @@ export default MyComponent;
 
 exports[`Solid > jsx > Typescript Test > self-referencing component with children 2`] = `
 "import { Show } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   return (
@@ -13132,7 +12835,6 @@ export default NestedShow;
 exports[`Solid > jsx > Typescript Test > showWithFor 2`] = `
 "import { Show, For } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 interface Props {
   conditionA: boolean;
   items: string[];
@@ -13179,7 +12881,6 @@ export default ShowRootText;
 exports[`Solid > jsx > Typescript Test > showWithRootText 2`] = `
 "import { Show } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
 interface Props {
   conditionA: boolean;
 }
@@ -13208,9 +12909,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > spreadAttrs 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <input {...attrs} />
@@ -13232,9 +12931,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > spreadNestedProps 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <input {...props.nested} />
@@ -13256,9 +12953,7 @@ export default MyBasicComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > spreadProps 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyBasicComponent(props: any) {
+"function MyBasicComponent(props: any) {
   return (
     <>
       <input {...props} />
@@ -13296,9 +12991,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > styleClassAndCss 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <div
@@ -13347,9 +13040,7 @@ export default StylePropClassAndCss;
 `;
 
 exports[`Solid > jsx > Typescript Test > stylePropClassAndCss 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function StylePropClassAndCss(props: any) {
+"function StylePropClassAndCss(props: any) {
   return (
     <>
       <div
@@ -13383,9 +13074,7 @@ export default SubComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > subComponent 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-import Foo from \\"./foo-sub-component\\";
+"import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props: any) {
   return (
@@ -13432,9 +13121,7 @@ export default SvgComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > svgComponent 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function SvgComponent(props: any) {
+"function SvgComponent(props: any) {
   return (
     <>
       <svg
@@ -13485,8 +13172,7 @@ export default TypeDependency;
 `;
 
 exports[`Solid > jsx > Typescript Test > typeDependency 2`] = `
-"import { css } from \\"solid-styled-components\\";
-export type TypeDependencyProps = {
+"export type TypeDependencyProps = {
   foo: Foo;
   foo2: Foo2;
 };
@@ -13531,9 +13217,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > use-style 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <button type=\\"button\\">Button</button>
@@ -13584,9 +13268,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > use-style-and-css 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <button class=\\"button-11144e0c\\" type=\\"button\\">
@@ -13636,9 +13318,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > jsx > Typescript Test > use-style-outside-component 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <button type=\\"button\\">Button</button>
@@ -13681,8 +13361,6 @@ export default UseTargetComponent;
 exports[`Solid > jsx > Typescript Test > useTarget 2`] = `
 "import { onMount, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function UseTargetComponent(props: any) {
   const [lastName, setLastName] = createSignal(\\"bar\\");
 
@@ -13724,8 +13402,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > basic 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [name, setName] = createSignal(\\"Steve\\");
@@ -13820,8 +13496,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > bindGroup 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   const [tortilla, setTortilla] = createSignal(\\"Plain\\");
 
@@ -13907,8 +13581,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > bindProperty 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   const [value, setValue] = createSignal(\\"hello\\");
 
@@ -13944,8 +13616,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > classDirective 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [focus, setFocus] = createSignal(true);
@@ -14012,8 +13682,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > each 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   const [numbers, setNumbers] = createSignal([\\"one\\", \\"two\\", \\"three\\"]);
 
@@ -14059,8 +13727,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > eventHandlers 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   function log(msg = \\"hello\\") {
     console.log(msg);
@@ -14096,8 +13762,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > html 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [html, setHtml] = createSignal(\\"<b>bold</b>\\");
@@ -14139,8 +13803,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > ifElse 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [show, setShow] = createSignal(true);
@@ -14189,8 +13851,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > imports 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import Button from \\"./Button\\";
 
 function MyComponent(props) {
@@ -14228,8 +13888,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > lifecycleHooks 2`] = `
 "import { onMount, on, createEffect } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   onMount(() => {
@@ -14272,8 +13930,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Javascript Test > reactive 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props) {
   const [name, setName] = createSignal(\\"Steve\\");
@@ -14341,8 +13997,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > reactiveWithFn 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   const [a, setA] = createSignal(2);
 
@@ -14400,9 +14054,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > svelte > Javascript Test > slots 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <div>
@@ -14446,9 +14098,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > svelte > Javascript Test > style 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props) {
+"function MyComponent(props) {
   return (
     <>
       <input class=\\"form-input\\" />
@@ -14496,8 +14146,6 @@ export default MyComponent;
 exports[`Solid > svelte > Javascript Test > textExpressions 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props) {
   const [a, setA] = createSignal(5);
 
@@ -14540,8 +14188,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > basic 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [name, setName] = createSignal(\\"Steve\\");
@@ -14636,8 +14282,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > bindGroup 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   const [tortilla, setTortilla] = createSignal(\\"Plain\\");
 
@@ -14723,8 +14367,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > bindProperty 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   const [value, setValue] = createSignal(\\"hello\\");
 
@@ -14760,8 +14402,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > classDirective 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [focus, setFocus] = createSignal(true);
@@ -14828,8 +14468,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > each 2`] = `
 "import { For, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   const [numbers, setNumbers] = createSignal([\\"one\\", \\"two\\", \\"three\\"]);
 
@@ -14875,8 +14513,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > eventHandlers 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   function log(msg = \\"hello\\") {
     console.log(msg);
@@ -14912,8 +14548,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > html 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [html, setHtml] = createSignal(\\"<b>bold</b>\\");
@@ -14955,8 +14589,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > ifElse 2`] = `
 "import { Show, createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [show, setShow] = createSignal(true);
@@ -15005,8 +14637,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > imports 2`] = `
 "import { createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 import Button from \\"./Button\\";
 
 function MyComponent(props: any) {
@@ -15044,8 +14674,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > lifecycleHooks 2`] = `
 "import { onMount, on, createEffect } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   onMount(() => {
@@ -15088,8 +14716,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > reactive 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [name, setName] = createSignal(\\"Steve\\");
@@ -15157,8 +14783,6 @@ export default MyComponent;
 exports[`Solid > svelte > Typescript Test > reactiveWithFn 2`] = `
 "import { on, createEffect, createSignal } from \\"solid-js\\";
 
-import { css } from \\"solid-styled-components\\";
-
 function MyComponent(props: any) {
   const [a, setA] = createSignal(2);
 
@@ -15216,9 +14840,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > svelte > Typescript Test > slots 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <div>
@@ -15262,9 +14884,7 @@ export default MyComponent;
 `;
 
 exports[`Solid > svelte > Typescript Test > style 2`] = `
-"import { css } from \\"solid-styled-components\\";
-
-function MyComponent(props: any) {
+"function MyComponent(props: any) {
   return (
     <>
       <input class=\\"form-input\\" />
@@ -15311,8 +14931,6 @@ export default MyComponent;
 
 exports[`Solid > svelte > Typescript Test > textExpressions 2`] = `
 "import { createSignal } from \\"solid-js\\";
-
-import { css } from \\"solid-styled-components\\";
 
 function MyComponent(props: any) {
   const [a, setA] = createSignal(5);

--- a/packages/core/src/generators/solid/index.ts
+++ b/packages/core/src/generators/solid/index.ts
@@ -177,9 +177,9 @@ export const componentToSolid: TranspilerGenerator<Partial<ToSolidOptions>> =
     ${!foundDynamicComponents ? '' : `import { Dynamic } from 'solid-js/web';`}
     ${storeImports.length > 0 ? `import { ${storeImports.join(', ')} } from 'solid-js/store';` : ''}
     ${
-      !componentHasStyles && options.stylesType === 'styled-components'
-        ? ''
-        : `import { css } from "solid-styled-components";`
+      componentHasStyles && options.stylesType === 'styled-components'
+        ? 'import { css } from "solid-styled-components";'
+        : ``
     }
     ${json.types && options.typescript ? json.types.join('\n') : ''}
     ${renderPreComponent({


### PR DESCRIPTION
## Description

Remove unnecessary import of "solid-styled-components"

## Issue

Mitosis will now wrongfully add `import { css } from "solid-styled-components` in generated `Solid` components when `styleType` attribute is set as "style-tag" in `mitosis.config.js` like this:

```javascript
// mitosis.config.js
 solid: {
    stylesType: 'style-tag'
 }
```

## Expected Behavior
Mitosis will only add `import { css } from "solid-styled-components"` when there are style code in `Mitosis jsx` and `styleType` attribute is set as "styled-components"

This PR will fix the issue and make it behave as expected.