### PR TITLE
fix: keep escaped string on _text

### DIFF
--- a/.changeset/nice-teachers-glow.md
+++ b/.changeset/nice-teachers-glow.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[All] Fix: Property handle escaped text in JSXString nodes.

--- a/.changeset/smooth-moose-wash.md
+++ b/.changeset/smooth-moose-wash.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Builder] Feature: Parse and serialize PersonalizedContainer in a JSX/LLM friendly way (like Columns)

--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -58,7 +58,7 @@ exports[`Alpine.js > jsx > Javascript Test > Basic 1`] = `
     x-on:change=\\"name = myEvent.target.value\\"
   />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <script>
   document.addEventListener(\\"alpine:init\\", () => {
@@ -2813,7 +2813,7 @@ exports[`Alpine.js > jsx > Typescript Test > Basic 1`] = `
     x-on:change=\\"name = myEvent.target.value\\"
   />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <script>
   document.addEventListener(\\"alpine:init\\", () => {

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -92,7 +92,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -6937,7 +6937,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -93,7 +93,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -7051,7 +7051,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -98,7 +98,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -7163,7 +7163,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -89,7 +89,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -6217,7 +6217,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -158,7 +158,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -256,7 +256,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -13023,7 +13023,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [
@@ -13125,7 +13125,7 @@ export const DEFAULT_VALUES = {
         (input)=\\"name = $event.target.value\\"
       />
 
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html.test.ts.snap
@@ -143,7 +143,7 @@ exports[`Html > jsx > Javascript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <style>
   .div {
@@ -6955,7 +6955,7 @@ exports[`Html > jsx > Typescript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input data-el=\\"input-1\\" data-dom-state=\\"input-2\\" />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <style>
   .div {

--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Liquid > jsx > Javascript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <style>
   .div {
@@ -922,7 +922,7 @@ exports[`Liquid > jsx > Typescript Test > Basic 1`] = `
 "<div class=\\"test div\\">
   <input />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 <style>
   .div {

--- a/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/lit.test.ts.snap
@@ -96,7 +96,7 @@ export default class MyBasicComponent extends LitElement {
     ) =>
       (this.name =
         myEvent.target.value)} /> Hello! I can run in React, Vue, Solid, or
-          Liquid!
+          Liquid! &gt;
         </div>
 
         \`;
@@ -4262,7 +4262,7 @@ export default class MyBasicComponent extends LitElement {
     ) =>
       (this.name =
         myEvent.target.value)} /> Hello! I can run in React, Vue, Solid, or
-          Liquid!
+          Liquid! &gt;
         </div>
 
         \`;

--- a/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/marko.test.ts.snap
@@ -125,17 +125,17 @@ class {
 }
 
 style { 
-  .div-724f419e {
+  .div-360ae4be {
     padding: 10px;
   }
 }
-<div class=\\"test div-724f419e\\">
+<div class=\\"test div-360ae4be\\">
   <input
     value=(DEFAULT_VALUES.name || state.name)
     on-input(myEvent => state.name = myEvent.target.value)
   />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>"
 `;
 
@@ -2565,17 +2565,17 @@ class {
 }
 
 style { 
-  .div-f70acf48 {
+  .div-11706802 {
     padding: 10px;
   }
 }
-<div class=\\"test div-f70acf48\\">
+<div class=\\"test div-11706802\\">
   <input
     value=(DEFAULT_VALUES.name || state.name)
     on-input(myEvent => state.name = myEvent.target.value)
   />
 
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>"
 `;
 

--- a/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/parse-jsx.test.ts.snap
@@ -301,7 +301,7 @@ exports[`Parse JSX > Javascript > Basic 1`] = `
           "name": "div",
           "properties": {
             "_text": "
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     ",
           },
           "scope": {},
@@ -11154,7 +11154,7 @@ exports[`Parse JSX > Typescript > Basic 1`] = `
           "name": "div",
           "properties": {
             "_text": "
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     ",
           },
           "scope": {},

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -88,7 +88,7 @@ function MyBasicComponent(props) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {
@@ -3497,7 +3497,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {

--- a/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/qwik.test.ts.snap
@@ -1761,7 +1761,7 @@ export const MyBasicComponent = component$((props) => {
         value={DEFAULT_VALUES.name || state.name}
         onChange$={$((event) => (state.name = myEvent.target.value))}
       />
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   );
 });
@@ -5067,7 +5067,7 @@ export const MyBasicComponent = component$((props: MyBasicComponentProps) => {
         value={DEFAULT_VALUES.name || state.name}
         onChange$={$((event) => (state.name = myEvent.target.value))}
       />
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   );
 });

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -110,7 +110,7 @@ function MyBasicComponent(props) {
         value={DEFAULT_VALUES.name || name}
         onChange={(myEvent) => setName(myEvent.target.value)}
       />
-      <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
+      <Text>Hello! I can run in React, Vue, Solid, or Liquid! &gt;</Text>
     </View>
   );
 }
@@ -4845,7 +4845,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
         value={DEFAULT_VALUES.name || name}
         onChange={(myEvent) => setName(myEvent.target.value)}
       />
-      <Text>Hello! I can run in React, Vue, Solid, or Liquid!</Text>
+      <Text>Hello! I can run in React, Vue, Solid, or Liquid! &gt;</Text>
     </View>
   );
 }

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -88,7 +88,7 @@ function MyBasicComponent(props) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {
@@ -3401,7 +3401,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -88,7 +88,7 @@ function MyBasicComponent(props) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {
@@ -3143,7 +3143,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style jsx>{\`
         .div {

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -152,14 +152,14 @@ function MyBasicComponent(props) {
 
   return (
     <>
-      <div class=\\"test div-6bae243e\\">
+      <div class=\\"test div-046ccea4\\">
         <input
           value={DEFAULT_VALUES.name || name()}
           onInput={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
-      <style>{\`.div-6bae243e {
+      <style>{\`.div-046ccea4 {
   padding: 10px;
 }\`}</style>
     </>
@@ -228,14 +228,14 @@ function MyBasicComponent(props) {
 
   return (
     <>
-      <div class=\\"test div-6bae243e\\">
+      <div class=\\"test div-046ccea4\\">
         <input
           value={DEFAULT_VALUES.name || name()}
           onInput={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
-      <style>{\`.div-6bae243e {
+      <style>{\`.div-046ccea4 {
   padding: 10px;
 }\`}</style>
     </>
@@ -7028,14 +7028,14 @@ function MyBasicComponent(props: MyBasicComponentProps) {
 
   return (
     <>
-      <div class=\\"test div-13f579ae\\">
+      <div class=\\"test div-3c5f02b2\\">
         <input
           value={DEFAULT_VALUES.name || name()}
           onInput={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
-      <style>{\`.div-13f579ae {
+      <style>{\`.div-3c5f02b2 {
   padding: 10px;
 }\`}</style>
     </>
@@ -7108,14 +7108,14 @@ function MyBasicComponent(props: MyBasicComponentProps) {
 
   return (
     <>
-      <div class=\\"test div-13f579ae\\">
+      <div class=\\"test div-3c5f02b2\\">
         <input
           value={DEFAULT_VALUES.name || name()}
           onInput={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
-      <style>{\`.div-13f579ae {
+      <style>{\`.div-3c5f02b2 {
   padding: 10px;
 }\`}</style>
     </>

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -90,7 +90,7 @@ export default class MyBasicComponent {
           value={DEFAULT_VALUES.name || this.name}
           onInput={(myEvent) => (this.name = myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
     );
   }
@@ -3165,7 +3165,7 @@ export default class MyBasicComponent {
           value={DEFAULT_VALUES.name || this.name}
           onInput={(myEvent) => (this.name = myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
     );
   }

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -74,7 +74,7 @@ exports[`Svelte > jsx > Javascript Test > Basic 1`] = `
       name = myEvent.target.value;
     }}
   />
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 
 <style>
@@ -2899,7 +2899,7 @@ exports[`Svelte > jsx > Typescript Test > Basic 1`] = `
       name = myEvent.target.value;
     }}
   />
-  Hello! I can run in React, Vue, Solid, or Liquid!
+  Hello! I can run in React, Vue, Solid, or Liquid! &gt;
 </div>
 
 <style>

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -89,7 +89,7 @@ function MyBasicComponent(props) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </View>
       <style jsx>{\`
         .view {
@@ -3464,7 +3464,7 @@ function MyBasicComponent(props: MyBasicComponentProps) {
           value={DEFAULT_VALUES.name || name}
           onChange={(myEvent) => setName(myEvent.target.value)}
         />
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </View>
       <style jsx>{\`
         .view {

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -63,7 +63,7 @@ exports[`Vue > jsx > Javascript Test > Basic 1`] = `
       :value=\\"DEFAULT_VALUES.name || name\\"
       @change=\\"name = $event.target.value\\"
     />
-    Hello! I can run in React, Vue, Solid, or Liquid!
+    Hello! I can run in React, Vue, Solid, or Liquid! &gt;
   </div>
 </template>
 
@@ -3079,7 +3079,7 @@ exports[`Vue > jsx > Typescript Test > Basic 1`] = `
       :value=\\"DEFAULT_VALUES.name || name\\"
       @change=\\"name = $event.target.value\\"
     />
-    Hello! I can run in React, Vue, Solid, or Liquid!
+    Hello! I can run in React, Vue, Solid, or Liquid! &gt;
   </div>
 </template>
 

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -80,7 +80,7 @@ exports[`Vue > jsx > Javascript Test > Basic 1`] = `
       :value=\\"DEFAULT_VALUES.name || name\\"
       @change=\\"name = $event.target.value\\"
     />
-    Hello! I can run in React, Vue, Solid, or Liquid!
+    Hello! I can run in React, Vue, Solid, or Liquid! &gt;
   </div>
 </template>
 
@@ -3877,7 +3877,7 @@ exports[`Vue > jsx > Typescript Test > Basic 1`] = `
       :value=\\"DEFAULT_VALUES.name || name\\"
       @change=\\"name = $event.target.value\\"
     />
-    Hello! I can run in React, Vue, Solid, or Liquid!
+    Hello! I can run in React, Vue, Solid, or Liquid! &gt;
   </div>
 </template>
 

--- a/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/webcomponent.test.ts.snap
@@ -712,7 +712,7 @@ class MyBasicComponent extends HTMLElement {
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
         />
       
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style>
         .div-my-basic-component {
@@ -15382,7 +15382,7 @@ class MyBasicComponent extends HTMLElement {
           data-dom-state=\\"MyBasicComponent-input-my-basic-component-1\\"
         />
       
-        Hello! I can run in React, Vue, Solid, or Liquid!
+        Hello! I can run in React, Vue, Solid, or Liquid! &gt;
       </div>
       <style>
         .div-my-basic-component {

--- a/packages/core/src/__tests__/data/basic.raw.tsx
+++ b/packages/core/src/__tests__/data/basic.raw.tsx
@@ -26,7 +26,7 @@ export default function MyBasicComponent(props: { id: string }) {
         value={DEFAULT_VALUES.name || state.name}
         onChange={(myEvent) => (state.name = myEvent.target.value)}
       />
-      Hello! I can run in React, Vue, Solid, or Liquid!
+      Hello! I can run in React, Vue, Solid, or Liquid! &gt;
     </div>
   );
 }

--- a/packages/core/src/parsers/jsx/element-parser.ts
+++ b/packages/core/src/parsers/jsx/element-parser.ts
@@ -29,9 +29,10 @@ export const jsxElementToJson = (
   node: babel.types.Expression | babel.types.JSX,
 ): MitosisNode | null => {
   if (types.isJSXText(node)) {
+    const value = typeof node.extra?.raw === 'string' ? node.extra.raw : node.value;
     return createMitosisNode({
       properties: {
-        _text: node.value,
+        _text: value,
       },
     });
   }


### PR DESCRIPTION
## Description

```
import { useState } from "@builder.io/mitosis";

export default function MyComponent(props) {
  const [name, setName] = useState("Steve");

  return (
    <div>
      -&gt;
    </div>
  );
}
```
this is a perfectly valid JSX component that generated broken code for all frameworks