### PR TITLE
[fix] `preventDefault` in Qwik

### DIFF
--- a/.changeset/late-trees-arrive.md
+++ b/.changeset/late-trees-arrive.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/mitosis": patch
+---
+
+[fix] `preventDefault` in Qwik

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -3285,10 +3285,9 @@ export const SmileReviews = component$((props) => {
             class=\\"textarea-SmileReviews\\"
           ></textarea>
           <button
-            preventdefault:click=\\"\\"
+            preventdefault:click
             class=\\"button-SmileReviews\\"
             onClick$={$((event) => {
-              event.preventDefault();
               state.showReviewPrompt = false;
             })}
           >
@@ -6657,10 +6656,9 @@ export const SmileReviews = component$((props: SmileReviewsProps) => {
             class=\\"textarea-SmileReviews\\"
           ></textarea>
           <button
-            preventdefault:click=\\"\\"
+            preventdefault:click
             class=\\"button-SmileReviews\\"
             onClick$={$((event) => {
-              event.preventDefault();
               state.showReviewPrompt = false;
             })}
           >

--- a/packages/core/src/generators/qwik/helpers/add-prevent-default.ts
+++ b/packages/core/src/generators/qwik/helpers/add-prevent-default.ts
@@ -16,6 +16,10 @@ export function addPreventDefault(json: MitosisComponent) {
             if (node.bindings[key]?.code.includes('.preventDefault()')) {
               const event = key.slice(2).toLowerCase();
               node.properties['preventdefault:' + event] = '';
+              node.bindings[key]!.code = node.bindings[key]!.code.replace(
+                /.*?\.preventDefault\(\);?/,
+                '',
+              ).trim();
             }
           }
         }

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -359,6 +359,10 @@ export class SrcBuilder {
         if (key === 'innerHTML') key = 'dangerouslySetInnerHTML';
         if (key === 'dataSet') return; // ignore
         if (self.isJSX) {
+          if (key.includes(':')) {
+            self.emit(' ', key);
+            return;
+          }
           self.emit(' ', key, '=');
           if (typeof value == 'string' && value.startsWith('"') && value.endsWith('"')) {
             self.emit(value);

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -359,7 +359,7 @@ export class SrcBuilder {
         if (key === 'innerHTML') key = 'dangerouslySetInnerHTML';
         if (key === 'dataSet') return; // ignore
         if (self.isJSX) {
-          if (key.includes(':')) {
+          if (key.includes(':') && value === '') {
             self.emit(' ', key);
             return;
           }

--- a/packages/core/src/generators/qwik/src-generator.ts
+++ b/packages/core/src/generators/qwik/src-generator.ts
@@ -359,7 +359,7 @@ export class SrcBuilder {
         if (key === 'innerHTML') key = 'dangerouslySetInnerHTML';
         if (key === 'dataSet') return; // ignore
         if (self.isJSX) {
-          if (key.includes(':') && value === '') {
+          if (key.includes(':') && value === '""') {
             self.emit(' ', key);
             return;
           }


### PR DESCRIPTION
## Description

This PR updates the `preventDefault` logic for Qwik by:
- removing `=""` from `preventdefault:eventName=""`
- removes any occurrences of `(event*).preventDefault();` inside the handler

For example test,

```jsx
import { useState } from '@builder.io/mitosis';

export default function MyComponent(props) {
  const [name, setName] = useState('Steve');

  return (
    <div>
      <input
        value={name}
        onChange={(event) => {
          event.preventDefault();

          setName(event.target.value);
        }}
      />
      Hello! I can run in React, Vue, Solid, or Liquid!
    </div>
  );
}
```

gives output,

```jsx
import { $, Fragment, component$, h, useStore } from "@builder.io/qwik";

export const MyComponent = component$((props) => {
  const state = useStore({ name: "Steve" });

  return (
    <div>
      <input
        preventdefault:change
        value={state.name}
        onChange$={$((event) => {
          state.name = event.target.value;
        })}
      />
      Hello! I can run in React, Vue, Solid, or Liquid!
    </div>
  );
});

export default MyComponent;

```
