### PR TITLE
fix: duplication of `Pressable` import in React Native

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -616,7 +616,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -14,7 +14,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -87,7 +86,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -137,7 +135,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useContext, useRef, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
@@ -193,7 +190,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -238,7 +234,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -271,7 +266,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -304,7 +298,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -329,7 +322,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
@@ -367,7 +359,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -406,7 +397,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -458,7 +448,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -527,7 +516,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
@@ -566,7 +554,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -625,7 +612,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -666,7 +652,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Column(props) {
@@ -725,7 +710,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function ContentSlotCode(props) {
@@ -760,7 +744,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -825,7 +808,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -902,7 +884,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -979,7 +960,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
@@ -1246,7 +1226,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -1354,7 +1333,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -1390,7 +1368,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1427,7 +1404,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1469,7 +1445,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -1505,7 +1480,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function RawText(props) {
@@ -1530,7 +1504,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SectionComponent(props) {
@@ -1568,7 +1541,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -1612,7 +1584,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SlotCode(props) {
@@ -1647,7 +1618,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1677,7 +1647,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
@@ -1713,7 +1682,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SlotCode(props) {
@@ -1745,7 +1713,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 import { kebabCase, snakeCase } from \\"lodash\\";
@@ -1849,7 +1816,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SubmitButton(props) {
@@ -1878,7 +1844,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
@@ -1921,7 +1886,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Textarea(props) {
@@ -1954,7 +1918,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Video(props) {
@@ -2000,7 +1963,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2041,7 +2003,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2094,7 +2055,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -2135,7 +2095,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -2176,7 +2135,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -2226,7 +2184,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2257,7 +2214,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2288,7 +2244,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -2319,7 +2274,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2356,7 +2310,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2394,7 +2347,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
@@ -2444,7 +2396,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
@@ -2499,7 +2450,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -2537,7 +2487,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -2591,7 +2540,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -2643,7 +2591,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 const DEFAULT_VALUES = {
@@ -2677,7 +2624,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2711,7 +2657,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -2760,7 +2705,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 
@@ -2797,7 +2741,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2836,7 +2779,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -2869,7 +2811,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -2918,7 +2859,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -2948,7 +2888,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function NestedShow(props) {
@@ -2993,7 +2932,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function NestedStyles(props) {
@@ -3035,7 +2973,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3066,7 +3003,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -3121,7 +3057,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -3157,7 +3092,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -3201,7 +3135,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -3237,7 +3170,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -3273,7 +3205,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -3303,7 +3234,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -3337,7 +3267,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 const b = 3;
@@ -3368,7 +3297,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3398,7 +3326,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -3432,7 +3359,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3462,7 +3388,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -3492,7 +3417,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -3534,7 +3458,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { TARGET } from \\"../../constants/target.js\\";
@@ -3808,7 +3731,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -3872,7 +3794,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function Button(props) {
@@ -3913,7 +3834,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function RenderStyles(props) {
@@ -3952,7 +3872,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -3982,7 +3901,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -4019,7 +3937,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function ShowWithOtherValues(props) {
@@ -4176,7 +4093,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function NestedShow(props) {
@@ -4217,7 +4133,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function ShowWithOtherValues(props) {
@@ -4287,7 +4202,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function ShowRootText(props) {
@@ -4324,7 +4238,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -4362,7 +4275,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -4387,7 +4299,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -4412,7 +4323,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props) {
@@ -4437,7 +4347,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -4473,7 +4382,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function StylePropClassAndCss(props) {
@@ -4502,7 +4410,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -4528,7 +4435,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SvgComponent(props) {
@@ -4569,7 +4475,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function TypeDependency(props) {
@@ -4598,7 +4503,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -4629,7 +4533,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -4662,7 +4565,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -4693,7 +4595,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -4732,7 +4633,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
@@ -4777,7 +4677,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -4811,7 +4710,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -4888,7 +4786,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -4942,7 +4839,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useContext, useRef, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
@@ -4998,7 +4894,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -5048,7 +4943,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -5081,7 +4975,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -5114,7 +5007,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -5139,7 +5031,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5182,7 +5073,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
@@ -5221,7 +5111,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -5273,7 +5162,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -5346,7 +5234,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
@@ -5389,7 +5276,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -5452,7 +5338,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -5500,7 +5385,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Column = {
@@ -5574,7 +5458,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -5615,7 +5498,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -5685,7 +5567,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -5767,7 +5648,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -5849,7 +5729,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -6147,7 +6026,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
@@ -6274,7 +6152,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6310,7 +6187,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ImgProps {
@@ -6365,7 +6241,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface FormInputProps {
@@ -6419,7 +6294,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
@@ -6455,7 +6329,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface RawTextProps {
@@ -6485,7 +6358,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface SectionProps {
@@ -6529,7 +6401,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface FormSelectProps {
@@ -6585,7 +6456,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -6624,7 +6494,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -6658,7 +6527,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -6698,7 +6566,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -6734,7 +6601,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -6843,7 +6709,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -6877,7 +6742,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -6929,7 +6793,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface TextareaProps {
@@ -6970,7 +6833,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface VideoProps {
@@ -7042,7 +6904,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7083,7 +6944,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7136,7 +6996,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -7182,7 +7041,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
@@ -7228,7 +7086,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -7278,7 +7135,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7309,7 +7165,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7340,7 +7195,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -7371,7 +7225,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7414,7 +7267,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7452,7 +7304,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
@@ -7507,7 +7358,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
@@ -7567,7 +7417,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
@@ -7605,7 +7454,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -7669,7 +7517,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -7729,7 +7576,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Props = {
@@ -7767,7 +7613,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7801,7 +7646,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -7854,7 +7698,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type RenderContentProps = {
@@ -7898,7 +7741,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -7937,7 +7779,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -7970,7 +7811,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -8019,7 +7859,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8049,7 +7888,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -8099,7 +7937,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function NestedStyles(props: any) {
@@ -8141,7 +7978,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -8172,7 +8008,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -8227,7 +8062,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
@@ -8263,7 +8097,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
@@ -8311,7 +8144,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8347,7 +8179,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8383,7 +8214,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8413,7 +8243,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -8451,7 +8280,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Types = {
@@ -8492,7 +8320,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export type A = \\"test\\";
@@ -8535,7 +8362,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8574,7 +8400,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Person {
@@ -8609,7 +8434,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 type Person = {
@@ -8644,7 +8468,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -8686,7 +8509,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -8973,7 +8795,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 
@@ -9045,7 +8866,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface ButtonProps {
@@ -9093,7 +8913,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export interface RenderStylesProps {
@@ -9136,7 +8955,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9166,7 +8984,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9203,7 +9020,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -9365,7 +9181,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -9411,7 +9226,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -9485,7 +9299,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 interface Props {
@@ -9526,7 +9339,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -9573,7 +9385,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -9598,7 +9409,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -9623,7 +9433,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
@@ -9648,7 +9457,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9684,7 +9492,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function StylePropClassAndCss(props: any) {
@@ -9713,7 +9520,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
@@ -9739,7 +9545,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function SvgComponent(props: any) {
@@ -9780,7 +9585,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 export type TypeDependencyProps = {
@@ -9816,7 +9620,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9847,7 +9650,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9880,7 +9682,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -9911,7 +9712,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -9950,7 +9750,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useRef } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
@@ -9995,7 +9794,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -10026,7 +9824,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10062,7 +9859,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10147,7 +9943,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10175,7 +9970,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10216,7 +10010,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10252,7 +10045,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -10293,7 +10085,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10321,7 +10112,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10367,7 +10157,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
@@ -10402,7 +10191,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -10442,7 +10230,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10480,7 +10267,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -10535,7 +10321,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -10571,7 +10356,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props) {
@@ -10598,7 +10382,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10636,7 +10419,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10672,7 +10454,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10757,7 +10538,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10785,7 +10565,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10826,7 +10605,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10862,7 +10640,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -10903,7 +10680,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10931,7 +10707,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -10977,7 +10752,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
@@ -11012,7 +10786,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
@@ -11052,7 +10825,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -11090,7 +10862,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
@@ -11145,7 +10916,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -11181,7 +10951,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 
 function MyComponent(props: any) {
@@ -11208,7 +10977,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 
@@ -11246,7 +11014,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import tw from \\"twrnc\\";
 import { clsx } from \\"clsx\\";
@@ -11287,7 +11054,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import { useState } from \\"react\\";
 import tw from \\"twrnc\\";
@@ -11320,7 +11086,6 @@ import {
   TouchableOpacity,
   Button,
   Linking,
-  Pressable,
 } from \\"react-native\\";
 import tw from \\"twrnc\\";
 

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -264,7 +264,7 @@ const getDefaultImport = (json: MitosisComponent, options: ToReactOptions): stri
   if (type === 'native') {
     return `
     import * as React from 'react';
-    import { FlatList, ScrollView, View, StyleSheet, Image, Text, Pressable, TextInput, TouchableOpacity, Button, Linking, Pressable } from 'react-native';
+    import { FlatList, ScrollView, View, StyleSheet, Image, Text, Pressable, TextInput, TouchableOpacity, Button, Linking } from 'react-native';
     `;
   }
   if (type === 'taro') {


### PR DESCRIPTION
## Description

removed the duplicated `Pressable` import

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [ ] format the codebase: from the root, run `yarn fmt:prettier`.
- [ ] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [ ] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
