### PR TITLE
fix: empty react fragment with text

### DIFF
--- a/.changeset/slimy-emus-bake.md
+++ b/.changeset/slimy-emus-bake.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-fix: react generator to appropriately add fragments when empty fragment with text
+fix: React generator: include `Fragment`s that only contain text content.

--- a/.changeset/slimy-emus-bake.md
+++ b/.changeset/slimy-emus-bake.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+fix: react generator to appropriately add fragments when empty fragment with text

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -592,7 +592,7 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -634,7 +634,9 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        <Text>{foo.value}</Text>
+        <>
+          <Text>{foo.value}</Text>
+        </>
       </Context1.Provider>
     </Context2.Provider>
   );

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -1847,7 +1847,7 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        {foo.value}
+        <Fragment>{foo.value}</Fragment>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -1883,7 +1883,7 @@ function ComponentWithContext(props) {
         }}
       >
         <Fragment>
-          {foo.value}
+          <Fragment>{foo.value}</Fragment>
           <div>other</div>
         </Fragment>
       </Context1.Provider>
@@ -5351,7 +5351,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
           },
         }}
       >
-        {foo.value}
+        <Fragment>{foo.value}</Fragment>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -5392,7 +5392,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
         }}
       >
         <Fragment>
-          {foo.value}
+          <Fragment>{foo.value}</Fragment>
           <div>other</div>
         </Fragment>
       </Context1.Provider>

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -2120,7 +2120,9 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        <Text>{foo.value}</Text>
+        <>
+          <Text>{foo.value}</Text>
+        </>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -2163,7 +2165,9 @@ function ComponentWithContext(props) {
         }}
       >
         <>
-          <Text>{foo.value}</Text>
+          <>
+            <Text>{foo.value}</Text>
+          </>
           <View>
             <Text>other</Text>
           </View>
@@ -6244,7 +6248,9 @@ function ComponentWithContext(props: ComponentWithContextProps) {
           },
         }}
       >
-        <Text>{foo.value}</Text>
+        <>
+          <Text>{foo.value}</Text>
+        </>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -6292,7 +6298,9 @@ function ComponentWithContext(props: ComponentWithContextProps) {
         }}
       >
         <>
-          <Text>{foo.value}</Text>
+          <>
+            <Text>{foo.value}</Text>
+          </>
           <View>
             <Text>other</Text>
           </View>

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -1831,7 +1831,7 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -1867,7 +1867,7 @@ function ComponentWithContext(props) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <div>other</div>
         </>
       </Context1.Provider>
@@ -5288,7 +5288,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -5329,7 +5329,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <div>other</div>
         </>
       </Context1.Provider>

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -1828,7 +1828,7 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -1864,7 +1864,7 @@ function ComponentWithContext(props) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <div>other</div>
         </>
       </Context1.Provider>
@@ -5029,7 +5029,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -5070,7 +5070,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <div>other</div>
         </>
       </Context1.Provider>

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -1846,7 +1846,7 @@ function ComponentWithContext(props) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -1883,7 +1883,7 @@ function ComponentWithContext(props) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <View>other</View>
         </>
       </Context1.Provider>
@@ -5377,7 +5377,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
           },
         }}
       >
-        {foo.value}
+        <>{foo.value}</>
       </Context1.Provider>
     </Context2.Provider>
   );
@@ -5419,7 +5419,7 @@ function ComponentWithContext(props: ComponentWithContextProps) {
         }}
       >
         <>
-          {foo.value}
+          <>{foo.value}</>
           <View>other</View>
         </>
       </Context1.Provider>

--- a/packages/core/src/generators/react/blocks.ts
+++ b/packages/core/src/generators/react/blocks.ts
@@ -67,7 +67,7 @@ const NODE_MAPPERS: {
     return `<>{${slotProp} ${hasChildren ? `|| (${renderChildren()})` : ''}}</>`;
   },
   Fragment(json, options, component) {
-    const wrap = wrapInFragment(json);
+    const wrap = wrapInFragment(json) || isRootTextNode(json);
     return `${wrap ? getFragment('open', options) : ''}${json.children
       .map((item) => blockToReact(item, options, component))
       .join('\n')}${wrap ? getFragment('close', options) : ''}`;


### PR DESCRIPTION
## Description

This PR fixes empty fragments in React generator when we use `<>text</>`

Mitosis link: https://mitosis.builder.io/?outputTab=E4UwhgxgLkA%3D&code=KYDwDg9gTgLgBAE2AMwIYFcA29noHYDGMAlhHnALICeAwhALaR7B4wAUYUEYAzgJRwA3gCg4cKMBjoo5NqLFwAPAD55CgBbBMmCGqUB6VWL4BuYQF8gA

### Before
![Screenshot 2024-04-18 at 4 38 22 PM](https://github.com/BuilderIO/mitosis/assets/73601258/6ba0579f-317e-4906-afdf-e6269d1e5dac)

### After
![Screenshot 2024-04-18 at 4 40 29 PM](https://github.com/BuilderIO/mitosis/assets/73601258/ebb53162-cc45-415a-b86b-8c7e28a29e4f)
