### PR TITLE
docs: note for useRef hook to avoid naming it "ref" -> conflict with vue

### DIFF
--- a/packages/docs/src/routes/docs/hooks/index.mdx
+++ b/packages/docs/src/routes/docs/hooks/index.mdx
@@ -46,6 +46,9 @@ export default function MyComponent() {
 }
 ```
 
+> **Note:** Don't name your `useRef` hook "ref" like `const ref = useRef<HTMLInputElement>(null);`.
+> This would be a conflict with the `ref` from [Vue](https://vuejs.org/api/reactivity-core.html#ref).
+
 ### forwardRef for React
 
 <details>


### PR DESCRIPTION
## Description

Please provide the following information:

Add a note in documentation for `useRef`:
Avoid using `const ref = useRef(null);`, beacuse it might be a conflict with `Vue`.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [ ] format the codebase: from the root, run `yarn fmt:prettier`.
- [ ] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [ ] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
