### PR TITLE
fix: ensure component name suffix

### DIFF
--- a/.changeset/fast-rivers-search.md
+++ b/.changeset/fast-rivers-search.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/mitosis": patch
+---
+
+Builder: fix: ensure component name suffix

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -38,7 +38,8 @@ const mapComponentName = (name: string) => {
   for (const prefix of builderBlockPrefixes) {
     if (name.startsWith(prefix)) {
       const suffix = name.replace(prefix, '');
-      if (isUpperCase(suffix[0])) {
+      const restOfName = suffix[0];
+      if (restOfName && isUpperCase(restOfName)) {
         return `${prefix}:${name.replace(prefix, '')}`;
       }
     }


### PR DESCRIPTION
Ensure that we found a suffix before trying to test if its uppercase.