### PR TITLE
improve docs - fix spelling and grammar & clarify some points

### DIFF
--- a/packages/docs/src/routes/docs/components/index.mdx
+++ b/packages/docs/src/routes/docs/components/index.mdx
@@ -182,7 +182,7 @@ Control flow in Builder is static like [Solid](https://github.com/ryansolid/soli
 
 ### Show
 
-Use `<Show>` for conditional logic. It takes a single `when` prop for the condition to match. When the condition is truthy, the children will render; otherwise, they will not. You can additionally provide an `else` prop for the content to be rendered in case the condition is falsy."
+Use `<Show>` for conditional logic. It takes a single `when` prop for the condition to match. When the condition is truthy, the children will render; otherwise, they will not. You can additionally provide an `else` prop for the content to be rendered in case the condition is falsy.
 
 ```tsx
 export default function MyComponent(props) {

--- a/packages/docs/src/routes/docs/components/index.mdx
+++ b/packages/docs/src/routes/docs/components/index.mdx
@@ -6,9 +6,9 @@ title: Components - Mitosis
 
 ## At a glance
 
-Mitosis is inspired by many modern frameworks. You'll see components look like React components and use React-like hooks, but have simple mutable state like Vue, use a static form of JSX like Solid, compile away like Svelte, and uses a simple, prescriptive structure like Angular.
+Mitosis is inspired by many modern frameworks. You'll see components that look like React components and use React-like hooks, but have simple mutable state like Vue, use a static form of JSX like Solid, compile away like Svelte, and use a simple, prescriptive structure like Angular.
 
-An example Mitosis component showing several features:
+An example of a Mitosis component showing several features:
 
 ```tsx
 import { For, Show, useStore } from '@builder.io/mitosis';
@@ -104,7 +104,7 @@ Components automatically update when state values change
 
 ### useState
 
-Alternatlively, you can use the `useState` hook to create a single piece of state
+Alternatively, you can use the `useState` hook to create a single piece of state
 
 ```tsx
 export default function MyComponent() {
@@ -145,7 +145,7 @@ export default function MyComponent() {
 
 ### `css`
 
-Styling is done via the `css` prop on dom elements and components. It takes CSS properties in `camelCase` (like the `style` object on DOM elements) and properties as valid CSS strings
+Styling is done via the `css` prop on DOM elements and components. It takes CSS properties in `camelCase` (like the `style` object on DOM elements) and properties as valid CSS strings
 
 ```tsx
 export default function CSSExample() {
@@ -182,7 +182,7 @@ Control flow in Builder is static like [Solid](https://github.com/ryansolid/soli
 
 ### Show
 
-Use `<Show>` for conditional logic. It takes a singular `when` prop for a condition to match for. When the condition is truthy, the children will render, the `else` otherwise they will not.
+Use `<Show>` for conditional logic. It takes a single `when` prop for the condition to match. When the condition is truthy, the children will render; otherwise, they will not. You can additionally provide an `else` prop for the content to be rendered in case the condition is falsy."
 
 ```tsx
 export default function MyComponent(props) {


### PR DESCRIPTION
fixes some spelling and grammar issues in the docs. also clarified the points about `<Show>` since it was confusing.