### PR TITLE
feat: `visuallyIgnoreHostElement` option for angular to apply `display: contents`

### DIFF
--- a/.changeset/witty-keys-flow.md
+++ b/.changeset/witty-keys-flow.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Feat: `visuallyIgnoreHostElement` option for angular to ignore angular components as elements in the DOM

--- a/.changeset/witty-keys-flow.md
+++ b/.changeset/witty-keys-flow.md
@@ -1,5 +1,5 @@
 ---
-'@builder.io/mitosis': patch
+'@builder.io/mitosis': minor
 ---
 
 Feat: `visuallyIgnoreHostElement` option for angular to ignore angular components as elements in the DOM

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -33,6 +33,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -93,6 +96,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -145,6 +151,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -179,6 +192,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -219,6 +239,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: any;
@@ -257,6 +284,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -293,6 +327,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -329,6 +370,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -369,6 +417,13 @@ import MyBooleanAttributeComponentModule from \\"./basic-boolean-attribute-compo
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: any;
@@ -406,6 +461,13 @@ import MyBasicComponentModule from \\"./basic.raw/angular\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -451,6 +513,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -504,6 +573,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -547,6 +619,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event) {
@@ -595,6 +674,13 @@ export function usePrevious(value) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -639,6 +725,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -674,6 +767,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -743,6 +839,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotCode {}
 
@@ -786,6 +889,13 @@ const defaultProps = {
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: any;
@@ -826,6 +936,13 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -907,6 +1024,13 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -1033,6 +1157,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -1329,6 +1456,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -1423,6 +1553,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -1456,6 +1593,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: any;
@@ -1504,6 +1648,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: any;
@@ -1543,6 +1694,13 @@ import FormInputComponentModule from \\"./input.raw/angular\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Stepper {
   handleChange(value) {
@@ -1574,6 +1732,13 @@ import { Component, Input } from \\"@angular/core\\";
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RawText {
   @Input() attributes!: any;
@@ -1607,6 +1772,13 @@ import { Component, Input } from \\"@angular/core\\";
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionComponent {
   @Input() attributes!: any;
@@ -1640,6 +1812,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: any;
@@ -1689,6 +1868,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SelectComponent {
   @Input() attributes!: any;
@@ -1721,6 +1907,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -1751,6 +1944,13 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -1779,6 +1979,13 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -1808,6 +2015,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -1865,6 +2079,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -1939,6 +2156,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubmitButton {
   @Input() attributes!: any;
@@ -1974,6 +2198,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Text {
   @Input() text!: any;
@@ -2008,6 +2239,13 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Textarea {
   @Input() attributes!: any;
@@ -2046,6 +2284,13 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Video {
   @Input() attributes!: any;
@@ -2088,6 +2333,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -2134,6 +2386,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -2196,6 +2455,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -2235,6 +2497,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -2267,6 +2532,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -2314,6 +2586,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -2347,6 +2622,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -2380,6 +2658,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -2412,6 +2693,13 @@ import { Component } from \\"@angular/core\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -2442,6 +2730,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -2481,6 +2772,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -2515,6 +2813,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -2545,6 +2850,13 @@ import BuilderContext from \\"@dummy/context.lite\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -2595,6 +2907,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -2648,6 +2967,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -2683,6 +3009,13 @@ const DEFAULT_VALUES = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -2717,6 +3050,13 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -2766,6 +3106,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -2811,6 +3158,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -2845,6 +3199,13 @@ import { Component, Input } from \\"@angular/core\\";
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() foo!: any;
@@ -2883,6 +3244,13 @@ import RenderBlockModule from \\"./builder-render-block.raw/angular\\";
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: any;
@@ -2916,6 +3284,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyImportComponent {}
 
@@ -2940,6 +3315,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -2969,6 +3351,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -3011,6 +3400,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -3044,6 +3440,13 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -3080,6 +3483,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -3109,6 +3519,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -3160,6 +3573,13 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -3194,6 +3614,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   constructor() {
@@ -3230,6 +3657,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   @Input() name!: any;
@@ -3263,6 +3697,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -3295,6 +3736,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -3334,6 +3782,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -3362,6 +3817,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: any;
@@ -3408,6 +3870,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -3440,6 +3909,13 @@ export function run(value) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -3464,6 +3940,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3493,6 +3976,13 @@ import { Component, Input } from \\"@angular/core\\";
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() type!: any;
@@ -3521,6 +4011,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3547,6 +4044,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3573,6 +4077,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -3670,6 +4181,13 @@ import RenderRepeatedBlockModule from \\"./render-repeated-block.lite/angular\\"
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -3905,6 +4423,9 @@ import RenderBlocksModule from \\"@dummy/RenderBlocks.lite.tsx/angular\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -3960,6 +4481,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -3990,6 +4518,13 @@ import { Component, Input } from \\"@angular/core\\";
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderStyles {
   @Input() foo!: any;
@@ -4021,6 +4556,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -4053,6 +4595,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -4086,6 +4635,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -4116,6 +4672,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: any;
@@ -4144,6 +4707,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4181,6 +4747,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -4205,6 +4778,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -4231,6 +4811,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -4260,6 +4847,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -4301,6 +4891,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -4336,6 +4929,13 @@ import FooModule from \\"./foo-sub-component.lite/angular\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubComponent {}
 
@@ -4381,6 +4981,13 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SvgComponent {}
 
@@ -4405,6 +5012,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class TypeDependency {
   @Input() foo!: any;
@@ -4433,6 +5047,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -4467,6 +5084,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -4504,6 +5124,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -4536,6 +5159,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -4574,6 +5204,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -4602,6 +5239,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}} ! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -4654,6 +5298,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -4718,6 +5365,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4770,6 +5420,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -4804,6 +5461,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -4849,6 +5513,13 @@ export interface Props {
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: Props[\\"bye\\"];
@@ -4887,6 +5558,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -4923,6 +5601,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -4959,6 +5644,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -5004,6 +5696,13 @@ import MyBooleanAttributeComponentModule from \\"./basic-boolean-attribute-compo
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: Props[\\"type\\"];
@@ -5041,6 +5740,13 @@ import MyBasicComponentModule from \\"./basic.raw/angular\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -5086,6 +5792,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -5143,6 +5856,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -5190,6 +5906,13 @@ export interface Props {
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event: Event) {
@@ -5242,6 +5965,13 @@ export function usePrevious<T>(value: T) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -5293,6 +6023,13 @@ export interface ButtonProps {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -5343,6 +6080,9 @@ export interface ColumnProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -5419,6 +6159,13 @@ import { JSX } from \\"../../../../jsx-runtime\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotCode {}
 
@@ -5467,6 +6214,13 @@ import { JSX } from \\"../../../../jsx-runtime\\";
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: Props[\\"attributes\\"];
@@ -5512,6 +6266,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -5598,6 +6359,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -5748,6 +6516,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -6070,6 +6841,9 @@ export interface ImageProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -6164,6 +6938,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -6214,6 +6995,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: ImgProps[\\"backgroundSize\\"];
@@ -6273,6 +7061,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: FormInputProps[\\"attributes\\"];
@@ -6312,6 +7107,13 @@ import FormInputComponentModule from \\"./input.raw/angular\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Stepper {
   handleChange(value: string) {
@@ -6348,6 +7150,13 @@ export interface RawTextProps {
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RawText {
   @Input() attributes!: RawTextProps[\\"attributes\\"];
@@ -6387,6 +7196,13 @@ export interface SectionProps {
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -6426,6 +7242,13 @@ export interface SectionProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -6486,6 +7309,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SelectComponent {
   @Input() attributes!: FormSelectProps[\\"attributes\\"];
@@ -6522,6 +7352,13 @@ type Props = {
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -6556,6 +7393,13 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -6588,6 +7432,13 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -6621,6 +7472,13 @@ type Props = {
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -6683,6 +7541,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -6762,6 +7623,13 @@ export interface ButtonProps {
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubmitButton {
   @Input() attributes!: ButtonProps[\\"attributes\\"];
@@ -6805,6 +7673,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Text {
   @Input() text!: TextProps[\\"text\\"];
@@ -6847,6 +7722,13 @@ export interface TextareaProps {
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Textarea {
   @Input() attributes!: TextareaProps[\\"attributes\\"];
@@ -6911,6 +7793,13 @@ export interface VideoProps {
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Video {
   @Input() attributes!: VideoProps[\\"attributes\\"];
@@ -6953,6 +7842,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -6999,6 +7895,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -7066,6 +7969,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -7110,6 +8016,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -7142,6 +8051,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -7189,6 +8105,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7222,6 +8141,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7255,6 +8177,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7294,6 +8219,13 @@ import { JSX } from \\"../../../../jsx-runtime\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -7324,6 +8256,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7367,6 +8302,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -7405,6 +8347,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -7435,6 +8384,13 @@ import BuilderContext from \\"@dummy/context.lite\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -7494,6 +8450,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -7555,6 +8518,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -7595,6 +8565,13 @@ const DEFAULT_VALUES: Props = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -7629,6 +8606,13 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -7678,6 +8662,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -7723,6 +8714,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -7761,6 +8759,13 @@ export interface ButtonProps {
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() foo!: ButtonProps[\\"foo\\"];
@@ -7808,6 +8813,13 @@ import RenderBlockModule, {
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: RenderContentProps[\\"renderContentProps\\"];
@@ -7841,6 +8853,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyImportComponent {}
 
@@ -7865,6 +8884,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -7894,6 +8920,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -7936,6 +8969,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -7969,6 +9009,13 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -8010,6 +9057,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -8039,6 +9093,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -8090,6 +9147,13 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -8124,6 +9188,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   constructor() {
@@ -8164,6 +9235,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   @Input() name!: Props[\\"name\\"];
@@ -8197,6 +9275,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -8229,6 +9314,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -8268,6 +9360,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -8300,6 +9399,13 @@ type Props = {
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: Props[\\"size\\"];
@@ -8346,6 +9452,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -8388,6 +9501,13 @@ export function run<T>(value: T) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -8425,6 +9545,13 @@ export interface MyBasicComponentProps {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: MyBasicComponentProps[\\"name\\"];
@@ -8459,6 +9586,13 @@ type Props = {
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() type!: Props[\\"type\\"];
@@ -8492,6 +9626,13 @@ interface Person {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person | never[\\"name\\"];
@@ -8523,6 +9664,13 @@ type Person = {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person[\\"name\\"];
@@ -8549,6 +9697,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -8659,6 +9814,13 @@ import { RepeatData } from \\"./types.js\\";
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -8902,6 +10064,9 @@ import RenderBlocksModule from \\"@dummy/RenderBlocks.lite.tsx/angular\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -8964,6 +10129,13 @@ export interface ButtonProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -8998,6 +10170,13 @@ export interface RenderStylesProps {
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderStyles {
   @Input() foo!: RenderStylesProps[\\"foo\\"];
@@ -9029,6 +10208,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -9061,6 +10247,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -9099,6 +10292,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -9133,6 +10333,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -9170,6 +10377,9 @@ type Props = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -9207,6 +10417,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -9231,6 +10448,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -9257,6 +10481,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -9286,6 +10517,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -9327,6 +10561,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -9362,6 +10599,13 @@ import FooModule from \\"./foo-sub-component.lite/angular\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubComponent {}
 
@@ -9407,6 +10651,13 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SvgComponent {}
 
@@ -9439,6 +10690,13 @@ import { Foo as Foo2 } from \\"./type-export.lite\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class TypeDependency {
   @Input() foo!: TypeDependencyProps[\\"foo\\"];
@@ -9467,6 +10725,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -9501,6 +10762,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -9538,6 +10802,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -9570,6 +10837,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -9608,6 +10882,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -9640,6 +10921,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -9713,6 +11001,13 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -9740,6 +11035,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -9770,6 +11072,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -9798,6 +11107,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -9830,6 +11146,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -9860,6 +11183,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -9888,6 +11218,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -9919,6 +11256,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   show = true;
@@ -9954,6 +11298,13 @@ import ButtonModule from \\"./Button.lite/angular\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -9980,6 +11331,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -10020,6 +11378,13 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -10054,6 +11419,13 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 2;
@@ -10092,6 +11464,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -10118,6 +11497,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -10157,6 +11539,13 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 5;
@@ -10188,6 +11577,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -10261,6 +11657,13 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -10288,6 +11691,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -10318,6 +11728,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -10346,6 +11763,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -10378,6 +11802,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -10408,6 +11839,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -10436,6 +11874,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -10467,6 +11912,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   show = true;
@@ -10502,6 +11954,13 @@ import ButtonModule from \\"./Button.lite/angular\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -10528,6 +11987,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -10568,6 +12034,13 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -10602,6 +12075,13 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 2;
@@ -10640,6 +12120,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -10666,6 +12153,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -10705,6 +12195,13 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 5;

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > AdvancedRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -33,9 +33,6 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -71,7 +68,7 @@ export class MyBasicRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -95,9 +92,6 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -124,7 +118,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic 2`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -149,13 +143,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -171,7 +158,7 @@ export class MyBasicForShowComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Context 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -189,13 +176,6 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -224,7 +204,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic OnMount Update 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -235,13 +215,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: any;
@@ -268,7 +241,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Outputs 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -279,13 +252,6 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -310,7 +276,7 @@ export class MyBasicOutputsComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Basic Outputs Meta 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -321,13 +287,6 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -352,7 +311,7 @@ export class MyBasicOutputsComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicAttribute 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -363,13 +322,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {}
 
@@ -382,7 +334,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -409,13 +361,6 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: any;
@@ -430,7 +375,7 @@ export class MyBooleanAttributeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicChildComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -452,13 +397,6 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -478,7 +416,7 @@ export class MyBasicChildComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicFor 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -503,13 +441,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -529,7 +460,7 @@ export class MyBasicForComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -562,9 +493,6 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -596,7 +524,7 @@ export class MyBasicRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRefAssignment 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -607,13 +535,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event) {
@@ -634,7 +555,7 @@ export class MyBasicRefAssignmentComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > BasicRefPrevious 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -661,13 +582,6 @@ export function usePrevious(value) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -688,7 +602,7 @@ export class MyPreviousComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Button 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -711,13 +625,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -735,7 +642,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Columns 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -752,9 +659,6 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -808,7 +712,7 @@ export class ColumnModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > ContentSlotHtml 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -823,13 +727,6 @@ import { Component, Input } from \\"@angular/core\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ContentSlotCode {}
 
@@ -842,7 +739,7 @@ export class ContentSlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > ContentSlotJSX 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -872,13 +769,6 @@ const defaultProps = {
       </div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: any;
@@ -903,7 +793,7 @@ export class ContentSlotJsxCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > CustomCode 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -918,13 +808,6 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -990,7 +873,7 @@ export class CustomCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Embed 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1005,13 +888,6 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -1077,7 +953,7 @@ export class CustomCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Form 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1137,9 +1013,6 @@ import {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .pre {
         padding: 10px;
         color: red;
@@ -1406,7 +1279,7 @@ export class FormComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Image 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1435,9 +1308,6 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -1514,7 +1384,7 @@ export class ImageModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Image State 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1531,13 +1401,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -1553,7 +1416,7 @@ export class ImgStateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Img 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1570,13 +1433,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: any;
@@ -1603,7 +1459,7 @@ export class ImgComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Input 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1624,13 +1480,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: any;
@@ -1652,7 +1501,7 @@ export class FormInputComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > InputParent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > InputParent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1669,13 +1518,6 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Stepper {
   handleChange(value) {
@@ -1692,7 +1534,7 @@ export class StepperModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > RawText 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1706,13 +1548,6 @@ import { Component, Input } from \\"@angular/core\\";
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RawText {
   @Input() attributes!: any;
@@ -1728,7 +1563,7 @@ export class RawTextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Section 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1745,13 +1580,6 @@ import { Component, Input } from \\"@angular/core\\";
       <ng-content></ng-content>
     </section>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SectionComponent {
   @Input() attributes!: any;
@@ -1767,7 +1595,7 @@ export class SectionComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Section 2`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1784,13 +1612,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: any;
@@ -1816,7 +1637,7 @@ export class SectionStateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Select 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1839,13 +1660,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SelectComponent {
   @Input() attributes!: any;
@@ -1864,7 +1678,7 @@ export class SelectComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotDefault 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1877,13 +1691,6 @@ import { Component } from \\"@angular/core\\";
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -1896,7 +1703,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotHtml 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1913,13 +1720,6 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -1932,7 +1732,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotJsx 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1947,13 +1747,6 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -1966,7 +1759,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > SlotNamed 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -1982,13 +1775,6 @@ import { Component } from \\"@angular/core\\";
       <ng-content>Default Child</ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -2001,7 +1787,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Stamped.io 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2045,9 +1831,6 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         display: block;
       }
@@ -2110,7 +1893,7 @@ export class SmileReviewsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Submit 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2121,13 +1904,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SubmitButton {
   @Input() attributes!: any;
@@ -2143,7 +1919,7 @@ export class SubmitButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Text 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2162,13 +1938,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Text {
   @Input() text!: any;
@@ -2186,7 +1955,7 @@ export class TextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Textarea 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2202,13 +1971,6 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Textarea {
   @Input() attributes!: any;
@@ -2227,7 +1989,7 @@ export class TextareaModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > Video 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2246,13 +2008,6 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Video {
   @Input() attributes!: any;
@@ -2283,7 +2038,7 @@ export class VideoModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2294,13 +2049,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -2321,7 +2069,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicForNoTagReference 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > basicForNoTagReference 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2346,13 +2094,6 @@ import {
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -2395,7 +2136,7 @@ export class MyBasicForNoTagRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicForwardRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2414,9 +2155,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -2436,7 +2174,7 @@ export class MyBasicForwardRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2455,9 +2193,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -2477,7 +2212,7 @@ export class MyBasicForwardRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2489,13 +2224,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -2527,7 +2255,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > class + ClassName + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2542,9 +2270,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -2562,7 +2287,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > class + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2577,9 +2302,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -2597,7 +2319,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > className + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2612,9 +2334,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -2632,7 +2351,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > className 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2646,13 +2365,6 @@ import { Component } from \\"@angular/core\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -2667,7 +2379,7 @@ export class ClassNameCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > classState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2682,9 +2394,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -2707,7 +2416,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > componentWithContext 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2723,13 +2432,6 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -2746,7 +2448,7 @@ export class ComponentWithContextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2763,13 +2465,6 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -2786,26 +2481,17 @@ export class ComponentWithContextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > contentState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
-
-import BuilderContext from \\"@dummy/context.js\\";
 
 @Component({
   selector: \\"render-content, RenderContent\\",
   template: \`
     <div>setting context</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -2821,7 +2507,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2855,13 +2541,6 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -2882,7 +2561,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2914,13 +2593,6 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -2940,7 +2612,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > defaultValsWithTypes 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2955,13 +2627,6 @@ const DEFAULT_VALUES = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -2978,7 +2643,7 @@ export class ComponentWithTypesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > dynamicComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > dynamicComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -2995,13 +2660,6 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -3025,7 +2683,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > dynamicComponentWithEventArg 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > dynamicComponentWithEventArg 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3050,13 +2708,6 @@ import {
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -3090,7 +2741,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > expressionState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3101,13 +2752,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -3126,7 +2770,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > getterState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > getterState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3141,13 +2785,6 @@ import { Component, Input } from \\"@angular/core\\";
       <p>{{baz(1)}}</p>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() foo!: any;
@@ -3172,7 +2809,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > import types 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3185,13 +2822,6 @@ import RenderBlock from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: any;
@@ -3213,7 +2843,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > importRaw 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3224,13 +2854,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyImportComponent {}
 
@@ -3243,7 +2866,7 @@ export class MyImportComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleOnUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3254,13 +2877,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -3278,7 +2894,7 @@ export class MultipleOnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3289,13 +2905,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -3326,7 +2935,7 @@ export class MultipleOnUpdateWithDepsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > multipleSpreads 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3337,13 +2946,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -3360,7 +2962,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > nativeAttributes 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > nativeAttributes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3376,13 +2978,6 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -3397,7 +2992,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > nestedShow 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3418,13 +3013,6 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -3440,7 +3028,7 @@ export class NestedShowModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > nestedStyles 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3453,9 +3041,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         --bar: red;
@@ -3495,7 +3080,7 @@ export class NestedStylesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onEvent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onEvent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3506,13 +3091,6 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -3535,7 +3113,7 @@ export class EmbedModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onInit & onMount 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3546,13 +3124,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnInit {
   constructor() {
@@ -3573,7 +3144,7 @@ export class OnInitModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onInit 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3588,13 +3159,6 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnInit {
   @Input() name!: any;
@@ -3616,7 +3180,7 @@ export class OnInitModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onMount 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3627,13 +3191,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -3654,7 +3211,7 @@ export class CompModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onMountMultiple 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onMountMultiple 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3665,13 +3222,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -3699,7 +3249,7 @@ export class CompModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3710,13 +3260,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -3733,7 +3276,7 @@ export class OnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > onUpdateWithDeps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3744,13 +3287,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: any;
@@ -3777,7 +3313,7 @@ export class OnUpdateWithDepsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > outputEventBinding 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3796,13 +3332,6 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -3817,7 +3346,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3834,13 +3363,6 @@ export function run(value) {}
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -3853,7 +3375,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > preserveTyping 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3864,13 +3386,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3885,7 +3400,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsDestructure 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3899,13 +3414,6 @@ import { Component, Input } from \\"@angular/core\\";
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() type!: any;
@@ -3922,7 +3430,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsInterface 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3933,13 +3441,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3954,7 +3455,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > propsType 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3965,13 +3466,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -3986,7 +3480,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > referencingFunInsideHook 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -3997,13 +3491,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -4030,7 +3517,7 @@ export class OnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > renderBlock 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > renderBlock 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4052,11 +3539,7 @@ import { getBlockProperties } from \\"../../functions/get-block-properties.js\\"
 import { getBlockTag } from \\"../../functions/get-block-tag.js\\";
 import { getProcessedBlock } from \\"../../functions/get-processed-block.js\\";
 import { getReactNativeBlockStyles } from \\"../../functions/get-react-native-block-styles.js\\";
-import BlockStyles from \\"./block-styles.lite\\";
 import { isEmptyHtmlElement } from \\"./render-block.helpers.js\\";
-import RenderComponentWithContext from \\"./render-component-with-context.js\\";
-import RenderComponent from \\"./render-component.lite\\";
-import RenderRepeatedBlock from \\"./render-repeated-block.lite\\";
 
 @Component({
   selector: \\"render-block, RenderBlock\\",
@@ -4100,13 +3583,6 @@ import RenderRepeatedBlock from \\"./render-repeated-block.lite\\";
       ></ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -4318,19 +3794,17 @@ export class RenderBlockModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > renderContentExample 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
 
-import BuilderContext from \\"@dummy/context.js\\";
 import {
   dispatchNewContentToVisualEditor,
   sendComponentsToVisualEditor,
   trackClick,
 } from \\"@dummy/injection-js\\";
-import RenderBlocks from \\"@dummy/RenderBlocks.lite.tsx\\";
 
 @Component({
   selector: \\"render-content, RenderContent\\",
@@ -4341,9 +3815,6 @@ import RenderBlocks from \\"@dummy/RenderBlocks.lite.tsx\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -4375,7 +3846,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4398,13 +3869,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -4422,7 +3886,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > rootShow 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4434,13 +3898,6 @@ import { Component, Input } from \\"@angular/core\\";
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderStyles {
   @Input() foo!: any;
@@ -4455,7 +3912,7 @@ export class RenderStylesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > self-referencing component 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4471,13 +3928,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -4492,7 +3942,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > self-referencing component with children 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4509,13 +3959,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -4530,7 +3973,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > showWithFor 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4548,13 +3991,6 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -4570,7 +4006,7 @@ export class NestedShowModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > showWithRootText 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > showWithRootText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4584,13 +4020,6 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: any;
@@ -4605,7 +4034,7 @@ export class ShowRootTextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > signalsOnUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > signalsOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4618,9 +4047,6 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -4646,7 +4072,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadAttrs 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4657,13 +4083,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -4676,7 +4095,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadNestedProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4687,13 +4106,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -4708,7 +4120,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > spreadProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4719,13 +4131,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -4738,7 +4143,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > styleClassAndCss 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > styleClassAndCss 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4754,9 +4159,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -4784,7 +4186,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > stylePropClassAndCss 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > stylePropClassAndCss 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4797,9 +4199,6 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -4821,26 +4220,17 @@ export class StylePropClassAndCssModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > subComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
-
-import Foo from \\"./foo-sub-component.lite\\";
 
 @Component({
   selector: \\"sub-component, SubComponent\\",
   template: \`
     <foo></foo>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SubComponent {}
 
@@ -4853,7 +4243,7 @@ export class SubComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > svgComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > svgComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4885,13 +4275,6 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SvgComponent {}
 
@@ -4904,7 +4287,7 @@ export class SvgComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > typeDependency 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4915,13 +4298,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{foo}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class TypeDependency {
   @Input() foo!: any;
@@ -4936,7 +4312,7 @@ export class TypeDependencyModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4949,9 +4325,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         background: blue;
         color: white;
@@ -4972,7 +4345,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style-and-css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -4985,9 +4358,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -5011,7 +4381,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > use-style-outside-component 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5024,9 +4394,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         background: blue;
         color: white;
@@ -5047,7 +4414,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > useTarget 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5058,13 +4425,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -5085,7 +4445,7 @@ export class UseTargetComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > webComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > webComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5102,13 +4462,6 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -5125,7 +4478,7 @@ export class MyBasicWebComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Remove Internal mitosis package 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Remove Internal mitosis package 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5136,13 +4489,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}} ! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -5157,7 +4503,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > AdvancedRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > AdvancedRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5194,9 +4540,6 @@ export interface Props {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -5232,7 +4575,7 @@ export class MyBasicRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5260,9 +4603,6 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -5289,7 +4629,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic 2`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic 2`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5314,13 +4654,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -5336,7 +4669,7 @@ export class MyBasicForShowComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Context 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic Context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5354,13 +4687,6 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -5389,7 +4715,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic OnMount Update 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5405,13 +4731,6 @@ export interface Props {
   template: \`
     <div>Hello {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: Props[\\"bye\\"];
@@ -5438,7 +4757,7 @@ export class MyBasicOnMountUpdateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Outputs 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic Outputs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5449,13 +4768,6 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -5480,7 +4792,7 @@ export class MyBasicOutputsComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Basic Outputs Meta 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Basic Outputs Meta 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5491,13 +4803,6 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -5522,7 +4827,7 @@ export class MyBasicOutputsComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicAttribute 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5533,13 +4838,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {}
 
@@ -5552,7 +4850,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5584,13 +4882,6 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: Props[\\"type\\"];
@@ -5605,7 +4896,7 @@ export class MyBooleanAttributeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicChildComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicChildComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5627,13 +4918,6 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -5653,7 +4937,7 @@ export class MyBasicChildComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicFor 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5678,13 +4962,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -5704,7 +4981,7 @@ export class MyBasicForComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5741,9 +5018,6 @@ export interface Props {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -5775,7 +5049,7 @@ export class MyBasicRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRefAssignment 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5790,13 +5064,6 @@ export interface Props {
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event: Event) {
@@ -5817,7 +5084,7 @@ export class MyBasicRefAssignmentComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > BasicRefPrevious 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5848,13 +5115,6 @@ export function usePrevious<T>(value: T) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -5875,7 +5135,7 @@ export class MyPreviousComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Button 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Button 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5905,13 +5165,6 @@ export interface ButtonProps {
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -5929,7 +5182,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Columns 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Columns 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -5961,9 +5214,6 @@ export interface ColumnProps {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -6017,7 +5267,7 @@ export class ColumnModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > ContentSlotHtml 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6039,13 +5289,6 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ContentSlotCode {}
 
@@ -6058,7 +5301,7 @@ export class ContentSlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > ContentSlotJSX 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6093,13 +5336,6 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       </div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: Props[\\"attributes\\"];
@@ -6124,7 +5360,7 @@ export class ContentSlotJsxCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > CustomCode 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > CustomCode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6144,13 +5380,6 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -6216,7 +5445,7 @@ export class CustomCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Embed 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Embed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6236,13 +5465,6 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -6308,7 +5530,7 @@ export class CustomCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Form 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Form 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6392,9 +5614,6 @@ import {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .pre {
         padding: 10px;
         color: red;
@@ -6668,7 +5887,7 @@ export class FormComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Image 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Image 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6716,9 +5935,6 @@ export interface ImageProps {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -6795,7 +6011,7 @@ export class ImageModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Image State 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Image State 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6812,13 +6028,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -6834,7 +6043,7 @@ export class ImgStateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Img 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Img 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6868,13 +6077,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: ImgProps[\\"backgroundSize\\"];
@@ -6901,7 +6103,7 @@ export class ImgComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Input 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Input 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6933,13 +6135,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: FormInputProps[\\"attributes\\"];
@@ -6961,7 +6156,7 @@ export class FormInputComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > InputParent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > InputParent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -6978,13 +6173,6 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Stepper {
   handleChange(value: string) {
@@ -7001,7 +6189,7 @@ export class StepperModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > RawText 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > RawText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7020,13 +6208,6 @@ export interface RawTextProps {
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RawText {
   @Input() attributes!: RawTextProps[\\"attributes\\"];
@@ -7042,7 +6223,7 @@ export class RawTextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Section 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Section 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7065,13 +6246,6 @@ export interface SectionProps {
       <ng-content></ng-content>
     </section>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SectionComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -7087,7 +6261,7 @@ export class SectionComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Section 2`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Section 2`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7110,13 +6284,6 @@ export interface SectionProps {
       </ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -7142,7 +6309,7 @@ export class SectionStateComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Select 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Select 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7176,13 +6343,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SelectComponent {
   @Input() attributes!: FormSelectProps[\\"attributes\\"];
@@ -7201,7 +6361,7 @@ export class SelectComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotDefault 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > SlotDefault 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7218,13 +6378,6 @@ type Props = {
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -7237,7 +6390,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotHtml 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > SlotHtml 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7258,13 +6411,6 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -7277,7 +6423,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotJsx 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > SlotJsx 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7296,13 +6442,6 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -7315,7 +6454,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > SlotNamed 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > SlotNamed 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7335,13 +6474,6 @@ type Props = {
       <ng-content>Default Child</ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SlotCode {}
 
@@ -7354,7 +6486,7 @@ export class SlotCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Stamped.io 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Stamped.io 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7403,9 +6535,6 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         display: block;
       }
@@ -7468,7 +6597,7 @@ export class SmileReviewsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Submit 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Submit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7484,13 +6613,6 @@ export interface ButtonProps {
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SubmitButton {
   @Input() attributes!: ButtonProps[\\"attributes\\"];
@@ -7506,7 +6628,7 @@ export class SubmitButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Text 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Text 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7533,13 +6655,6 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Text {
   @Input() text!: TextProps[\\"text\\"];
@@ -7557,7 +6672,7 @@ export class TextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Textarea 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Textarea 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7581,13 +6696,6 @@ export interface TextareaProps {
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Textarea {
   @Input() attributes!: TextareaProps[\\"attributes\\"];
@@ -7606,7 +6714,7 @@ export class TextareaModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > Video 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > Video 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7651,13 +6759,6 @@ export interface VideoProps {
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Video {
   @Input() attributes!: VideoProps[\\"attributes\\"];
@@ -7688,7 +6789,7 @@ export class VideoModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7699,13 +6800,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -7726,7 +6820,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicForNoTagReference 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > basicForNoTagReference 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7751,13 +6845,6 @@ import {
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -7800,7 +6887,7 @@ export class MyBasicForNoTagRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicForwardRef 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > basicForwardRef 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7824,9 +6911,6 @@ export interface Props {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -7846,7 +6930,7 @@ export class MyBasicForwardRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7870,9 +6954,6 @@ export interface Props {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .input {
         color: red;
       }
@@ -7892,7 +6973,7 @@ export class MyBasicForwardRefComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7904,13 +6985,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -7942,7 +7016,7 @@ export class MyBasicOnUpdateReturnComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > class + ClassName + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > class + ClassName + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7957,9 +7031,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -7977,7 +7048,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > class + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > class + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -7992,9 +7063,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -8012,7 +7080,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > className + css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > className + css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8027,9 +7095,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -8047,7 +7112,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > className 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > className 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8068,13 +7133,6 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -8089,7 +7147,7 @@ export class ClassNameCodeModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > classState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > classState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8104,9 +7162,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -8129,7 +7184,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > componentWithContext 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > componentWithContext 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8149,13 +7204,6 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -8172,7 +7220,7 @@ export class ComponentWithContextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8193,13 +7241,6 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -8216,26 +7257,17 @@ export class ComponentWithContextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > contentState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > contentState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component, Input } from \\"@angular/core\\";
-
-import BuilderContext from \\"@dummy/context.js\\";
 
 @Component({
   selector: \\"render-content, RenderContent\\",
   template: \`
     <div>setting context</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -8251,7 +7283,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > defaultProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8294,13 +7326,6 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -8322,7 +7347,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8361,13 +7386,6 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -8388,7 +7406,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > defaultValsWithTypes 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > defaultValsWithTypes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8407,13 +7425,6 @@ const DEFAULT_VALUES: Props = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -8430,7 +7441,7 @@ export class ComponentWithTypesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > dynamicComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > dynamicComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8447,13 +7458,6 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -8477,7 +7481,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > dynamicComponentWithEventArg 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > dynamicComponentWithEventArg 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8502,13 +7506,6 @@ import {
               \\"
     ></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -8542,7 +7539,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > expressionState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > expressionState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8553,13 +7550,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -8578,7 +7568,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > getterState 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > getterState 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8597,13 +7587,6 @@ export interface ButtonProps {
       <p>{{baz(1)}}</p>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() foo!: ButtonProps[\\"foo\\"];
@@ -8628,7 +7611,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > import types 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > import types 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8648,13 +7631,6 @@ import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: RenderContentProps[\\"renderContentProps\\"];
@@ -8676,7 +7652,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > importRaw 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > importRaw 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8687,13 +7663,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyImportComponent {}
 
@@ -8706,7 +7675,7 @@ export class MyImportComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleOnUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > multipleOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8717,13 +7686,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -8741,7 +7703,7 @@ export class MultipleOnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8752,13 +7714,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -8789,7 +7744,7 @@ export class MultipleOnUpdateWithDepsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > multipleSpreads 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > multipleSpreads 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8800,13 +7755,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -8823,7 +7771,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > nativeAttributes 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > nativeAttributes 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8839,13 +7787,6 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -8860,7 +7801,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > nestedShow 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > nestedShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8886,13 +7827,6 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -8908,7 +7842,7 @@ export class NestedShowModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > nestedStyles 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > nestedStyles 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8921,9 +7855,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         --bar: red;
@@ -8963,7 +7894,7 @@ export class NestedStylesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onEvent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onEvent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -8974,13 +7905,6 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -9003,7 +7927,7 @@ export class EmbedModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onInit & onMount 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onInit & onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9014,13 +7938,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnInit {
   constructor() {
@@ -9041,7 +7958,7 @@ export class OnInitModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onInit 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onInit 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9060,13 +7977,6 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnInit {
   @Input() name!: Props[\\"name\\"];
@@ -9088,7 +7998,7 @@ export class OnInitModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onMount 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onMount 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9099,13 +8009,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -9126,7 +8029,7 @@ export class CompModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onMountMultiple 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onMountMultiple 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9137,13 +8040,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -9171,7 +8067,7 @@ export class CompModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9182,13 +8078,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -9205,7 +8094,7 @@ export class OnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > onUpdateWithDeps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9220,13 +8109,6 @@ type Props = {
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: Props[\\"size\\"];
@@ -9253,7 +8135,7 @@ export class OnUpdateWithDepsModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > outputEventBinding 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > outputEventBinding 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9272,13 +8154,6 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -9293,7 +8168,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9320,13 +8195,6 @@ export function run<T>(value: T) {}
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -9339,7 +8207,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > preserveTyping 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > preserveTyping 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9363,13 +8231,6 @@ export interface MyBasicComponentProps {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: MyBasicComponentProps[\\"name\\"];
@@ -9384,7 +8245,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsDestructure 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > propsDestructure 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9403,13 +8264,6 @@ type Props = {
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() type!: Props[\\"type\\"];
@@ -9426,7 +8280,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsInterface 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > propsInterface 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9442,13 +8296,6 @@ interface Person {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person | never[\\"name\\"];
@@ -9463,7 +8310,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > propsType 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > propsType 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9479,13 +8326,6 @@ type Person = {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person[\\"name\\"];
@@ -9500,7 +8340,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > referencingFunInsideHook 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > referencingFunInsideHook 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9511,13 +8351,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -9544,7 +8377,7 @@ export class OnUpdateModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > renderBlock 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > renderBlock 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9577,12 +8410,7 @@ import { getProcessedBlock } from \\"../../functions/get-processed-block.js\\";
 import { getReactNativeBlockStyles } from \\"../../functions/get-react-native-block-styles.js\\";
 import type { BuilderBlock } from \\"../../types/builder-block.js\\";
 import type { Nullable } from \\"../../types/typescript.js\\";
-import BlockStyles from \\"./block-styles.lite\\";
 import { isEmptyHtmlElement } from \\"./render-block.helpers.js\\";
-import RenderComponentWithContext from \\"./render-component-with-context.js\\";
-import type { RenderComponentProps } from \\"./render-component.lite\\";
-import RenderComponent from \\"./render-component.lite\\";
-import RenderRepeatedBlock from \\"./render-repeated-block.lite\\";
 import type { RepeatData } from \\"./types.js\\";
 
 @Component({
@@ -9627,13 +8455,6 @@ import type { RepeatData } from \\"./types.js\\";
       ></ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -9845,7 +8666,7 @@ export class RenderBlockModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > renderContentExample 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > renderContentExample 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9859,13 +8680,11 @@ type Props = {
   };
 };
 
-import BuilderContext from \\"@dummy/context.js\\";
 import {
   dispatchNewContentToVisualEditor,
   sendComponentsToVisualEditor,
   trackClick,
 } from \\"@dummy/injection-js\\";
-import RenderBlocks from \\"@dummy/RenderBlocks.lite.tsx\\";
 
 @Component({
   selector: \\"render-content, RenderContent\\",
@@ -9876,9 +8695,6 @@ import RenderBlocks from \\"@dummy/RenderBlocks.lite.tsx\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -9910,7 +8726,7 @@ export class RenderContentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9940,13 +8756,6 @@ export interface ButtonProps {
       </ng-container>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -9964,7 +8773,7 @@ export class ButtonModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > rootShow 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > rootShow 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -9980,13 +8789,6 @@ export interface RenderStylesProps {
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class RenderStyles {
   @Input() foo!: RenderStylesProps[\\"foo\\"];
@@ -10001,7 +8803,7 @@ export class RenderStylesModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > self-referencing component 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > self-referencing component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10017,13 +8819,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -10038,7 +8833,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > self-referencing component with children 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > self-referencing component with children 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10055,13 +8850,6 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -10076,7 +8864,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > showWithFor 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > showWithFor 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10099,13 +8887,6 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -10121,7 +8902,7 @@ export class NestedShowModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > showWithRootText 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > showWithRootText 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10139,13 +8920,6 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -10160,7 +8934,7 @@ export class ShowRootTextModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > signalsOnUpdate 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > signalsOnUpdate 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10182,9 +8956,6 @@ type Props = {
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         padding: 10px;
       }
@@ -10210,7 +8981,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadAttrs 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > spreadAttrs 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10221,13 +8992,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -10240,7 +9004,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadNestedProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > spreadNestedProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10251,13 +9015,6 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -10272,7 +9029,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > spreadProps 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > spreadProps 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10283,13 +9040,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicComponent {}
 
@@ -10302,7 +9052,7 @@ export class MyBasicComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > styleClassAndCss 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > styleClassAndCss 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10318,9 +9068,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -10348,7 +9095,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > stylePropClassAndCss 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > stylePropClassAndCss 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10361,9 +9108,6 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       .div {
         display: flex;
         flex-direction: column;
@@ -10385,26 +9129,17 @@ export class StylePropClassAndCssModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > subComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > subComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
-
-import Foo from \\"./foo-sub-component.lite\\";
 
 @Component({
   selector: \\"sub-component, SubComponent\\",
   template: \`
     <foo></foo>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SubComponent {}
 
@@ -10417,7 +9152,7 @@ export class SubComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > svgComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > svgComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10449,13 +9184,6 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class SvgComponent {}
 
@@ -10468,7 +9196,7 @@ export class SvgComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > typeDependency 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > typeDependency 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10480,20 +9208,12 @@ export type TypeDependencyProps = {
 };
 
 import type { Foo } from \\"./foo-type\\";
-import type { Foo as Foo2 } from \\"./type-export.lite\\";
 
 @Component({
   selector: \\"type-dependency, TypeDependency\\",
   template: \`
     <div>{{foo}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class TypeDependency {
   @Input() foo!: TypeDependencyProps[\\"foo\\"];
@@ -10508,7 +9228,7 @@ export class TypeDependencyModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > use-style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10521,9 +9241,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         background: blue;
         color: white;
@@ -10544,7 +9261,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style-and-css 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > use-style-and-css 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10557,9 +9274,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -10583,7 +9297,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > use-style-outside-component 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10596,9 +9310,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       button {
         background: blue;
         color: white;
@@ -10619,7 +9330,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > useTarget 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10630,13 +9341,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -10657,7 +9361,7 @@ export class UseTargetComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > webComponent 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > webComponent 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10674,13 +9378,6 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -10697,7 +9394,7 @@ export class MyBasicWebComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > basic 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10712,13 +9409,6 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -10733,7 +9423,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > bindGroup 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10791,13 +9481,6 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -10813,7 +9496,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > bindProperty 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10824,13 +9507,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -10845,7 +9521,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > classDirective 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10860,13 +9536,6 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -10883,7 +9552,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > context 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10894,13 +9563,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -10917,7 +9579,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > each 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10932,13 +9594,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -10953,7 +9608,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > eventHandlers 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -10968,13 +9623,6 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -10991,7 +9639,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > html 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11002,13 +9650,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -11023,7 +9664,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > ifElse 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11039,13 +9680,6 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   show = true;
@@ -11063,13 +9697,11 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > imports 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
-
-import Button from \\"./Button.lite\\";
 
 @Component({
   selector: \\"my-component, MyComponent\\",
@@ -11080,13 +9712,6 @@ import Button from \\"./Button.lite\\";
       </button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -11101,7 +9726,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > lifecycleHooks 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11112,13 +9737,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -11143,7 +9761,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > reactive 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11158,13 +9776,6 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -11182,7 +9793,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > reactiveWithFn 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11198,13 +9809,6 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   a = 2;
@@ -11228,7 +9832,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > slots 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11242,13 +9846,6 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {}
 
@@ -11261,7 +9858,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > style 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11274,9 +9871,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       input {
         color: red;
         font-size: 12px;
@@ -11299,7 +9893,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Javascript Test > textExpressions 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Javascript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11315,13 +9909,6 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   a = 5;
@@ -11337,7 +9924,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > basic 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > basic 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11352,13 +9939,6 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -11373,7 +9953,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > bindGroup 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > bindGroup 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11431,13 +10011,6 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -11453,7 +10026,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > bindProperty 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > bindProperty 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11464,13 +10037,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -11485,7 +10051,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > classDirective 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > classDirective 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11500,13 +10066,6 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -11523,7 +10082,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > context 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > context 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11534,13 +10093,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -11557,7 +10109,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > each 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > each 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11572,13 +10124,6 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -11593,7 +10138,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > eventHandlers 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > eventHandlers 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11608,13 +10153,6 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -11631,7 +10169,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > html 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > html 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11642,13 +10180,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -11663,7 +10194,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > ifElse 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > ifElse 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11679,13 +10210,6 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   show = true;
@@ -11703,13 +10227,11 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > imports 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > imports 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
 import { Component } from \\"@angular/core\\";
-
-import Button from \\"./Button.lite\\";
 
 @Component({
   selector: \\"my-component, MyComponent\\",
@@ -11720,13 +10242,6 @@ import Button from \\"./Button.lite\\";
       </button>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -11741,7 +10256,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > lifecycleHooks 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > lifecycleHooks 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11752,13 +10267,6 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -11783,7 +10291,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > reactive 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > reactive 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11798,13 +10306,6 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -11822,7 +10323,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > reactiveWithFn 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > reactiveWithFn 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11838,13 +10339,6 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   a = 2;
@@ -11868,7 +10362,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > slots 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > slots 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11882,13 +10376,6 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {}
 
@@ -11901,7 +10388,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > style 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > style 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11914,9 +10401,6 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
-      :host {
-        display: contents;
-      }
       input {
         color: red;
         font-size: 12px;
@@ -11939,7 +10423,7 @@ export class MyComponentModule {}
 "
 `;
 
-exports[`Angular with Preserve Imports and File Extensions > svelte > Typescript Test > textExpressions 1`] = `
+exports[`Angular with visuallyIgnoreHostElement = false > svelte > Typescript Test > textExpressions 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
 
@@ -11955,13 +10439,6 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
-  styles: [
-    \`
-      :host {
-        display: contents;
-      }
-    \`,
-  ],
 })
 export default class MyComponent {
   a = 5;

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -33,6 +33,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -99,6 +102,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -153,6 +159,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -204,6 +213,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -241,6 +257,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -285,6 +304,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -313,6 +339,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -357,6 +390,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -391,6 +431,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: any;
@@ -426,6 +473,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -458,6 +512,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -491,6 +552,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -521,6 +589,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -554,6 +629,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -584,6 +666,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -605,6 +694,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -639,6 +735,13 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: any;
@@ -678,6 +781,13 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyBooleanAttributeComponent],
 })
@@ -709,6 +819,13 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -748,6 +865,13 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyBasicComponent, MyBasicOnMountUpdateComponent],
 })
@@ -783,6 +907,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -825,6 +956,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -872,6 +1010,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -934,6 +1075,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -971,6 +1115,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event) {
@@ -1000,6 +1151,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1042,6 +1200,13 @@ export function usePrevious(value) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -1087,6 +1252,13 @@ export function usePrevious(value) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1125,6 +1297,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -1163,6 +1342,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1192,6 +1378,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -1260,6 +1449,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -1323,6 +1515,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotCode {}
 
@@ -1348,6 +1547,13 @@ import { CommonModule } from \\"@angular/common\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1385,6 +1591,13 @@ const defaultProps = {
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: any;
@@ -1437,6 +1650,13 @@ const defaultProps = {
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1471,6 +1691,13 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -1549,6 +1776,13 @@ import { CommonModule } from \\"@angular/common\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1624,6 +1858,13 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: any;
@@ -1702,6 +1943,13 @@ import { CommonModule } from \\"@angular/common\\";
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -1822,6 +2070,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -2146,6 +2397,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -2436,6 +2690,9 @@ import { Component, ViewChild, ElementRef, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -2539,6 +2796,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -2627,6 +2887,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -2657,6 +2924,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -2684,6 +2958,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: any;
@@ -2725,6 +3006,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -2767,6 +3055,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: any;
@@ -2807,6 +3102,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -2840,6 +3142,13 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Stepper {
   handleChange(value) {
@@ -2871,6 +3180,13 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, FormInputComponent],
 })
@@ -2896,6 +3212,13 @@ import { Component, Input } from \\"@angular/core\\";
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RawText {
   @Input() attributes!: any;
@@ -2923,6 +3246,13 @@ import { CommonModule } from \\"@angular/common\\";
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -2950,6 +3280,13 @@ import { Component, Input } from \\"@angular/core\\";
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionComponent {
   @Input() attributes!: any;
@@ -2982,6 +3319,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: any;
@@ -3022,6 +3366,13 @@ import { CommonModule } from \\"@angular/common\\";
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3047,6 +3398,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3090,6 +3448,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SelectComponent {
   @Input() attributes!: any;
@@ -3129,6 +3494,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3155,6 +3527,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -3178,6 +3557,13 @@ import { CommonModule } from \\"@angular/common\\";
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3202,6 +3588,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -3229,6 +3622,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
 })
@@ -3251,6 +3651,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -3276,6 +3683,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
 })
@@ -3299,6 +3713,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -3325,6 +3746,13 @@ import { CommonModule } from \\"@angular/common\\";
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3376,6 +3804,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -3480,6 +3911,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -3548,6 +3982,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubmitButton {
   @Input() attributes!: any;
@@ -3572,6 +4013,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3601,6 +4049,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Text {
   @Input() text!: any;
@@ -3635,6 +4090,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3663,6 +4125,13 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Textarea {
   @Input() attributes!: any;
@@ -3695,6 +4164,13 @@ import { CommonModule } from \\"@angular/common\\";
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3727,6 +4203,13 @@ import { Component, Input } from \\"@angular/core\\";
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Video {
   @Input() attributes!: any;
@@ -3774,6 +4257,13 @@ import { CommonModule } from \\"@angular/common\\";
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3810,6 +4300,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -3839,6 +4336,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -3879,6 +4383,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -3944,6 +4455,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4000,6 +4518,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -4036,6 +4557,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -4069,6 +4593,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -4105,6 +4632,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -4131,6 +4661,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -4172,6 +4709,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4213,6 +4757,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4243,6 +4790,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4270,6 +4820,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4300,6 +4853,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4327,6 +4883,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4357,6 +4916,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4383,6 +4945,13 @@ import { Component } from \\"@angular/core\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -4409,6 +4978,13 @@ import { CommonModule } from \\"@angular/common\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4433,6 +5009,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4468,6 +5047,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -4501,6 +5083,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -4531,6 +5120,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4559,6 +5155,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: any;
@@ -4590,6 +5193,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4612,6 +5222,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -4638,6 +5255,13 @@ import BuilderContext from \\"@dummy/context.js\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4682,6 +5306,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -4734,6 +5365,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4781,6 +5419,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any = defaultProps[\\"link\\"];
@@ -4830,6 +5475,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4859,6 +5511,13 @@ const DEFAULT_VALUES = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -4888,6 +5547,13 @@ const DEFAULT_VALUES = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4916,6 +5582,13 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -4954,6 +5627,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -4997,6 +5677,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -5053,6 +5740,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5092,6 +5786,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -5119,6 +5820,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5147,6 +5855,13 @@ import { Component, Input } from \\"@angular/core\\";
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() foo!: any;
@@ -5184,6 +5899,13 @@ import { CommonModule } from \\"@angular/common\\";
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5216,6 +5938,13 @@ import RenderBlock from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: any;
@@ -5248,6 +5977,13 @@ import RenderBlock from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, RenderBlock],
 })
@@ -5275,6 +6011,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyImportComponent {}
 
@@ -5296,6 +6039,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5314,6 +6064,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -5340,6 +6097,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5363,6 +6127,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -5402,6 +6173,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5438,6 +6216,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -5463,6 +6248,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5490,6 +6282,13 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -5518,6 +6317,13 @@ import { CommonModule } from \\"@angular/common\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5548,6 +6354,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -5582,6 +6395,13 @@ import { CommonModule } from \\"@angular/common\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5605,6 +6425,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -5655,6 +6478,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -5700,6 +6526,13 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -5731,6 +6564,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5759,6 +6599,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   constructor() {
@@ -5788,6 +6635,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5818,6 +6672,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   @Input() name!: any;
@@ -5852,6 +6713,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5879,6 +6747,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -5908,6 +6783,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -5934,6 +6816,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -5970,6 +6859,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6003,6 +6899,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -6028,6 +6931,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6050,6 +6960,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: any;
@@ -6085,6 +7002,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6125,6 +7049,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -6156,6 +7087,13 @@ import { CommonModule } from \\"@angular/common\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6182,6 +7120,13 @@ export function run(value) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -6209,6 +7154,13 @@ export function run(value) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6227,6 +7179,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -6250,6 +7209,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6273,6 +7239,13 @@ import { Component, Input } from \\"@angular/core\\";
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() type!: any;
@@ -6301,6 +7274,13 @@ import { CommonModule } from \\"@angular/common\\";
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6323,6 +7303,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -6346,6 +7333,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6366,6 +7360,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: any;
@@ -6389,6 +7390,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6409,6 +7417,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -6444,6 +7459,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -6531,6 +7553,13 @@ import { isEmptyHtmlElement } from \\"./render-block.helpers.js\\";
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -6810,6 +7839,13 @@ import RenderRepeatedBlock from \\"./render-repeated-block.js\\";
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, RenderRepeatedBlock, RenderBlock, BlockStyles],
 })
@@ -7032,6 +8068,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -7084,6 +8123,9 @@ import RenderBlocks from \\"@dummy/RenderBlocks.js\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -7133,6 +8175,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: any;
@@ -7171,6 +8220,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7195,6 +8251,13 @@ import { Component, Input } from \\"@angular/core\\";
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderStyles {
   @Input() foo!: any;
@@ -7219,6 +8282,13 @@ import { CommonModule } from \\"@angular/common\\";
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7244,6 +8314,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -7272,6 +8349,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyComponent],
 })
@@ -7298,6 +8382,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -7327,6 +8418,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyComponent],
 })
@@ -7354,6 +8452,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: any;
@@ -7385,6 +8490,13 @@ import { CommonModule } from \\"@angular/common\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7409,6 +8521,13 @@ import { Component, Input } from \\"@angular/core\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: any;
@@ -7435,6 +8554,13 @@ import { CommonModule } from \\"@angular/common\\";
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7457,6 +8583,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7493,6 +8622,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -7524,6 +8656,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -7545,6 +8684,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7563,6 +8709,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -7586,6 +8739,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7606,6 +8766,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -7627,6 +8794,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7650,6 +8824,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -7691,6 +8868,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -7726,6 +8906,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -7758,6 +8941,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -7785,6 +8971,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubComponent {}
 
@@ -7808,6 +9001,13 @@ import Foo from \\"./foo-sub-component.js\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, Foo],
 })
@@ -7847,6 +9047,13 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SvgComponent {}
 
@@ -7889,6 +9096,13 @@ import { CommonModule } from \\"@angular/common\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7907,6 +9121,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class TypeDependency {
   @Input() foo!: any;
@@ -7930,6 +9151,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -7952,6 +9180,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -7983,6 +9214,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -8011,6 +9245,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -8045,6 +9282,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -8076,6 +9316,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -8107,6 +9350,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -8133,6 +9379,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -8162,6 +9415,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8194,6 +9454,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -8225,6 +9492,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8247,6 +9521,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}} ! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -8270,6 +9551,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello {{name}} ! I can run in React, Qwik, Vue, Solid, or Liquid!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8316,6 +9604,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -8386,6 +9677,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -8444,6 +9738,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -8495,6 +9792,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForShowComponent {
   name = \\"PatrickJS\\";
@@ -8536,6 +9840,9 @@ export const DEFAULT_VALUES = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -8580,6 +9887,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8608,6 +9922,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   name = \\"PatrickJS\\";
@@ -8652,6 +9973,13 @@ import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
       <input (input)=\\"onChange\\" />
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8691,6 +10019,13 @@ export interface Props {
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnMountUpdateComponent {
   @Input() bye!: Props[\\"bye\\"];
@@ -8731,6 +10066,13 @@ export interface Props {
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8763,6 +10105,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -8796,6 +10145,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8826,6 +10182,13 @@ import { Output, EventEmitter, Component, Input } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOutputsComponent {
   @Input() message!: any;
@@ -8859,6 +10222,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8889,6 +10259,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -8910,6 +10287,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input autocapitalize=\\"on\\" autocomplete=\\"on\\" [attr.spellcheck]=\\"true\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -8949,6 +10333,13 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBooleanAttribute {
   @Input() type!: Props[\\"type\\"];
@@ -8993,6 +10384,13 @@ import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.r
       ></my-boolean-attribute-component>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyBooleanAttributeComponent],
 })
@@ -9024,6 +10422,13 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicChildComponent {
   name = \\"Steve\\";
@@ -9063,6 +10468,13 @@ import MyBasicComponent from \\"./basic.raw\\";
       </div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyBasicComponent, MyBasicOnMountUpdateComponent],
 })
@@ -9098,6 +10510,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForComponent {
   name = \\"PatrickJS\\";
@@ -9140,6 +10559,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9191,6 +10617,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -9257,6 +10686,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -9298,6 +10730,13 @@ export interface Props {
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicRefAssignmentComponent {
   handlerClick = function handlerClick(event: Event) {
@@ -9331,6 +10770,13 @@ export interface Props {
   template: \`
     <div><button (click)=\\"handlerClick($event)\\">Click</button></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9377,6 +10823,13 @@ export function usePrevious<T>(value: T) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyPreviousComponent {
   count = 0;
@@ -9426,6 +10879,13 @@ export function usePrevious<T>(value: T) {
       <button (click)=\\"count += 1\\">Increment</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9471,6 +10931,13 @@ export interface ButtonProps {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -9516,6 +10983,13 @@ export interface ButtonProps {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9560,6 +11034,9 @@ export interface ColumnProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -9643,6 +11120,9 @@ export interface ColumnProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -9713,6 +11193,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotCode {}
 
@@ -9745,6 +11232,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div><ng-content></ng-content></div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9787,6 +11281,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ContentSlotJsxCode {
   @Input() attributes!: Props[\\"attributes\\"];
@@ -9844,6 +11345,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       </div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -9883,6 +11391,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -9966,6 +11481,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -10046,6 +11568,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class CustomCode {
   @Input() replaceNodes!: CustomCodeProps[\\"replaceNodes\\"];
@@ -10129,6 +11658,13 @@ export interface CustomCodeProps {
       [innerHTML]=\\"code\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -10273,6 +11809,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -10628,6 +12167,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .pre {
         padding: 10px;
         color: red;
@@ -10944,6 +12486,9 @@ export interface ImageProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -11066,6 +12611,9 @@ export interface ImageProps {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .img {
         opacity: 1;
         transition: opacity 0.2s ease-in-out;
@@ -11154,6 +12702,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgStateComponent {
   canShow = true;
@@ -11184,6 +12739,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11228,6 +12790,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ImgComponent {
   @Input() backgroundSize!: ImgProps[\\"backgroundSize\\"];
@@ -11286,6 +12855,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [attr.src]=\\"imgSrc\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11339,6 +12915,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class FormInputComponent {
   @Input() attributes!: FormInputProps[\\"attributes\\"];
@@ -11390,6 +12973,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       (input)=\\"onChange?.($event.target.value)\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11423,6 +13013,13 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Stepper {
   handleChange(value: string) {
@@ -11454,6 +13051,13 @@ import FormInputComponent from \\"./input.raw\\";
       (change)=\\"handleChange($event)\\"
     ></form-input-component>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, FormInputComponent],
 })
@@ -11484,6 +13088,13 @@ export interface RawTextProps {
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RawText {
   @Input() attributes!: RawTextProps[\\"attributes\\"];
@@ -11516,6 +13127,13 @@ export interface RawTextProps {
       [innerHTML]=\\"text || ''\\"
     ></span>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11549,6 +13167,13 @@ export interface SectionProps {
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -11587,6 +13212,13 @@ export interface SectionProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SectionStateComponent {
   @Input() attributes!: SectionProps[\\"attributes\\"];
@@ -11633,6 +13265,13 @@ export interface SectionProps {
       <ng-content></ng-content>
     </section>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11664,6 +13303,13 @@ export interface SectionProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11718,6 +13364,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SelectComponent {
   @Input() attributes!: FormSelectProps[\\"attributes\\"];
@@ -11768,6 +13421,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       </ng-container>
     </select>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11798,6 +13458,13 @@ type Props = {
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -11825,6 +13492,13 @@ type Props = {
       <ng-content><div class=\\"default-slot\\">Default content</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -11853,6 +13527,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -11884,6 +13565,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       </content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
 })
@@ -11910,6 +13598,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -11939,6 +13634,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
       <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
 })
@@ -11966,6 +13668,13 @@ type Props = {
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SlotCode {}
 
@@ -11996,6 +13705,13 @@ type Props = {
       <ng-content>Default Child</ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12052,6 +13768,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -12161,6 +13880,9 @@ import { kebabCase, snakeCase } from \\"lodash\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         display: block;
       }
@@ -12234,6 +13956,13 @@ export interface ButtonProps {
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubmitButton {
   @Input() attributes!: ButtonProps[\\"attributes\\"];
@@ -12263,6 +13992,13 @@ export interface ButtonProps {
   template: \`
     <button type=\\"submit\\">{{text}}</button>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12300,6 +14036,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Text {
   @Input() text!: TextProps[\\"text\\"];
@@ -12342,6 +14085,13 @@ import { Builder } from \\"@builder.io/sdk\\";
       [innerHTML]=\\"text || content || name || '<p class=&quot;text-lg&quot;>my name</p>'\\"
     ></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12378,6 +14128,13 @@ export interface TextareaProps {
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Textarea {
   @Input() attributes!: TextareaProps[\\"attributes\\"];
@@ -12418,6 +14175,13 @@ export interface TextareaProps {
       [attr.defaultValue]=\\"defaultValue\\"
     ></textarea>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12476,6 +14240,13 @@ export interface VideoProps {
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Video {
   @Input() attributes!: VideoProps[\\"attributes\\"];
@@ -12549,6 +14320,13 @@ export interface VideoProps {
       [attr.loop]=\\"loop\\"
     ></video>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12585,6 +14363,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"steve\\";
@@ -12614,6 +14399,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12654,6 +14446,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicForNoTagRefComponent {
   @Input() actions!: any;
@@ -12719,6 +14518,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -12780,6 +14586,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -12821,6 +14630,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -12859,6 +14671,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -12900,6 +14715,9 @@ export interface Props {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .input {
         color: red;
       }
@@ -12926,6 +14744,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicOnUpdateReturnComponent {
   name = \\"PatrickJS\\";
@@ -12967,6 +14792,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Hello! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13008,6 +14840,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13038,6 +14873,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13065,6 +14903,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13095,6 +14936,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13122,6 +14966,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13152,6 +14999,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13185,6 +15035,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ClassNameCode {
   bindings = \\"a binding\\";
@@ -13218,6 +15075,13 @@ import type { JSX } from \\"../../../../jsx-runtime\\";
       <div [class]=\\"bindings\\">With binding</div>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13242,6 +15106,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13277,6 +15144,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -13314,6 +15184,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -13348,6 +15225,13 @@ import Context2 from \\"@dummy/2\\";
       <ng-container>{{foo.value}}</ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13380,6 +15264,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithContext {
   @Input() content!: ComponentWithContextProps[\\"content\\"];
@@ -13415,6 +15306,13 @@ import Context2 from \\"@dummy/2\\";
       <div>other</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13437,6 +15335,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() content!: any;
@@ -13463,6 +15368,13 @@ import BuilderContext from \\"@dummy/context.js\\";
   template: \`
     <div>setting context</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13516,6 +15428,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -13578,6 +15497,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13633,6 +15559,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"] = defaultProps[\\"link\\"];
@@ -13690,6 +15623,13 @@ const defaultProps = {
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13724,6 +15664,13 @@ const DEFAULT_VALUES: Props = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ComponentWithTypes {
   DEFAULT_VALUES = DEFAULT_VALUES;
@@ -13757,6 +15704,13 @@ const DEFAULT_VALUES: Props = {
   template: \`
     <div>Hello {{name || DEFAULT_VALUES.name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13785,6 +15739,13 @@ import { Component, Input } from \\"@angular/core\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -13823,6 +15784,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13866,6 +15834,13 @@ import {
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() attributes!: any;
@@ -13922,6 +15897,13 @@ import { CommonModule } from \\"@angular/common\\";
               \\"
     ></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -13961,6 +15943,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() componentRef!: any;
@@ -13988,6 +15977,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{refToUse}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14020,6 +16016,13 @@ export interface ButtonProps {
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() foo!: ButtonProps[\\"foo\\"];
@@ -14061,6 +16064,13 @@ export interface ButtonProps {
       <p>{{baz(1)}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14100,6 +16110,13 @@ import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderContent {
   @Input() renderContentProps!: RenderContentProps[\\"renderContentProps\\"];
@@ -14139,6 +16156,13 @@ import RenderBlock, { RenderBlockProps } from \\"./builder-render-block.raw\\";
   template: \`
     <render-block></render-block>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, RenderBlock],
 })
@@ -14166,6 +16190,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyImportComponent {}
 
@@ -14187,6 +16218,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>Testing which imports get excluded!</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14205,6 +16243,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdate {
   ngAfterContentChecked() {
@@ -14231,6 +16276,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14254,6 +16306,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MultipleOnUpdateWithDeps {
   a = \\"a\\";
@@ -14293,6 +16352,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14329,6 +16395,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   attrs = {
@@ -14354,6 +16427,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14381,6 +16461,13 @@ import { Component, Input } from \\"@angular/core\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -14409,6 +16496,13 @@ import { CommonModule } from \\"@angular/common\\";
       be visible in the DOM.
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14444,6 +16538,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -14483,6 +16584,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14506,6 +16614,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -14556,6 +16667,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         --bar: red;
@@ -14601,6 +16715,13 @@ import { Component, ViewChild, ElementRef } from \\"@angular/core\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Embed {
   @ViewChild(\\"elem\\") elem!: ElementRef;
@@ -14632,6 +16753,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div class=\\"builder-embed\\" #elem><div>Test</div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14660,6 +16788,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   constructor() {
@@ -14689,6 +16824,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14723,6 +16865,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnInit {
   @Input() name!: Props[\\"name\\"];
@@ -14761,6 +16910,13 @@ export const defaultValues = {
   template: \`
     <div>Default name defined by parent {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14788,6 +16944,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -14817,6 +16980,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14843,6 +17013,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Comp {
   ngOnInit() {
@@ -14879,6 +17056,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14912,6 +17096,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   ngAfterContentChecked() {
@@ -14937,6 +17128,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -14963,6 +17161,13 @@ type Props = {
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdateWithDeps {
   @Input() size!: Props[\\"size\\"];
@@ -15002,6 +17207,13 @@ type Props = {
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15042,6 +17254,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -15073,6 +17292,13 @@ import { CommonModule } from \\"@angular/common\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15109,6 +17335,13 @@ export function run<T>(value: T) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -15146,6 +17379,13 @@ export function run<T>(value: T) {}
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15177,6 +17417,13 @@ export interface MyBasicComponentProps {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: MyBasicComponentProps[\\"name\\"];
@@ -15213,6 +17460,13 @@ export interface MyBasicComponentProps {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15241,6 +17495,13 @@ type Props = {
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() type!: Props[\\"type\\"];
@@ -15274,6 +17535,13 @@ type Props = {
       {{type}} Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15301,6 +17569,13 @@ interface Person {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person | never[\\"name\\"];
@@ -15329,6 +17604,13 @@ interface Person {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15354,6 +17636,13 @@ type Person = {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() name!: Person[\\"name\\"];
@@ -15382,6 +17671,13 @@ type Person = {
   template: \`
     <div>Hello! I can run in React, Vue, Solid, or Liquid! {{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15402,6 +17698,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class OnUpdate {
   foo = function foo(params) {};
@@ -15437,6 +17740,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -15536,6 +17846,13 @@ import type { RepeatData } from \\"./types.js\\";
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderBlock {
   isEmptyHtmlElement = isEmptyHtmlElement;
@@ -15828,6 +18145,13 @@ import type { RepeatData } from \\"./types.js\\";
       ></ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, RenderRepeatedBlock, RenderBlock, BlockStyles],
 })
@@ -16058,6 +18382,9 @@ import {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -16118,6 +18445,9 @@ import RenderBlocks from \\"@dummy/RenderBlocks.js\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: columns;
@@ -16174,6 +18504,13 @@ export interface ButtonProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class Button {
   @Input() link!: ButtonProps[\\"link\\"];
@@ -16219,6 +18556,13 @@ export interface ButtonProps {
       </ng-container>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16247,6 +18591,13 @@ export interface RenderStylesProps {
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class RenderStyles {
   @Input() foo!: RenderStylesProps[\\"foo\\"];
@@ -16275,6 +18626,13 @@ export interface RenderStylesProps {
     <ng-container *ngIf=\\"foo === 'bar'\\"><div>Bar</div></ng-container>
     <ng-container *ngIf=\\"!(foo === 'bar')\\"><div>Foo</div></ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16300,6 +18658,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -16328,6 +18693,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyComponent],
 })
@@ -16354,6 +18726,13 @@ import { Component, Input } from \\"@angular/core\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() name!: any;
@@ -16383,6 +18762,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, MyComponent],
 })
@@ -16415,6 +18801,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class NestedShow {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -16451,6 +18844,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16479,6 +18879,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class ShowRootText {
   @Input() conditionA!: Props[\\"conditionA\\"];
@@ -16509,6 +18916,13 @@ interface Props {
       <div>else-condition-A</div>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16540,6 +18954,9 @@ type Props = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -16585,6 +19002,9 @@ type Props = {
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         padding: 10px;
       }
@@ -16616,6 +19036,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -16637,6 +19064,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16655,6 +19089,13 @@ import { Component, Input } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {
   @Input() nested!: any;
@@ -16678,6 +19119,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16698,6 +19146,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicComponent {}
 
@@ -16719,6 +19174,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -16742,6 +19204,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -16783,6 +19248,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -16818,6 +19286,9 @@ import { Component, Input } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -16850,6 +19321,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       .div {
         display: flex;
         flex-direction: column;
@@ -16877,6 +19351,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SubComponent {}
 
@@ -16900,6 +19381,13 @@ import Foo from \\"./foo-sub-component.js\\";
   template: \`
     <foo></foo>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, Foo],
 })
@@ -16939,6 +19427,13 @@ import { Component } from \\"@angular/core\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class SvgComponent {}
 
@@ -16981,6 +19476,13 @@ import { CommonModule } from \\"@angular/common\\";
       </defs>
     </svg>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17006,6 +19508,13 @@ import type { Foo } from \\"./foo-type\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class TypeDependency {
   @Input() foo!: TypeDependencyProps[\\"foo\\"];
@@ -17037,6 +19546,13 @@ import type { Foo as Foo2 } from \\"./type-export.js\\";
   template: \`
     <div>{{foo}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17059,6 +19575,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -17090,6 +19609,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -17118,6 +19640,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -17152,6 +19677,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         font-size: 12px;
         outline: 1px solid black;
@@ -17183,6 +19711,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -17214,6 +19745,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       button {
         background: blue;
         color: white;
@@ -17240,6 +19774,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class UseTargetComponent {
   get name() {
@@ -17269,6 +19810,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{name}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17301,6 +19849,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyBasicWebComponent {
   constructor() {
@@ -17332,6 +19887,13 @@ import { register } from \\"swiper/element/bundle\\";
       <swiper-slide>Slide 3</swiper-slide>
     </swiper-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17358,6 +19920,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -17385,6 +19954,13 @@ import { CommonModule } from \\"@angular/common\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17452,6 +20028,13 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -17523,6 +20106,13 @@ import { CommonModule } from \\"@angular/common\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17544,6 +20134,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -17567,6 +20164,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17591,6 +20195,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -17620,6 +20231,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17642,6 +20260,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -17667,6 +20292,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17693,6 +20325,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -17720,6 +20359,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17744,6 +20390,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -17773,6 +20426,13 @@ import { CommonModule } from \\"@angular/common\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17795,6 +20455,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -17818,6 +20485,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17843,6 +20517,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   show = true;
@@ -17874,6 +20555,13 @@ import { CommonModule } from \\"@angular/common\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -17901,6 +20589,13 @@ import { Component } from \\"@angular/core\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -17930,6 +20625,13 @@ import Button from \\"./Button.js\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, Button],
 })
@@ -17950,6 +20652,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -17983,6 +20692,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18017,6 +20733,13 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -18047,6 +20770,13 @@ import { CommonModule } from \\"@angular/common\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18075,6 +20805,13 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 2;
@@ -18112,6 +20849,13 @@ import { CommonModule } from \\"@angular/common\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18144,6 +20888,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -18168,6 +20919,13 @@ import { CommonModule } from \\"@angular/common\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18188,6 +20946,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -18221,6 +20982,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -18254,6 +21018,13 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 5;
@@ -18283,6 +21054,13 @@ import { CommonModule } from \\"@angular/common\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18308,6 +21086,13 @@ import { Component } from \\"@angular/core\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -18335,6 +21120,13 @@ import { CommonModule } from \\"@angular/common\\";
       Hello! I can run in React, Vue, Solid, or Liquid!
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18402,6 +21194,13 @@ import { Component } from \\"@angular/core\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   tortilla = \\"Plain\\";
@@ -18473,6 +21272,13 @@ import { CommonModule } from \\"@angular/common\\";
       <p>Fillings: {{fillings}}</p>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18494,6 +21300,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   value = \\"hello\\";
@@ -18517,6 +21330,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <input [attr.value]=\\"value\\" />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18541,6 +21361,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   @Input() disabled!: any;
@@ -18570,6 +21397,13 @@ const defaultProps = {};
       [class]=\\"\\\\\`form-input \\\\\${disabled ? 'disabled' : ''} \\\\\${focus ? 'focus' : ''}\\\\\`\\"
     />
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18592,6 +21426,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   activeTab = 0;
@@ -18617,6 +21458,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div>{{activeTab}}</div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18643,6 +21491,13 @@ import { Component } from \\"@angular/core\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   numbers = [\\"one\\", \\"two\\", \\"three\\"];
@@ -18670,6 +21525,13 @@ import { CommonModule } from \\"@angular/common\\";
       </ng-container>
     </ul>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18694,6 +21556,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   log = function log(msg = \\"hello\\") {
@@ -18723,6 +21592,13 @@ import { CommonModule } from \\"@angular/common\\";
       <button (click)=\\"log($event)\\">Log</button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18745,6 +21621,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   html = \\"<b>bold</b>\\";
@@ -18768,6 +21651,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div [innerHTML]=\\"html\\"></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18793,6 +21683,13 @@ import { Component } from \\"@angular/core\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   show = true;
@@ -18824,6 +21721,13 @@ import { CommonModule } from \\"@angular/common\\";
       <button (click)=\\"toggle($event)\\">Show</button>
     </ng-container>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18851,6 +21755,13 @@ import { Component } from \\"@angular/core\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   disabled = false;
@@ -18880,6 +21791,13 @@ import Button from \\"./Button.js\\";
       </button>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule, Button],
 })
@@ -18900,6 +21818,13 @@ import { Component } from \\"@angular/core\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   ngOnInit() {
@@ -18933,6 +21858,13 @@ import { CommonModule } from \\"@angular/common\\";
   template: \`
     <div></div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -18967,6 +21899,13 @@ import { Component } from \\"@angular/core\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   name = \\"Steve\\";
@@ -18997,6 +21936,13 @@ import { CommonModule } from \\"@angular/common\\";
       Lowercase: {{lowercaseName}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -19025,6 +21971,13 @@ import { Component } from \\"@angular/core\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 2;
@@ -19062,6 +22015,13 @@ import { CommonModule } from \\"@angular/common\\";
       Result: {{result}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -19094,6 +22054,13 @@ import { Component } from \\"@angular/core\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {}
 
@@ -19118,6 +22085,13 @@ import { CommonModule } from \\"@angular/common\\";
       <ng-content select=\\"[test]\\"><div>default</div></ng-content>
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })
@@ -19138,6 +22112,9 @@ import { Component } from \\"@angular/core\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -19171,6 +22148,9 @@ import { CommonModule } from \\"@angular/common\\";
   \`,
   styles: [
     \`
+      :host {
+        display: contents;
+      }
       input {
         color: red;
         font-size: 12px;
@@ -19204,6 +22184,13 @@ import { Component } from \\"@angular/core\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
 })
 export default class MyComponent {
   a = 5;
@@ -19233,6 +22220,13 @@ import { CommonModule } from \\"@angular/common\\";
       conditional {{a > 2 ? 'hello' : 'bye'}}
     </div>
   \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
   standalone: true,
   imports: [CommonModule],
 })

--- a/packages/core/src/__tests__/angular.styles.test.ts
+++ b/packages/core/src/__tests__/angular.styles.test.ts
@@ -1,0 +1,12 @@
+import { componentToAngular } from '../generators/angular';
+import { runTestsForTarget } from './test-generator';
+
+describe('Angular with visuallyIgnoreHostElement = false', () => {
+  runTestsForTarget({
+    options: {
+      visuallyIgnoreHostElement: false,
+    },
+    target: 'angular',
+    generator: componentToAngular,
+  });
+});

--- a/packages/core/src/generators/angular/index.ts
+++ b/packages/core/src/generators/angular/index.ts
@@ -632,6 +632,9 @@ export const componentToAngular: TranspilerGenerator<ToAngularOptions> =
       },
     );
 
+    const hostDisplayCss = options.visuallyIgnoreHostElement ? ':host { display: contents; }' : '';
+    const styles = css.length ? [hostDisplayCss, css].join('\n') : hostDisplayCss;
+
     // Preparing built in component metadata parameters
     const componentMetadata: Record<string, any> = {
       selector: `'${kebabCase(json.name || 'my-component')}, ${json.name}'`,
@@ -639,9 +642,9 @@ export const componentToAngular: TranspilerGenerator<ToAngularOptions> =
         ${indent(dynamicTemplate, 8).replace(/`/g, '\\`').replace(/\$\{/g, '\\${')}
         ${indent(template, 8).replace(/`/g, '\\`').replace(/\$\{/g, '\\${')}
         \``,
-      ...(css.length
+      ...(styles
         ? {
-            styles: `[\`${indent(css, 8)}\`]`,
+            styles: `[\`${indent(styles, 8)}\`]`,
           }
         : {}),
       ...(options.standalone

--- a/packages/core/src/generators/angular/types.ts
+++ b/packages/core/src/generators/angular/types.ts
@@ -8,11 +8,13 @@ export interface ToAngularOptions extends BaseTranspilerOptions {
   preserveFileExtensions?: boolean;
   importMapper?: Function;
   bootstrapMapper?: Function;
+  visuallyIgnoreHostElement?: boolean;
 }
 
 export const DEFAULT_ANGULAR_OPTIONS: ToAngularOptions = {
   preserveImports: false,
   preserveFileExtensions: false,
+  visuallyIgnoreHostElement: true,
 };
 
 export interface AngularBlockOptions {


### PR DESCRIPTION
## Description

In this PR, we are adding a new option called `visuallyIgnoreHostElement` which attaches `display: contents;` to the host angular element, which means they will now just be considered as decoration element and will not interfere with dom stylings in any way. 

> Why is this needed? Refer: https://stackoverflow.com/questions/34280475/remove-the-host-html-element-selectors-created-by-angular-component/52292365#52292365

> `display: contents` causes an element's children to appear as if they were direct children of the element's parent, ignoring the element itself. This can be useful when a wrapper element should be ignored when using CSS grid or similar layout techniques.

### Steps to reproduce

- Go to [angular.dev](https://angular.dev/) playground
- Use this code snippet,
```ts
import {Component} from '@angular/core';
import {bootstrapApplication} from '@angular/platform-browser';

@Component({
  selector: 'deep',
  standalone: true,
  template: `
  <style>
    .div {
      margin-left: auto;
      margin-right: auto;
    }
    </style>
    <div class="div"><ng-content></ng-content></div>
  `,
  //styles: [':host { display: contents; }']
})
export class Deep{}

@Component({
  selector: 'nested',
  standalone: true,
  template: `
    <deep>hello</deep>
  `,
  imports: [Deep],
  //styles: [':host { display: contents; }']
})
export class Nested{}

@Component({
  selector: 'hello',
  standalone: true,
  template: `
   <style>
    .div2 {
      display: flex;
      flex-direction: column;
    }
    </style>
  <div class="div2">
    <nested />
    <nested />
    <nested />
    </div>
  `,
  imports: [Nested],
  //styles: [':host { display: contents; }']
})
export class Hello{}

@Component({
  selector: 'app-root',
  standalone: true,
  template: `
    <hello></hello>
  `,
  imports: [Hello],
})
export class PlaygroundComponent {}

bootstrapApplication(PlaygroundComponent);
```
- inspect elements and notice the angular components act as elements on the DOM and interfere with margin:auto which should've been applied in normal case and angular components should just behave as fragments
- if you add the comments back (display: contents), content are now centered because angular elements don't hamper the stylings now