### PR TITLE
fix: npm run start script on win

### DIFF
--- a/.changeset/twenty-cheetahs-carry.md
+++ b/.changeset/twenty-cheetahs-carry.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/create-mitosis": patch
+---
+
+Fix: `npm run start` command on Windows.

--- a/packages/starter/template/library/package.json
+++ b/packages/starter/template/library/package.json
@@ -2,7 +2,7 @@
   "name": "@template/library",
   "private": true,
   "scripts": {
-    "start": "watch 'npm run build' ./src",
+    "start": "watch \"npm run build\" ./src",
     "build": "mitosis build --c mitosis.config.cjs",
     "lint": "eslint"
   },


### PR DESCRIPTION
## Description

This PR is related to issue #1444
The launch of command `npm run start` failed on windows because of the single quote inside the command start in the `package.json`:

```json
"start": "watch 'npm run build' ./src",
```

To make it work on windows too, it is enough to replace them with escaped double quotes
This small fix solves the problem and allows it to be run on windows too.