### PR TITLE
[feat] support `onClick` events in RN with Pressable

### DIFF
--- a/.changeset/quick-cows-change.md
+++ b/.changeset/quick-cows-change.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-feat: React Native: add support for onClick events using Pressable
+feat: React Native: add support for `onClick` event handlers using `Pressable`

--- a/.changeset/quick-cows-change.md
+++ b/.changeset/quick-cows-change.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+feat: React Native: add support for onClick events using Pressable

--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -611,6 +611,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -76,6 +77,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -120,6 +122,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useContext, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
@@ -168,6 +171,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -205,6 +209,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -232,6 +237,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -259,6 +265,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -278,6 +285,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
@@ -310,6 +318,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -343,6 +352,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -389,6 +399,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -452,6 +463,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
@@ -465,9 +477,9 @@ function MyBasicRefAssignmentComponent(props) {
 
   return (
     <View>
-      <View onClick={(evt) => handlerClick(evt)}>
+      <Pressable onPress={(evt) => handlerClick(evt)}>
         <Text>Click</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -485,6 +497,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -518,9 +531,9 @@ function MyPreviousComponent(props) {
         <Text>, before: </Text>
         <Text>{prevCount.current}</Text>
       </View>
-      <View onClick={(event) => setCount(1)}>
+      <Pressable onPress={(event) => setCount(1)}>
         <Text>Increment</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -538,6 +551,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -574,6 +588,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Column(props) {
@@ -627,6 +642,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function ContentSlotCode(props) {
@@ -656,6 +672,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -676,11 +693,11 @@ function ContentSlotJsxCode(props) {
     <>
       {props.slotReference ? (
         <>
-          <View
+          <Pressable
             name={props.slotContent ? \\"name1\\" : \\"name2\\"}
             title={props.slotContent ? \\"title1\\" : \\"title2\\"}
             {...props.attributes}
-            onClick={(event) => show()}
+            onPress={(event) => show()}
           >
             {showContent && props.slotContent ? (
               <>{props.content || <Text>{props.content}</Text>}</>
@@ -689,7 +706,7 @@ function ContentSlotJsxCode(props) {
               <View />
             </View>
             <View>{props.children}</View>
-          </View>
+          </Pressable>
         </>
       ) : null}
     </>
@@ -715,6 +732,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -786,6 +804,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -857,6 +876,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
@@ -1118,6 +1138,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -1220,6 +1241,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -1250,6 +1272,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1281,6 +1304,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1317,6 +1341,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -1347,6 +1372,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function RawText(props) {
@@ -1366,6 +1392,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SectionComponent(props) {
@@ -1398,6 +1425,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1436,6 +1464,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SlotCode(props) {
@@ -1465,6 +1494,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1489,6 +1519,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1513,6 +1544,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SlotCode(props) {
@@ -1538,6 +1570,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 import { kebabCase, snakeCase } from \\"lodash\\";
@@ -1571,22 +1604,22 @@ function SmileReviews(props) {
 
   return (
     <View data-user={name}>
-      <View onClick={(event) => setShowReviewPrompt(true)}>
+      <Pressable onPress={(event) => setShowReviewPrompt(true)}>
         <Text>Write a review</Text>
-      </View>
+      </Pressable>
       {showReviewPrompt || \\"asdf\\" ? (
         <>
           <View placeholder=\\"Email\\" />
           <View placeholder=\\"Title\\" />
           <View placeholder=\\"How was your experience?\\" />
-          <View
-            onClick={(event) => {
+          <Pressable
+            onPress={(event) => {
               event.preventDefault();
               setShowReviewPrompt(false);
             }}
           >
             <Text>Submit</Text>
-          </View>
+          </Pressable>
         </>
       ) : null}
       {reviews?.map((review, index) => (
@@ -1636,6 +1669,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SubmitButton(props) {
@@ -1659,6 +1693,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
@@ -1696,6 +1731,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Textarea(props) {
@@ -1723,6 +1759,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Video(props) {
@@ -1763,6 +1800,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -1798,6 +1836,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -1845,6 +1884,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -1880,6 +1920,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -1915,6 +1956,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -1959,6 +2001,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -1984,6 +2027,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2009,6 +2053,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2034,6 +2079,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2065,6 +2111,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2097,6 +2144,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
@@ -2141,6 +2189,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
@@ -2190,6 +2239,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -2222,6 +2272,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -2237,13 +2288,13 @@ function Button(props) {
         </View>
       ) : null}
       {!props.link ? (
-        <View
+        <Pressable
           type=\\"button\\"
           {...props.attributes}
-          onClick={(event) => props.onClick(event)}
+          onPress={(event) => props.onClick(event)}
         >
           <Text>{props.buttonText}</Text>
-        </View>
+        </Pressable>
       ) : null}
     </View>
   );
@@ -2271,6 +2322,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -2286,13 +2338,13 @@ function Button(props) {
         </View>
       ) : null}
       {!props.link ? (
-        <View
+        <Pressable
           type=\\"button\\"
           {...props.attributes}
-          onClick={(event) => props.onClick(event)}
+          onPress={(event) => props.onClick(event)}
         >
           <Text>{props.text}</Text>
-        </View>
+        </Pressable>
       ) : null}
     </View>
   );
@@ -2318,6 +2370,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 const DEFAULT_VALUES = {
@@ -2346,6 +2399,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2374,6 +2428,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 
@@ -2405,6 +2460,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2432,6 +2488,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -2475,6 +2532,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2499,6 +2557,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function NestedShow(props) {
@@ -2538,6 +2597,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function NestedStyles(props) {
@@ -2565,6 +2625,32 @@ export default NestedStyles;
 "
 `;
 
+exports[`React Native > jsx > Javascript Test > onClickToPressable 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+  Pressable,
+} from \\"react-native\\";
+
+function MyComponent(props) {
+  return (
+    <View>
+      <Pressable onPress={(e) => console.log(\\"event\\")}>
+        <Text>Hello</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default MyComponent;
+"
+`;
+
 exports[`React Native > jsx > Javascript Test > onEvent 1`] = `
 "import * as React from \\"react\\";
 import {
@@ -2574,6 +2660,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -2623,6 +2710,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2651,6 +2739,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -2687,6 +2776,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2717,6 +2807,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2747,6 +2838,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2771,6 +2863,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -2799,6 +2892,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 const b = 3;
@@ -2824,6 +2918,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2848,6 +2943,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2876,6 +2972,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2900,6 +2997,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2924,6 +3022,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2960,6 +3059,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { TARGET } from \\"../../constants/target.js\\";
@@ -3228,6 +3328,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -3259,18 +3360,18 @@ function RenderContent(props) {
         },
       }}
     >
-      <View
-        onClick={(event) => trackClick(props.content.id)}
-        style={styles.view1}
+      <Pressable
+        onPress={(event) => trackClick(props.content.id)}
+        style={styles.pressable1}
       >
         <RenderBlocks blocks={props.content.blocks} />
-      </View>
+      </Pressable>
     </BuilderContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
-  view1: { display: \\"flex\\", flexDirection: \\"columns\\" },
+  pressable1: { display: \\"flex\\", flexDirection: \\"columns\\" },
 });
 
 export default RenderContent;
@@ -3286,6 +3387,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -3322,6 +3424,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function RenderStyles(props) {
@@ -3355,6 +3458,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3379,6 +3483,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3410,6 +3515,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function NestedShow(props) {
@@ -3445,6 +3551,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function ShowRootText(props) {
@@ -3476,6 +3583,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -3508,6 +3616,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3527,6 +3636,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3546,6 +3656,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3565,6 +3676,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3595,6 +3707,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function StylePropClassAndCss(props) {
@@ -3618,6 +3731,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -3638,6 +3752,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SvgComponent(props) {
@@ -3673,6 +3788,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function TypeDependency(props) {
@@ -3696,6 +3812,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3721,6 +3838,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3748,6 +3866,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3773,6 +3892,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -3806,6 +3926,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
@@ -3843,6 +3964,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -3871,6 +3993,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -3942,6 +4065,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -3990,6 +4114,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useContext, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
@@ -4038,6 +4163,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -4080,6 +4206,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -4107,6 +4234,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -4134,6 +4262,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -4153,6 +4282,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -4190,6 +4320,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -4223,6 +4354,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -4269,6 +4401,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -4336,6 +4469,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
@@ -4353,9 +4487,9 @@ function MyBasicRefAssignmentComponent(props: Props) {
 
   return (
     <View>
-      <View onClick={(evt) => handlerClick(evt)}>
+      <Pressable onPress={(evt) => handlerClick(evt)}>
         <Text>Click</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -4373,6 +4507,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -4410,9 +4545,9 @@ function MyPreviousComponent(props: Props) {
         <Text>, before: </Text>
         <Text>{prevCount.current}</Text>
       </View>
-      <View onClick={(event) => setCount(1)}>
+      <Pressable onPress={(event) => setCount(1)}>
         <Text>Increment</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -4430,6 +4565,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -4473,6 +4609,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Column = {
@@ -4541,6 +4678,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -4576,6 +4714,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -4601,11 +4740,11 @@ function ContentSlotJsxCode(props: Props) {
     <>
       {props.slotReference ? (
         <>
-          <View
+          <Pressable
             name={props.slotContent ? \\"name1\\" : \\"name2\\"}
             title={props.slotContent ? \\"title1\\" : \\"title2\\"}
             {...props.attributes}
-            onClick={(event) => show()}
+            onPress={(event) => show()}
           >
             {showContent && props.slotContent ? (
               <>{props.content || <Text>{props.content}</Text>}</>
@@ -4614,7 +4753,7 @@ function ContentSlotJsxCode(props: Props) {
               <View />
             </View>
             <View>{props.children}</View>
-          </View>
+          </Pressable>
         </>
       ) : null}
     </>
@@ -4640,6 +4779,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -4716,6 +4856,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -4792,6 +4933,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -5084,6 +5226,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -5205,6 +5348,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -5235,6 +5379,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ImgProps {
@@ -5284,6 +5429,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface FormInputProps {
@@ -5332,6 +5478,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -5362,6 +5509,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface RawTextProps {
@@ -5386,6 +5534,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface SectionProps {
@@ -5424,6 +5573,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface FormSelectProps {
@@ -5474,6 +5624,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5507,6 +5658,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5535,6 +5687,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5563,6 +5716,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5592,6 +5746,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -5630,22 +5785,22 @@ function SmileReviews(props: SmileReviewsProps) {
 
   return (
     <View data-user={name}>
-      <View onClick={(event) => setShowReviewPrompt(true)}>
+      <Pressable onPress={(event) => setShowReviewPrompt(true)}>
         <Text>Write a review</Text>
-      </View>
+      </Pressable>
       {showReviewPrompt || \\"asdf\\" ? (
         <>
           <View placeholder=\\"Email\\" />
           <View placeholder=\\"Title\\" />
           <View placeholder=\\"How was your experience?\\" />
-          <View
-            onClick={(event) => {
+          <Pressable
+            onPress={(event) => {
               event.preventDefault();
               setShowReviewPrompt(false);
             }}
           >
             <Text>Submit</Text>
-          </View>
+          </Pressable>
         </>
       ) : null}
       {reviews?.map((review, index) => (
@@ -5695,6 +5850,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -5723,6 +5879,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -5769,6 +5926,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface TextareaProps {
@@ -5804,6 +5962,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface VideoProps {
@@ -5870,6 +6029,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -5905,6 +6065,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -5952,6 +6113,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -5992,6 +6154,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -6032,6 +6195,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -6076,6 +6240,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -6101,6 +6266,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -6126,6 +6292,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -6151,6 +6318,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6188,6 +6356,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6220,6 +6389,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
@@ -6269,6 +6439,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
@@ -6323,6 +6494,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -6355,6 +6527,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -6380,13 +6553,13 @@ function Button(props: ButtonProps) {
         </View>
       ) : null}
       {!props.link ? (
-        <View
+        <Pressable
           type=\\"button\\"
           {...props.attributes}
-          onClick={(event) => props.onClick(event)}
+          onPress={(event) => props.onClick(event)}
         >
           <Text>{props.buttonText}</Text>
-        </View>
+        </Pressable>
       ) : null}
     </View>
   );
@@ -6414,6 +6587,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -6437,13 +6611,13 @@ function Button(props: ButtonProps) {
         </View>
       ) : null}
       {!props.link ? (
-        <View
+        <Pressable
           type=\\"button\\"
           {...props.attributes}
-          onClick={(event) => props.onClick(event)}
+          onPress={(event) => props.onClick(event)}
         >
           <Text>{props.text}</Text>
-        </View>
+        </Pressable>
       ) : null}
     </View>
   );
@@ -6469,6 +6643,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -6501,6 +6676,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6529,6 +6705,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type RenderContentProps = {
@@ -6567,6 +6744,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -6594,6 +6772,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -6637,6 +6816,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6661,6 +6841,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -6705,6 +6886,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function NestedStyles(props: any) {
@@ -6732,6 +6914,32 @@ export default NestedStyles;
 "
 `;
 
+exports[`React Native > jsx > Typescript Test > onClickToPressable 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+  Pressable,
+} from \\"react-native\\";
+
+function MyComponent(props: any) {
+  return (
+    <View>
+      <Pressable onPress={(e) => console.log(\\"event\\")}>
+        <Text>Hello</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default MyComponent;
+"
+`;
+
 exports[`React Native > jsx > Typescript Test > onEvent 1`] = `
 "import * as React from \\"react\\";
 import {
@@ -6741,6 +6949,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -6790,6 +6999,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -6818,6 +7028,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -6858,6 +7069,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -6888,6 +7100,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -6918,6 +7131,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -6942,6 +7156,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -6974,6 +7189,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Types = {
@@ -7009,6 +7225,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export type A = \\"test\\";
@@ -7046,6 +7263,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7079,6 +7297,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 interface Person {
@@ -7108,6 +7327,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 type Person = {
@@ -7137,6 +7357,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -7173,6 +7394,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7454,6 +7676,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 
@@ -7493,18 +7716,18 @@ function RenderContent(props: Props) {
         },
       }}
     >
-      <View
-        onClick={(event) => trackClick(props.content.id)}
-        style={styles.view1}
+      <Pressable
+        onPress={(event) => trackClick(props.content.id)}
+        style={styles.pressable1}
       >
         <RenderBlocks blocks={props.content.blocks} />
-      </View>
+      </Pressable>
     </BuilderContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
-  view1: { display: \\"flex\\", flexDirection: \\"columns\\" },
+  pressable1: { display: \\"flex\\", flexDirection: \\"columns\\" },
 });
 
 export default RenderContent;
@@ -7520,6 +7743,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -7563,6 +7787,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export interface RenderStylesProps {
@@ -7600,6 +7825,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -7624,6 +7850,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -7655,6 +7882,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -7695,6 +7923,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -7730,6 +7959,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -7771,6 +8001,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7790,6 +8021,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7809,6 +8041,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7828,6 +8061,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -7858,6 +8092,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function StylePropClassAndCss(props: any) {
@@ -7881,6 +8116,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -7901,6 +8137,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function SvgComponent(props: any) {
@@ -7936,6 +8173,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 export type TypeDependencyProps = {
@@ -7966,6 +8204,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -7991,6 +8230,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -8018,6 +8258,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -8043,6 +8284,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -8076,6 +8318,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
@@ -8113,6 +8356,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8140,6 +8384,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8219,6 +8464,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8241,6 +8487,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8276,6 +8523,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8306,6 +8554,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -8315,15 +8564,15 @@ function MyComponent(props) {
 
   return (
     <View>
-      <View onClick={(a) => log(\\"hi\\")}>
+      <Pressable onPress={(a) => log(\\"hi\\")}>
         <Text>Log</Text>
-      </View>
-      <View onClick={(event) => log(event)}>
+      </Pressable>
+      <Pressable onPress={(event) => log(event)}>
         <Text>Log</Text>
-      </View>
-      <View onClick={(event) => log(event)}>
+      </Pressable>
+      <Pressable onPress={(event) => log(event)}>
         <Text>Log</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -8341,6 +8590,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8363,6 +8613,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8377,14 +8628,14 @@ function MyComponent(props) {
     <>
       {show ? (
         <>
-          <View onClick={(event) => toggle(event)}>
+          <Pressable onPress={(event) => toggle(event)}>
             <Text> Hide </Text>
-          </View>
+          </Pressable>
         </>
       ) : (
-        <View onClick={(event) => toggle(event)}>
+        <Pressable onPress={(event) => toggle(event)}>
           <Text> Show </Text>
-        </View>
+        </Pressable>
       )}
     </>
   );
@@ -8403,6 +8654,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
@@ -8432,6 +8684,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8466,6 +8719,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8498,6 +8752,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -8547,6 +8802,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -8577,6 +8833,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -8598,6 +8855,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8630,6 +8888,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8657,6 +8916,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8736,6 +8996,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8758,6 +9019,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8793,6 +9055,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8823,6 +9086,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -8832,15 +9096,15 @@ function MyComponent(props: any) {
 
   return (
     <View>
-      <View onClick={(a) => log(\\"hi\\")}>
+      <Pressable onPress={(a) => log(\\"hi\\")}>
         <Text>Log</Text>
-      </View>
-      <View onClick={(event) => log(event)}>
+      </Pressable>
+      <Pressable onPress={(event) => log(event)}>
         <Text>Log</Text>
-      </View>
-      <View onClick={(event) => log(event)}>
+      </Pressable>
+      <Pressable onPress={(event) => log(event)}>
         <Text>Log</Text>
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -8858,6 +9122,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8880,6 +9145,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8894,14 +9160,14 @@ function MyComponent(props: any) {
     <>
       {show ? (
         <>
-          <View onClick={(event) => toggle(event)}>
+          <Pressable onPress={(event) => toggle(event)}>
             <Text> Hide </Text>
-          </View>
+          </Pressable>
         </>
       ) : (
-        <View onClick={(event) => toggle(event)}>
+        <Pressable onPress={(event) => toggle(event)}>
           <Text> Show </Text>
-        </View>
+        </Pressable>
       )}
     </>
   );
@@ -8920,6 +9186,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
@@ -8949,6 +9216,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8983,6 +9251,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -9015,6 +9284,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -9064,6 +9334,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9094,6 +9365,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9115,6 +9387,7 @@ import {
   StyleSheet,
   Image,
   Text,
+  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 

--- a/packages/core/src/__tests__/data/react-native/onclick-to-pressable.raw.tsx
+++ b/packages/core/src/__tests__/data/react-native/onclick-to-pressable.raw.tsx
@@ -1,0 +1,7 @@
+export default function MyComponent(props) {
+  return (
+    <div>
+      <button onClick={(e) => console.log('event')}>Hello</button>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/test-generator.ts
+++ b/packages/core/src/__tests__/test-generator.ts
@@ -118,6 +118,7 @@ const builderRenderContent = getRawFile('./data/blocks/builder-render-content.ra
 
 const rootFragmentMultiNode = getRawFile('./data/blocks/root-fragment-multi-node.raw.tsx');
 const renderContentExample = getRawFile('./data/render-content.raw.tsx');
+const onClickToPressable = getRawFile('./data/react-native/onclick-to-pressable.raw.tsx');
 
 type Tests = { [index: string]: RawFile };
 
@@ -138,6 +139,10 @@ const SVELTE_SYNTAX_TESTS: Tests = {
   slots: getRawFile('./syntax/svelte/slots.raw.svelte'),
   style: getRawFile('./syntax/svelte/style.raw.svelte'),
   textExpressions: getRawFile('./syntax/svelte/text-expressions.raw.svelte'),
+};
+
+const REACT_NATIVE_TESTS: Tests = {
+  onClickToPressable,
 };
 
 const BASIC_TESTS: Tests = {
@@ -446,6 +451,7 @@ const JSX_TESTS_FOR_TARGET: Partial<Record<Target, Tests[]>> = {
     FORM_BLOCK_TESTS,
     ADVANCED_REF,
     ON_UPDATE_RETURN,
+    REACT_NATIVE_TESTS,
     // FOR_SHOW_TESTS,
   ],
   liquid: [

--- a/packages/core/src/generators/react-native/index.ts
+++ b/packages/core/src/generators/react-native/index.ts
@@ -123,6 +123,9 @@ const PROCESS_REACT_NATIVE_PLUGIN: Plugin = () => ({
             node.name = '';
           } else if (node.name.toLowerCase() === node.name && VALID_HTML_TAGS.includes(node.name)) {
             node.name = 'View';
+            if (node.bindings.onClick) {
+              node.name = 'Pressable';
+            }
           } else if (
             node.properties._text?.trim().length ||
             node.bindings._text?.code?.trim()?.length

--- a/packages/core/src/generators/react/blocks.ts
+++ b/packages/core/src/generators/react/blocks.ts
@@ -147,6 +147,12 @@ const BINDING_MAPPERS: {
   ...ATTTRIBUTE_MAPPERS,
 };
 
+const NATIVE_EVENT_MAPPER: {
+  [key: string]: string;
+} = {
+  onClick: 'onPress',
+};
+
 export const blockToReact = (
   json: MitosisNode,
   options: ToReactOptions,
@@ -213,7 +219,8 @@ export const blockToReact = (
       str += ` {...(${value})} `;
     } else if (key.startsWith('on')) {
       const { arguments: cusArgs = ['event'] } = json.bindings[key]!;
-      str += ` ${key}={(${cusArgs.join(',')}) => ${updateStateSettersInCode(
+      const eventName = options.type === 'native' ? NATIVE_EVENT_MAPPER[key] || key : key;
+      str += ` ${eventName}={(${cusArgs.join(',')}) => ${updateStateSettersInCode(
         useBindingValue,
         options,
       )} } `;

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -264,7 +264,7 @@ const getDefaultImport = (json: MitosisComponent, options: ToReactOptions): stri
   if (type === 'native') {
     return `
     import * as React from 'react';
-    import { FlatList, ScrollView, View, StyleSheet, Image, Text } from 'react-native';
+    import { FlatList, ScrollView, View, StyleSheet, Image, Text, Pressable } from 'react-native';
     `;
   }
   if (type === 'taro') {


### PR DESCRIPTION
## Description

This PR converts any `View` with onClick event attached to a `Pressable` and converts the `onClick` to `onPress` so that its handled properly inside React Native

**Jira**
https://builder-io.atlassian.net/browse/ENG-5713

**Loom**
https://www.loom.com/share/bf63014d0a6346bb878c8f2f8be50b98