### PR TITLE
don't eat text node wrappers that have components, bindings, or properties

### DIFF
--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -4,7 +4,7 @@ import { BuilderContent, BuilderElement } from '@builder.io/sdk';
 import json5 from 'json5';
 import { mapKeys, merge, omit, omitBy, sortBy, upperFirst } from 'lodash';
 import traverse from 'traverse';
-import { MitosisComponent, MitosisState, hashCodeAsString } from '../..';
+import { hashCodeAsString, MitosisComponent, MitosisState } from '../..';
 import { Size, sizeNames, sizes } from '../../constants/media-sizes';
 import { createSingleBinding } from '../../helpers/bindings';
 import { capitalize } from '../../helpers/capitalize';
@@ -128,6 +128,18 @@ const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosi
   }
 
   return styleString;
+};
+
+const hasComponent = (block: BuilderElement) => {
+  return Boolean(block.component?.name);
+};
+
+const hasProperties = (block: BuilderElement) => {
+  return Boolean(block.properties && Object.keys(block.properties).length);
+};
+
+const hasBindings = (block: BuilderElement) => {
+  return Boolean(block.bindings && Object.keys(block.bindings).length);
 };
 
 const hasStyles = (block: BuilderElement) => {
@@ -432,7 +444,13 @@ const componentMappers: {
     };
     const finalTagname = block.tagName || (assumeLink ? 'a' : 'div');
 
-    if ((block.tagName && block.tagName !== 'div') || hasStyles(block)) {
+    if (
+      (block.tagName && block.tagName !== 'div') ||
+      hasStyles(block) ||
+      hasComponent(block) ||
+      hasBindings(block) ||
+      hasProperties(block)
+    ) {
       return createMitosisNode({
         name: finalTagname,
         bindings,

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -4,7 +4,7 @@ import { BuilderContent, BuilderElement } from '@builder.io/sdk';
 import json5 from 'json5';
 import { mapKeys, merge, omit, omitBy, sortBy, upperFirst } from 'lodash';
 import traverse from 'traverse';
-import { hashCodeAsString, MitosisComponent, MitosisState } from '../..';
+import { MitosisComponent, MitosisState, hashCodeAsString } from '../..';
 import { Size, sizeNames, sizes } from '../../constants/media-sizes';
 import { createSingleBinding } from '../../helpers/bindings';
 import { capitalize } from '../../helpers/capitalize';


### PR DESCRIPTION
we have code for converting Builder.io content to Mitosis where we skip simple unstyled wrapper divs around text

we neglected tho to make sure we don't skip (aka gobble) layers that have other important things - like components, properties, or bindings

this should fix this, making sure we only eat parents around text if they are purely a `<div>` tag with no style, properties, component, etc as originally intended

