### PR TITLE
fix(docs): correct typo in using-libraries

### DIFF
--- a/packages/docs/src/routes/docs/using-libraries/index.mdx
+++ b/packages/docs/src/routes/docs/using-libraries/index.mdx
@@ -65,7 +65,7 @@ In the `overrides/` directory of a [Mitosis project](/docs/project-structure/), 
 you want to override.
 
 For example, if you have a file in `src/components/foo.lite.tsx` and you need a specific
-implemtnation for Angular, for instance to use a specific library or unique feature, you can
+implementation for Angular, for instance to use a specific library or unique feature, you can
 create a file `overrides/angular/src/components.foo.ts` and provide the Angular-specific implementation.
 
 See examples in the [overrides directory](https://github.com/BuilderIO/builder/tree/main/packages/sdks/overrides)

--- a/packages/docs/src/routes/docs/using-libraries/index.mdx
+++ b/packages/docs/src/routes/docs/using-libraries/index.mdx
@@ -20,7 +20,7 @@ export default function MyComponent(props: { name: string }) {
 ## Framework-specific libraries
 
 Because of the cross-framework nature of Mitosis, you cannot use framework-specific libraries
-direclty in Mitosis code.
+directly in Mitosis code.
 
 For instance a React form library wouldn't make sense in the context of Mitosis, because
 Mitosis components are framework-agnostic, so how would it work with Vue or Svelte?


### PR DESCRIPTION

Correct typo in using-libraries of docs
