### PR TITLE
 fix for issue No #1350

### DIFF
--- a/packages/core/src/helpers/slots.ts
+++ b/packages/core/src/helpers/slots.ts
@@ -8,7 +8,7 @@ export const isSlotProperty = (key: string, slotPrefix: string = SLOT_PREFIX): b
   key.startsWith(slotPrefix);
 
 export const stripSlotPrefix = (key: string, slotPrefix: string = SLOT_PREFIX): string =>
-  isSlotProperty(key, slotPrefix) ? key.substring(slotPrefix.length) : key;
+  isSlotProperty(key, slotPrefix) ? convertToKebabCase(key.substring(slotPrefix.length)) : convertToKebabCase(key);
 
 export function replaceSlotsInString(code: string, mapper: SlotMapper) {
   return babelTransformExpression(code, {
@@ -20,4 +20,9 @@ export function replaceSlotsInString(code: string, mapper: SlotMapper) {
       }
     },
   });
+}
+
+function convertToKebabCase(key: string) {
+  var formattedString = key.replace(/([A-Z])/g, '-$1').trim();
+  return formattedString;
 }


### PR DESCRIPTION
formatting slot name to kebab casing to make it consistent across Angular and Vu js


## Description

- I have made changes in slots.ts file. I have added a function to format the slot name such a way, so it stays consistent after compilation by Angular or Vu js. 

- As with current implementation the slots names were not consistent, Anguler js compiling to kebab case where vu js wasn't. Also, as per VU js documentation it's a good practice to name as per kebab casing. So, with this new function we will format the slot name to kebab casing. 
-
- I have tried to implement minimum changes to achieve the desired result of maintaining consistency in the slot name across Angular and VU js. So with this new method I am able to fix the issue. I have tested my changes in the provided repro steps. 

This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

