### PR TITLE
chore: Bump neotraverse to 0.6.15

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",
     "lodash": "^4.17.20",
-    "neotraverse": "^0.6.14",
+    "neotraverse": "^0.6.15",
     "object-hash": "^2.0.3",
     "prettier": ">=2.0.0 <3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",
     "lodash": "^4.17.20",
-    "neotraverse": "https://pkg.pr.new/PuruVJ/neotraverse@11",
+    "neotraverse": "^0.6.14",
     "object-hash": "^2.0.3",
     "prettier": ">=2.0.0 <3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",
     "lodash": "^4.17.20",
-    "neotraverse": "^0.6.11",
+    "neotraverse": "^0.6.12",
     "object-hash": "^2.0.3",
     "prettier": ">=2.0.0 <3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",
     "lodash": "^4.17.20",
-    "neotraverse": "^0.6.13",
+    "neotraverse": "https://pkg.pr.new/PuruVJ/neotraverse@11",
     "object-hash": "^2.0.3",
     "prettier": ">=2.0.0 <3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "hash-sum": "^2.0.0",
     "json5": "^2.1.3",
     "lodash": "^4.17.20",
-    "neotraverse": "^0.6.12",
+    "neotraverse": "^0.6.13",
     "object-hash": "^2.0.3",
     "prettier": ">=2.0.0 <3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
     hash-sum: "npm:^2.0.0"
     json5: "npm:^2.1.3"
     lodash: "npm:^4.17.20"
-    neotraverse: "npm:^0.6.14"
+    neotraverse: "npm:^0.6.15"
     nx: "npm:^19.0.8"
     nx-cloud: "npm:^19.0.0"
     object-hash: "npm:^2.0.3"
@@ -17090,10 +17090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neotraverse@npm:^0.6.14":
-  version: 0.6.14
-  resolution: "neotraverse@npm:0.6.14"
-  checksum: 10/54b26b1c2c667a2fc9a079ea4141393414c7db4b16c82057175fa2f7e47194cb074ec867738d584169c94a3aa768754db35e74f3d9e36db2964387a69d62ce5a
+"neotraverse@npm:^0.6.15":
+  version: 0.6.15
+  resolution: "neotraverse@npm:0.6.15"
+  checksum: 10/246bbd1bdc2ba4a871b3663d5fa8ec6600153c4d174d3aeeb1be9f0875d0619868cf8735e6344eb15fec168f71a42d675ab67d6ffc58bd97fdbb7ff4a5ba4725
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
     hash-sum: "npm:^2.0.0"
     json5: "npm:^2.1.3"
     lodash: "npm:^4.17.20"
-    neotraverse: "npm:^0.6.13"
+    neotraverse: "https://pkg.pr.new/PuruVJ/neotraverse@11"
     nx: "npm:^19.0.8"
     nx-cloud: "npm:^19.0.0"
     object-hash: "npm:^2.0.3"
@@ -17090,10 +17090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neotraverse@npm:^0.6.13":
+"neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@11":
   version: 0.6.13
-  resolution: "neotraverse@npm:0.6.13"
-  checksum: 10/676451b797e3e8c943314bfc1e03dd8b87b47d641aee2271b1d70303772e4e0b56015df8f501b844ee0781029a50a8737f749b5a2aa95c745cc27df3dfa8d422
+  resolution: "neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@11"
+  checksum: 10/4bb601e0d2a35fed3c2303862c1add280edf10415a51b77398420bcc9f9dbfa0d1449c3e9bb26e1ae6fdf53afa538c3ab722c4a455fb164dc1123c2eb13f2adf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
     hash-sum: "npm:^2.0.0"
     json5: "npm:^2.1.3"
     lodash: "npm:^4.17.20"
-    neotraverse: "npm:^0.6.12"
+    neotraverse: "npm:^0.6.13"
     nx: "npm:^19.0.8"
     nx-cloud: "npm:^19.0.0"
     object-hash: "npm:^2.0.3"
@@ -17090,10 +17090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neotraverse@npm:^0.6.12":
-  version: 0.6.12
-  resolution: "neotraverse@npm:0.6.12"
-  checksum: 10/5d2f2dfe7f10c23d30ec33b63a6ef597da540099c73f930bf5bfb177b755a06cb39465b47e5a066a62e2b4beee07ba53406c1bb7070cadb2e47a6c67a7ea8f69
+"neotraverse@npm:^0.6.13":
+  version: 0.6.13
+  resolution: "neotraverse@npm:0.6.13"
+  checksum: 10/676451b797e3e8c943314bfc1e03dd8b87b47d641aee2271b1d70303772e4e0b56015df8f501b844ee0781029a50a8737f749b5a2aa95c745cc27df3dfa8d422
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
     hash-sum: "npm:^2.0.0"
     json5: "npm:^2.1.3"
     lodash: "npm:^4.17.20"
-    neotraverse: "npm:^0.6.11"
+    neotraverse: "npm:^0.6.12"
     nx: "npm:^19.0.8"
     nx-cloud: "npm:^19.0.0"
     object-hash: "npm:^2.0.3"
@@ -17090,10 +17090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neotraverse@npm:^0.6.11":
-  version: 0.6.11
-  resolution: "neotraverse@npm:0.6.11"
-  checksum: 10/465577eed0429300c906b90953bf51ea7fea7a90b97a1e42fafe8005a4462c37cba4dbce711eb76710b8e0b91600d81cc42a4fc337ad0fb6c3a1f334049ac92c
+"neotraverse@npm:^0.6.12":
+  version: 0.6.12
+  resolution: "neotraverse@npm:0.6.12"
+  checksum: 10/5d2f2dfe7f10c23d30ec33b63a6ef597da540099c73f930bf5bfb177b755a06cb39465b47e5a066a62e2b4beee07ba53406c1bb7070cadb2e47a6c67a7ea8f69
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
     hash-sum: "npm:^2.0.0"
     json5: "npm:^2.1.3"
     lodash: "npm:^4.17.20"
-    neotraverse: "https://pkg.pr.new/PuruVJ/neotraverse@11"
+    neotraverse: "npm:^0.6.14"
     nx: "npm:^19.0.8"
     nx-cloud: "npm:^19.0.0"
     object-hash: "npm:^2.0.3"
@@ -17090,10 +17090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@11":
-  version: 0.6.13
-  resolution: "neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@11"
-  checksum: 10/4bb601e0d2a35fed3c2303862c1add280edf10415a51b77398420bcc9f9dbfa0d1449c3e9bb26e1ae6fdf53afa538c3ab722c4a455fb164dc1123c2eb13f2adf
+"neotraverse@npm:^0.6.14":
+  version: 0.6.14
+  resolution: "neotraverse@npm:0.6.14"
+  checksum: 10/54b26b1c2c667a2fc9a079ea4141393414c7db4b16c82057175fa2f7e47194cb074ec867738d584169c94a3aa768754db35e74f3d9e36db2964387a69d62ce5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

neotraverse/legacy wouldn't work with Webpack 4 and before as is, as webpack 4 doesn't support export maps. v0.6.12 provides fallback for that as a top level legacy.js file.

Edit: Bumped to 0.6.15, comes with better TypeScript support(irrelevant to this PR, just good to be on the latest), lower NodeJS support

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [ ] format the codebase: from the root, run `yarn fmt:prettier`.
- [ ] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [ ] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
