### PR TITLE
fix: remove 2 deprecated dependencies in core package

### DIFF
--- a/.changeset/rotten-camels-wash.md
+++ b/.changeset/rotten-camels-wash.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-fix: remove deprecated dependencies in core package
+Fix: remove deprecated dependencies: `vue` and `@babel/plugin-proposal-class-properties`

--- a/.changeset/rotten-camels-wash.md
+++ b/.changeset/rotten-camels-wash.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+fix: remove deprecated dependencies in core package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,6 @@
     "@angular/compiler": "^11.2.11",
     "@babel/core": "7.14.5",
     "@babel/generator": "^7.14.3",
-    "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-syntax-decorators": "^7.12.1",
     "@babel/plugin-syntax-typescript": "^7.20.0",
     "@babel/plugin-transform-react-jsx": "^7.13.12",
@@ -107,7 +106,6 @@
     "typescript": "^5.3.2",
     "vite": "^4.5.0",
     "vite-tsconfig-paths": "^3.5.0",
-    "vitest": "^0.34.6",
-    "vue": "~2.6"
+    "vitest": "^0.34.6"
   }
 }

--- a/packages/core/src/generators/vue/optionsApi.ts
+++ b/packages/core/src/generators/vue/optionsApi.ts
@@ -6,10 +6,9 @@ import { checkIsComponentImport } from '@/helpers/render-imports';
 import { BaseHook, MitosisComponent } from '@/types/mitosis-component';
 import json5 from 'json5';
 import { kebabCase, size, uniq } from 'lodash';
-import type { DefaultProps, PropsDefinition } from 'vue/types/options';
 import { stringifySingleScopeOnMount } from '../helpers/on-mount';
 import { encodeQuotes, getContextKey, getContextValue, getOnUpdateHookName } from './helpers';
-import { ToVueOptions } from './types';
+import { DefaultProps, PropsDefinition, ToVueOptions } from './types';
 
 const getContextProvideString = (json: MitosisComponent, options: ToVueOptions) => {
   return `{

--- a/packages/core/src/generators/vue/types.ts
+++ b/packages/core/src/generators/vue/types.ts
@@ -11,3 +11,24 @@ export interface ToVueOptions extends BaseTranspilerOptions {
   convertClassStringToObject?: boolean;
   casing?: 'pascal' | 'kebab';
 }
+
+export type Prop<T> =
+  | { (): T }
+  | { new (...args: never[]): T & object }
+  | { new (...args: string[]): Function };
+export type PropType<T> = Prop<T> | Prop<T>[];
+export type PropValidator<T> = PropOptions<T> | PropType<T>;
+
+export interface PropOptions<T = any> {
+  type?: PropType<T>;
+  required?: boolean;
+  default?: T | null | undefined | (() => T | null | undefined);
+  validator?(value: T): boolean;
+}
+
+export type DefaultProps = Record<string, any>;
+export type RecordPropsDefinition<T> = {
+  [K in keyof T]: PropValidator<T[K]>;
+};
+export type ArrayPropsDefinition<T> = (keyof T)[];
+export type PropsDefinition<T> = ArrayPropsDefinition<T> | RecordPropsDefinition<T>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,7 +3369,6 @@ __metadata:
     "@angular/compiler": "npm:^11.2.11"
     "@babel/core": "npm:7.14.5"
     "@babel/generator": "npm:^7.14.3"
-    "@babel/plugin-proposal-class-properties": "npm:^7.13.0"
     "@babel/plugin-syntax-decorators": "npm:^7.12.1"
     "@babel/plugin-syntax-typescript": "npm:^7.20.0"
     "@babel/plugin-transform-react-jsx": "npm:^7.13.12"
@@ -3417,7 +3416,6 @@ __metadata:
     vite: "npm:^4.5.0"
     vite-tsconfig-paths: "npm:^3.5.0"
     vitest: "npm:^0.34.6"
-    vue: "npm:~2.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Remove 2 deprecated dependencies: `vue` and `@babel/plugin-proposal-class-properties`


## Why?

- Vue has already has its v2 version deprecated.
- `@babel/plugin-proposal-class-properties` is deprecated, which can be seen in [here](https://www.npmjs.com/package/@babel/plugin-proposal-class-properties).


## Solution

### Vue

There are just 1 place in core's code to import vue for its ts definition. So we could copy them and remove the import of `vue2`

### @babel/plugin-proposal-class-properties
As there were 0 places to import `@babel/plugin-proposal-class-properties`, we could just remove the import of it.
