### PR TITLE
fix: check string value in isUpperCase

### DIFF
--- a/.changeset/small-shrimps-vanish.md
+++ b/.changeset/small-shrimps-vanish.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/mitosis": patch
+---
+
+fix: check string value in `isUpperCase`

--- a/packages/core/src/helpers/is-upper-case.ts
+++ b/packages/core/src/helpers/is-upper-case.ts
@@ -1,1 +1,1 @@
-export const isUpperCase = (str: string) => str.toUpperCase() === str;
+export const isUpperCase = (str: string) => typeof str === 'string' && str.toUpperCase() === str;


### PR DESCRIPTION
While parsing JSX, it's possible that it received an invalid or undefined tag. For the most part this is fine and mitosis handles this, except internally there's one scenario where it crashes when trying to uppercase the undefined tag. This PR just does a double check that the value is a valid string.