### PR TITLE
fix: issue with single quotes in package.json not working for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "ci:test": "nx run-many --target test",
     "ci:e2e": "nx e2e @builder.io/e2e-app",
     "test:update": "nx run-many -t test:update",
-    "fmt": "run-s 'fmt:*'",
+    "fmt": "run-s \"fmt:*\"",
     "fmt:eslint": "yarn lint:eslint --fix",
     "fmt:prettier": "yarn lint:prettier --write",
-    "lint": "run-p -c 'lint:*'",
-    "lint:eslint": "eslint --cache 'packages/**/*.ts{,x}'",
+    "lint": "run-p -c \"lint:*\"",
+    "lint:eslint": "eslint --cache \"packages/**/*.ts{,x}\"",
     "lint:prettier": "yarn run prettier --check",
-    "prettier": "prettier --cache --loglevel warn '{packages,docs,e2e}/**/*.{js,jsx,ts,tsx,json,md,html}'"
+    "prettier": "prettier --cache --loglevel warn \"{packages,docs,e2e}/**/*.{js,jsx,ts,tsx,json,md,html}\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:

Replaces `'` with `\"` in package.json

- Why you made them, and:

Single quotes doesn't work on Windows.

- Any other useful context:

closes #1444

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [ ] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
