### PR TITLE
fix(docs): hide overview ruler column in code editor

### DIFF
--- a/packages/docs/src/components/code-editor.tsx
+++ b/packages/docs/src/components/code-editor.tsx
@@ -60,6 +60,7 @@ export const CodeEditor = component$((props: CodeEditorProps) => {
         renderLineHighlight: 'none',
         selectionHighlight: false,
         scrollbar: { vertical: 'hidden' },
+        overviewRulerLanes: 0,
         minimap: {
           enabled: false,
         },


### PR DESCRIPTION
## Description

The monaco code editor in the playground shows a small gray border where the overview ruler is.

![CleanShot 2024-05-23 at 00 10 11@2x](https://github.com/BuilderIO/mitosis/assets/13732623/04bc5a87-5e16-4bac-8c02-9ec0f8a3d3dd)

This PR disables that canvas element (border) from rendering:

![CleanShot 2024-05-23 at 00 12 23@2x](https://github.com/BuilderIO/mitosis/assets/13732623/cfd8a3b0-c2d5-4110-a1f9-0c7ffeab5828)

Documentation for `overviewRulerLanes` option is available here: https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneEditorConstructionOptions.html#overviewRulerLanes

I believe this is the intended visual display based on the vertical scrollbars being hidden. I'm not sure why the production site is not capitalizing the dropdown text for "jsx" vs. "Jsx" as seen in the screenshots, but that is outside of the scope of my changes. 