### PR TITLE
fix: do not crash on Text node with bindings

### DIFF
--- a/.changeset/famous-pumas-shop.md
+++ b/.changeset/famous-pumas-shop.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+do not crash on Text node with bindings

--- a/.changeset/famous-pumas-shop.md
+++ b/.changeset/famous-pumas-shop.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-do not crash on Text node with bindings
+[Builder]: fix Text node crash with bindings

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -1643,6 +1643,101 @@ export default function MyComponent(props) {
 "
 `;
 
+exports[`Builder > Text with bindings 1`] = `
+{
+  "@type": "@builder.io/mitosis/component",
+  "children": [
+    {
+      "@type": "@builder.io/mitosis/node",
+      "bindings": {},
+      "children": [
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {},
+          "children": [],
+          "meta": {},
+          "name": "div",
+          "properties": {
+            "_text": "<p>Time left: {state.timeLeft} seconds</p>",
+          },
+          "scope": {},
+        },
+      ],
+      "meta": {},
+      "name": "div",
+      "properties": {},
+      "scope": {},
+    },
+  ],
+  "context": {
+    "get": {},
+    "set": {},
+  },
+  "exports": {},
+  "hooks": {
+    "onEvent": [],
+    "onMount": [],
+  },
+  "imports": [],
+  "inputs": undefined,
+  "meta": {
+    "useMetadata": {
+      "httpRequests": undefined,
+    },
+  },
+  "name": "MyComponent",
+  "refs": {},
+  "state": {},
+  "subComponents": [],
+}
+`;
+
+exports[`Builder > Text with bindings 2`] = `
+"export default function MyComponent(props) {
+  return (
+    <div>
+      <p>Time left: {state.timeLeft} seconds</p>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Builder > Text with bindings 3`] = `
+{
+  "data": {
+    "blocks": [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "actions": {},
+        "bindings": {},
+        "children": [
+          {
+            "@type": "@builder.io/sdk:Element",
+            "bindings": {},
+            "component": {
+              "name": "Text",
+              "options": {
+                "text": "<p>Time left: {{state.timeLeft}} seconds</p>",
+              },
+            },
+            "tagName": "span",
+          },
+        ],
+        "code": {
+          "actions": {},
+          "bindings": {},
+        },
+        "properties": {},
+        "tagName": "div",
+      },
+    ],
+    "jsCode": "",
+    "tsCode": "",
+  },
+}
+`;
+
 exports[`Builder > binding 1`] = `
 {
   "@type": "@builder.io/mitosis/component",

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -18,6 +18,7 @@ import customComponentSlotPropertyContent from './data/builder/custom-component-
 import lazyLoadSection from './data/builder/lazy-load-section.json?raw';
 import slotsContent from './data/builder/slots.json?raw';
 import slots2Content from './data/builder/slots2.json?raw';
+import textBindings from './data/builder/text-bindings.json?raw';
 
 const mitosisOptions: ToMitosisOptions = {
   format: 'legacy',
@@ -87,6 +88,18 @@ describe('Builder', () => {
     })({ component });
 
     expect(html).toMatchSnapshot();
+  });
+
+  test('Text with bindings', async () => {
+    const originalBuilder = JSON.parse(textBindings);
+    const component = builderContentToMitosisComponent(originalBuilder);
+    const mitosisJsx = componentToMitosis()({ component });
+
+    expect(component).toMatchSnapshot();
+    expect(mitosisJsx).toMatchSnapshot();
+
+    const backToBuilder = componentToBuilder()({ component });
+    expect(backToBuilder).toMatchSnapshot();
   });
 
   test('Regenerate Image', () => {

--- a/packages/core/src/__tests__/data/builder/text-bindings.json
+++ b/packages/core/src/__tests__/data/builder/text-bindings.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "blocks": [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        "id": "builder-170e19cac58e4c28998d443a9dce80b4",
+        "component": {
+          "name": "Text",
+          "options": {
+            "text": "<p>Time left: {{state.timeLeft}} seconds</p>"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -211,7 +211,8 @@ export const blockToBuilder = (
         component: {
           name: 'Text',
           options: {
-            text: json.properties._text,
+            // Mitosis uses {} for bindings, but Builder expects {{}} so we need to convert
+            text: json.properties._text?.replace(/\{(.*?)\}/g, '{{$1}}'),
           },
         },
       },

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -417,10 +417,14 @@ const componentMappers: {
     }
     const text = block.component!.options.text;
 
+    // Builder uses {{}} for bindings, but Mitosis expects {} so we need to convert
     const innerProperties = innerBindings._text
       ? {}
       : {
-          [options.preserveTextBlocks ? 'innerHTML' : '_text']: text,
+          [options.preserveTextBlocks ? 'innerHTML' : '_text']: text.replace(
+            /\{\{(.*?)\}\}/g,
+            '{$1}',
+          ),
         };
 
     if (options.preserveTextBlocks) {


### PR DESCRIPTION
Converting Builder content to Mitosis currently crashes given a Text node with a stringified binding. This is happening because Builder uses a `{{ }}` syntax for bindings, but Mitosis expects a `{ }` format. This PR fixes the issue by converting `{{ }}` to `{ }` when going from Builder --> Mitosis and by converting `{ }` to `{{ }}` when going from Mitosis --> Builder for Text nodes.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
