### PR TITLE
feat: react-native "twrnc" and "native-wind" styling types

### DIFF
--- a/.changeset/strong-cycles-cough.md
+++ b/.changeset/strong-cycles-cough.md
@@ -1,5 +1,5 @@
 ---
-'@builder.io/mitosis': minor
+'@builder.io/mitosis': patch
 ---
 
 Adds two new styling options for the react-native generator: twrnc and native-wind

--- a/.changeset/strong-cycles-cough.md
+++ b/.changeset/strong-cycles-cough.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': minor
+---
+
+Adds two new styling options for the react-native generator: twrnc and native-wind

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -10264,3 +10264,31 @@ function MyComponent(props: any) {
 export default MyComponent;
 "
 `;
+
+exports[`React Native > twrnc style 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+  Pressable,
+  TextInput,
+} from \\"react-native\\";
+import tw from \\"twrnc\\";
+
+function MyComponent(props) {
+  return (
+    <View style=\\"{tw\`bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded\`}\\">
+      <Pressable onPress={(e) => console.log(\\"event\\")}>
+        <Text>Hello</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default MyComponent;
+"
+`;

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -9165,6 +9165,33 @@ export default MyBasicWebComponent;
 "
 `;
 
+exports[`React Native > native-wind style 1`] = `
+"import * as React from \\"react\\";
+import {
+  FlatList,
+  ScrollView,
+  View,
+  StyleSheet,
+  Image,
+  Text,
+  Pressable,
+  TextInput,
+} from \\"react-native\\";
+
+function MyComponent(props) {
+  return (
+    <View className=\\"bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded\\">
+      <Pressable onPress={(e) => console.log(\\"event\\")}>
+        <Text>Hello</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default MyComponent;
+"
+`;
+
 exports[`React Native > svelte > Javascript Test > basic 1`] = `
 "import * as React from \\"react\\";
 import {

--- a/packages/core/src/__tests__/data/react-native/twrnc-styled-component.raw.tsx
+++ b/packages/core/src/__tests__/data/react-native/twrnc-styled-component.raw.tsx
@@ -1,0 +1,7 @@
+export default function MyComponent(props) {
+    return (
+      <div class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+        <button onClick={(e) => console.log('event')}>Hello</button>
+      </div>
+    );
+  }

--- a/packages/core/src/__tests__/data/react-native/twrnc-styled-component.raw.tsx
+++ b/packages/core/src/__tests__/data/react-native/twrnc-styled-component.raw.tsx
@@ -1,7 +1,7 @@
 export default function MyComponent(props) {
-    return (
-      <div class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-        <button onClick={(e) => console.log('event')}>Hello</button>
-      </div>
-    );
-  }
+  return (
+    <div class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+      <button onClick={(e) => console.log('event')}>Hello</button>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/react-native.test.ts
+++ b/packages/core/src/__tests__/react-native.test.ts
@@ -15,4 +15,13 @@ describe('React Native', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  test('native-wind style', () => {
+    const component = parseJsx(twrncStyledComponentRN);
+    const output = componentToReactNative({
+      stylesType: 'native-wind',
+    })({ component });
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/core/src/__tests__/react-native.test.ts
+++ b/packages/core/src/__tests__/react-native.test.ts
@@ -1,6 +1,18 @@
 import { componentToReactNative } from '../generators/react-native';
 import { runTestsForTarget } from './test-generator';
 
+import { parseJsx } from '..';
+import twrncStyledComponentRN from './data/react-native/twrnc-styled-component.raw.tsx?raw';
+
 describe('React Native', () => {
   runTestsForTarget({ options: {}, target: 'reactNative', generator: componentToReactNative });
+
+  test('twrnc style', () => {
+    const component = parseJsx(twrncStyledComponentRN);
+    const output = componentToReactNative({
+      stylesType: 'twrnc',
+    })({ component });
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/core/src/generators/react-native/index.ts
+++ b/packages/core/src/generators/react-native/index.ts
@@ -70,7 +70,7 @@ export const collectReactNativeStyles = (json: MitosisComponent): ClassStyleMap 
 
         item.bindings.style!.code = json5.stringify(styleValue);
       }
-    } catch (e) { }
+    } catch (e) {}
 
     if (!size(cssValue)) {
       return;
@@ -141,7 +141,7 @@ const PROCESS_REACT_NATIVE_PLUGIN: Plugin = () => ({
 });
 
 /**
- * Removes React Native className and class properties from the JSON 
+ * Removes React Native className and class properties from the JSON
  */
 const REMOVE_REACT_NATIVE_CLASSES_PLUGIN: Plugin = () => ({
   json: {
@@ -178,8 +178,10 @@ const TWRNC_STYLES_PLUGIN: Plugin = () => ({
             node.properties.class,
             node.properties.className,
             node.bindings.class,
-            node.bindings.className
-          ].filter(Boolean).join(' ');
+            node.bindings.className,
+          ]
+            .filter(Boolean)
+            .join(' ');
 
           if (combinedClasses) {
             node.properties.style = `{tw\`${combinedClasses}\`}`;
@@ -216,9 +218,10 @@ const NATIVE_WIND_STYLES_PLUGIN: Plugin = () => ({
             node.properties.class,
             node.properties.className,
             node.bindings.class,
-            node.bindings.className
-          ].filter(Boolean).join(' ');
-
+            node.bindings.className,
+          ]
+            .filter(Boolean)
+            .join(' ');
 
           if (node.properties.class) {
             delete node.properties.class;
@@ -250,18 +253,18 @@ const DEFAULT_OPTIONS: ToReactNativeOptions = {
 
 export const componentToReactNative: TranspilerGenerator<Partial<ToReactNativeOptions>> =
   (_options = {}) =>
-    ({ component, path }) => {
-      const json = fastClone(component);
+  ({ component, path }) => {
+    const json = fastClone(component);
 
-      const options = mergeOptions(DEFAULT_OPTIONS, _options);
+    const options = mergeOptions(DEFAULT_OPTIONS, _options);
 
-      if (options.stylesType === 'twrnc') {
-        options.plugins.push(TWRNC_STYLES_PLUGIN);
-      } else if (options.stylesType === 'native-wind') {
-        options.plugins.push(NATIVE_WIND_STYLES_PLUGIN);
-      } else {
-        options.plugins.push(REMOVE_REACT_NATIVE_CLASSES_PLUGIN);
-      }
+    if (options.stylesType === 'twrnc') {
+      options.plugins.push(TWRNC_STYLES_PLUGIN);
+    } else if (options.stylesType === 'native-wind') {
+      options.plugins.push(NATIVE_WIND_STYLES_PLUGIN);
+    } else {
+      options.plugins.push(REMOVE_REACT_NATIVE_CLASSES_PLUGIN);
+    }
 
-      return componentToReact({ ...options, type: 'native' })({ component: json, path });
-    };
+    return componentToReact({ ...options, type: 'native' })({ component: json, path });
+  };

--- a/packages/core/src/generators/react-native/index.ts
+++ b/packages/core/src/generators/react-native/index.ts
@@ -182,7 +182,7 @@ const TWRNC_STYLES_PLUGIN: Plugin = () => ({
           ].filter(Boolean).join(' ');
 
           if (combinedClasses) {
-            node.properties.style = `tw\`${combinedClasses}\``;
+            node.properties.style = `{tw\`${combinedClasses}\`}`;
           }
 
           if (node.properties.class) {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -541,6 +541,7 @@ const _componentToReact = (
         }'`
       : ''
   }
+  ${options.stylesType === 'twrnc' ? `import tw from 'twrnc';\n` : ''}
   ${
     componentHasStyles && options.stylesType === 'emotion' && options.format !== 'lite'
       ? `/** @jsx jsx */

--- a/packages/core/src/generators/react/types.ts
+++ b/packages/core/src/generators/react/types.ts
@@ -1,7 +1,7 @@
 import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export interface ToReactOptions extends BaseTranspilerOptions {
-  stylesType: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native' | 'style-tag';
+  stylesType: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native' | 'style-tag' | 'twrnc';
   stateType: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder' | 'variables';
   format?: 'lite' | 'safe';
   type: 'dom' | 'native' | 'taro';

--- a/packages/core/src/generators/react/types.ts
+++ b/packages/core/src/generators/react/types.ts
@@ -1,7 +1,7 @@
 import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export interface ToReactOptions extends BaseTranspilerOptions {
-  stylesType: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native' | 'style-tag' | 'twrnc';
+  stylesType: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native' | 'style-tag' | 'twrnc' | 'native-wind';
   stateType: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder' | 'variables';
   format?: 'lite' | 'safe';
   type: 'dom' | 'native' | 'taro';

--- a/packages/core/src/generators/react/types.ts
+++ b/packages/core/src/generators/react/types.ts
@@ -1,7 +1,14 @@
 import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export interface ToReactOptions extends BaseTranspilerOptions {
-  stylesType: 'emotion' | 'styled-components' | 'styled-jsx' | 'react-native' | 'style-tag' | 'twrnc' | 'native-wind';
+  stylesType:
+    | 'emotion'
+    | 'styled-components'
+    | 'styled-jsx'
+    | 'react-native'
+    | 'style-tag'
+    | 'twrnc'
+    | 'native-wind';
   stateType: 'useState' | 'mobx' | 'valtio' | 'solid' | 'builder' | 'variables';
   format?: 'lite' | 'safe';
   type: 'dom' | 'native' | 'taro';


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made: 
  - Adds support for [twrc ](https://github.com/jaredh159/tailwind-react-native-classnames)and [native-wind](https://www.nativewind.dev/) styling to the react-native target

- Why you made them, and: 
  - It will allow users more freedom to style their components, specially if they use a tailwind-based style system, that way they can share their style preset across all generator types

- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
