### PR TITLE
fix: [Angular] fix logic used for parsing objects provided as input to useObjectWrapper

### DIFF
--- a/.changeset/perfect-seas-bow.md
+++ b/.changeset/perfect-seas-bow.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': minor
+---
+
+fix logic responsible for parsing object provided to useObjectWrapper angular method

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -5149,6 +5149,58 @@ export class MyComponentModule {}
 "
 `;
 
+exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with Preserve Imports and File Extensions > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -10829,6 +10881,58 @@ export default class MyComponent {}
 @NgModule({
   declarations: [MyComponent],
   imports: [CommonModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular with Preserve Imports and File Extensions > jsx > Typescript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -5252,6 +5252,59 @@ export class MyComponentModule {}
 "
 `;
 
+exports[`Angular with Import Mapper Tests > jsx > Javascript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+  bootstrap: [SomeOtherComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with Import Mapper Tests > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11039,6 +11092,59 @@ export default class MyComponent {}
 @NgModule({
   declarations: [MyComponent],
   imports: [CommonModule],
+  exports: [MyComponent],
+  bootstrap: [SomeOtherComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular with Import Mapper Tests > jsx > Typescript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
   exports: [MyComponent],
   bootstrap: [SomeOtherComponent],
 })

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -5361,6 +5361,82 @@ export class MyComponentModule {}
 "
 `;
 
+exports[`Angular with manually creating and handling class properties as bindings (more stable) > jsx > Javascript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent [tooltipPlacementOptions]=\\"node_0_CustomComponent\\">
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {
+  node_0_CustomComponent = null;
+
+  ngOnInit() {
+    this.node_0_CustomComponent = {
+      positions: [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+      offsets: {
+        left: {
+          topOffset: 0,
+          leftOffset: -24,
+        },
+        bottom: {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+        \\"bottom-left\\": {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+      },
+    };
+  }
+
+  ngOnChanges() {
+    this.node_0_CustomComponent = {
+      positions: [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+      offsets: {
+        left: {
+          topOffset: 0,
+          leftOffset: -24,
+        },
+        bottom: {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+        \\"bottom-left\\": {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+      },
+    };
+  }
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with manually creating and handling class properties as bindings (more stable) > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -11251,6 +11327,82 @@ export default class MyComponent {}
 @NgModule({
   declarations: [MyComponent],
   imports: [CommonModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular with manually creating and handling class properties as bindings (more stable) > jsx > Typescript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent [tooltipPlacementOptions]=\\"node_0_CustomComponent\\">
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {
+  node_0_CustomComponent = null;
+
+  ngOnInit() {
+    this.node_0_CustomComponent = {
+      positions: [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+      offsets: {
+        left: {
+          topOffset: 0,
+          leftOffset: -24,
+        },
+        bottom: {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+        \\"bottom-left\\": {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+      },
+    };
+  }
+
+  ngOnChanges() {
+    this.node_0_CustomComponent = {
+      positions: [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+      offsets: {
+        left: {
+          topOffset: 0,
+          leftOffset: -24,
+        },
+        bottom: {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+        \\"bottom-left\\": {
+          topOffset: 24,
+          leftOffset: 0,
+        },
+      },
+    };
+  }
+}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -4502,6 +4502,51 @@ export class MyComponentModule {}
 "
 `;
 
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
 exports[`Angular with visuallyIgnoreHostElement = false > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -9512,6 +9557,51 @@ export default class MyComponent {}
 @NgModule({
   declarations: [MyComponent],
   imports: [CommonModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular with visuallyIgnoreHostElement = false > jsx > Typescript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
   exports: [MyComponent],
 })
 export class MyComponentModule {}

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -9558,6 +9558,103 @@ export default class MyComponent {}
 "
 `;
 
+exports[`Angular > jsx > Javascript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular > jsx > Javascript Test > useObjectWrapper 2`] = `
+"import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+  standalone: true,
+  imports: [CommonModule, CustomComponent],
+})
+export default class MyComponent {}
+"
+`;
+
 exports[`Angular > jsx > Javascript Test > useTarget 1`] = `
 "import { NgModule } from \\"@angular/core\\";
 import { CommonModule } from \\"@angular/common\\";
@@ -20162,6 +20259,103 @@ import { CommonModule } from \\"@angular/common\\";
   ],
   standalone: true,
   imports: [CommonModule],
+})
+export default class MyComponent {}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > useObjectWrapper 1`] = `
+"import { NgModule } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+import { Component } from \\"@angular/core\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+})
+export default class MyComponent {}
+
+@NgModule({
+  declarations: [MyComponent],
+  imports: [CommonModule, CustomComponentModule],
+  exports: [MyComponent],
+})
+export class MyComponentModule {}
+"
+`;
+
+exports[`Angular > jsx > Typescript Test > useObjectWrapper 2`] = `
+"import { Component } from \\"@angular/core\\";
+import { CommonModule } from \\"@angular/common\\";
+
+@Component({
+  selector: \\"my-component, MyComponent\\",
+  template: \`
+    <div>
+      <CustomComponent
+        [tooltipPlacementOptions]='{
+          \\"positions\\": [\\"left\\", \\"bottom\\", \\"bottom-left\\"],
+          \\"offsets\\": {
+            \\"left\\": {
+              \\"topOffset\\": 0,
+              \\"leftOffset\\": -24
+            },
+            \\"bottom\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            },
+            \\"bottom-left\\": {
+              \\"topOffset\\": 24,
+              \\"leftOffset\\": 0
+            }
+          }
+        }'
+      >
+        test
+      </CustomComponent>
+    </div>
+  \`,
+  styles: [
+    \`
+      :host {
+        display: contents;
+      }
+    \`,
+  ],
+  standalone: true,
+  imports: [CommonModule, CustomComponent],
 })
 export default class MyComponent {}
 "

--- a/packages/core/src/__tests__/data/angular/use-object-wrapper.raw.tsx
+++ b/packages/core/src/__tests__/data/angular/use-object-wrapper.raw.tsx
@@ -1,0 +1,18 @@
+export default function MyComponent(props) {
+  return (
+    <div>
+      <CustomComponent
+        tooltipPlacementOptions={{
+          positions: ['left', 'bottom', 'bottom-left'],
+          offsets: {
+            left: { topOffset: 0, leftOffset: -24 },
+            bottom: { topOffset: 24, leftOffset: 0 },
+            'bottom-left': { topOffset: 24, leftOffset: 0 },
+          },
+        }}
+      >
+        test
+      </CustomComponent>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/test-generator.ts
+++ b/packages/core/src/__tests__/test-generator.ts
@@ -285,6 +285,7 @@ const ANGULAR_TESTS: Tests = {
   dynamicComponentWithEventArg: getRawFile(
     './data/angular/dynamic-component-with-event-args.raw.tsx',
   ),
+  useObjectWrapper: getRawFile('./data/angular/use-object-wrapper.raw.tsx'),
 };
 
 const CONTEXT_TEST: Tests = {

--- a/packages/core/src/generators/angular/index.ts
+++ b/packages/core/src/generators/angular/index.ts
@@ -124,29 +124,10 @@ const handleObjectBindings = (code: string) => {
   let objectCode = code.replace(/^{/, '').replace(/}$/, '');
   objectCode = objectCode.replace(/\/\/.*\n/g, '');
 
-  const spreadOutObjects = objectCode
-    .split(',')
-    .filter((item) => item.includes('...'))
-    .map((item) => item.replace('...', '').trim());
-
-  const objectKeys = objectCode
-    .split(',')
-    .filter((item) => !item.includes('...'))
-    .map((item) => item.trim());
-
-  const otherObjs = objectKeys.map((item) => {
-    return `{ ${item} }`;
-  });
-
-  let temp = `${spreadOutObjects.join(', ')}, ${otherObjs.join(', ')}`;
-
-  if (temp.endsWith(', ')) {
-    temp = temp.slice(0, -2);
-  }
-
-  if (temp.startsWith(', ')) {
-    temp = temp.slice(2);
-  }
+  let temp = objectCode.replace(/\.\.\./g, '');
+  temp = temp.replace(/\{(\w+)}/g, '$1');
+  temp = temp.replace(/\{{2,}/g, '{');
+  temp = temp.replace(/}{2,}/g, '}');
 
   // handle template strings
   if (temp.includes('`')) {
@@ -166,7 +147,7 @@ const handleObjectBindings = (code: string) => {
 
 const processCodeBlockInTemplate = (code: string) => {
   // contains helper calls as Angular doesn't support JS expressions in templates
-  if (code.startsWith('{')) {
+  if (code.startsWith('{') && code.includes('...')) {
     // Objects cannot be spread out directly in Angular so we need to use `useObjectWrapper`
     return `useObjectWrapper(${handleObjectBindings(code)})`;
   } else if (code.startsWith('Object.values')) {


### PR DESCRIPTION
## Description
This is propsed fix to issue: [1410](https://github.com/BuilderIO/mitosis/issues/1410)

- What changes you made:
The logic responsible for parsing an input to the method was incorrect. It used ',' comma as object separator. This gave weird results for any other constructs that would use comma, like arrays. Besides, this logic should probably be used only when input actually has spread operator in it. 

Regardless from object detection logic, I'm not convinced if logic responsible for concatenation `${spreadOutObjects.join(', ')}, ${otherObjs.join(', ')}` was correct. `spreadOutObjects` collects objects that use spread operator. `otherObjs` collect the rest of the objects from input. When we concatenate them using the initial logic, I believe we are completely mixing the order of objects, as there is no guarantee that `spreadOutObjects` in the original input, where at the begining. What if they were spread out somewhere else, in some nested object, of some complicated input? I believe this would either completely malform the object or in best case change the object structure. 

Now, about the propsed solution. As I understand, the whole purpose of this method is to get rid of `...` spread operator from syntax, as angular won't accept it. 

I tried to approach this problem in recursive way(to fix initial way of detecting objects - instead of using comma as object separator, try to figure start bracket and end bracket), but it is tricky, as regex are not good with recursive problems and even when I extracted recursion to separate method, it still was tricky for some complicated examples. And then I switched the approach - in the end, why do we need to detect separate objects? Our goal is to get rid of `...` from the string. So we can simply get rid of the `...` and then deal with potential consequences: 

 1) `someField: ...someObject` -> remove `...` and we are done
 2) `someField: {...someObject}` -> remove `...` and we are left with {object} result
 3) `someField: {...{nestedDeeper: true }}` -> remove `...` and we are left with {{ something: true }} result

I believe those cases will cover every possible variations on different levels of nesting. So after removing `...` we just have to cleanup what's left.

I prepared the PR using remarks from CONTRIBUTING.md file, however, I noticed that even without my changes there are tests failing in the `core` package(?). 
