### PR TITLE
fix: issue with functions in `useStore` for typescript

### DIFF
--- a/.changeset/lemon-melons-build.md
+++ b/.changeset/lemon-melons-build.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Angular, React, Vue] fix: issue with functions inside `useStore` missing ReturnType<...> when using `typescript: true` in config

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -13957,14 +13957,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -14181,14 +14181,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -14388,14 +14388,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -12530,14 +12530,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -26271,14 +26271,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }
@@ -26319,14 +26319,14 @@ type GetterStore = {
 })
 export default class TypeGetterStore {
   name: GetterStore[\\"name\\"] = \\"test\\";
-  getName(): GetterStore[\\"getName\\"] {
+  getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (this.name === \\"a\\") {
       return \\"b\\";
     }
 
     return this.name;
   }
-  get test(): GetterStore[\\"test\\"] {
+  get test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 }

--- a/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/preact.test.ts.snap
@@ -7153,7 +7153,7 @@ type GetterStore = {
 function TypeGetterStore(props: any) {
   const [name, setName] = useState<GetterStore[\\"name\\"]>(() => \\"test\\");
 
-  function getName(): GetterStore[\\"getName\\"] {
+  function getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (name === \\"a\\") {
       return \\"b\\";
     }
@@ -7161,7 +7161,7 @@ function TypeGetterStore(props: any) {
     return name;
   }
 
-  function test(): GetterStore[\\"test\\"] {
+  function test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -9806,7 +9806,7 @@ type GetterStore = {
 function TypeGetterStore(props: any) {
   const [name, setName] = useState<GetterStore[\\"name\\"]>(() => \\"test\\");
 
-  function getName(): GetterStore[\\"getName\\"] {
+  function getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (name === \\"a\\") {
       return \\"b\\";
     }
@@ -9814,7 +9814,7 @@ function TypeGetterStore(props: any) {
     return name;
   }
 
-  function test(): GetterStore[\\"test\\"] {
+  function test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -6962,7 +6962,7 @@ type GetterStore = {
 function TypeGetterStore(props: any) {
   const [name, setName] = useState<GetterStore[\\"name\\"]>(() => \\"test\\");
 
-  function getName(): GetterStore[\\"getName\\"] {
+  function getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (name === \\"a\\") {
       return \\"b\\";
     }
@@ -6970,7 +6970,7 @@ function TypeGetterStore(props: any) {
     return name;
   }
 
-  function test(): GetterStore[\\"test\\"] {
+  function test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 

--- a/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/rsc.test.ts.snap
@@ -6436,7 +6436,7 @@ type GetterStore = {
 function TypeGetterStore(props: any) {
   const [name, setName] = useState<GetterStore[\\"name\\"]>(() => \\"test\\");
 
-  function getName(): GetterStore[\\"getName\\"] {
+  function getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (name === \\"a\\") {
       return \\"b\\";
     }
@@ -6444,7 +6444,7 @@ function TypeGetterStore(props: any) {
     return name;
   }
 
-  function test(): GetterStore[\\"test\\"] {
+  function test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 

--- a/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/taro.test.ts.snap
@@ -7114,7 +7114,7 @@ import { View, Text } from \\"@tarojs/components\\";
 function TypeGetterStore(props: any) {
   const [name, setName] = useState<GetterStore[\\"name\\"]>(() => \\"test\\");
 
-  function getName(): GetterStore[\\"getName\\"] {
+  function getName(): ReturnType<GetterStore[\\"getName\\"]> {
     if (name === \\"a\\") {
       return \\"b\\";
     }
@@ -7122,7 +7122,7 @@ function TypeGetterStore(props: any) {
     return name;
   }
 
-  function test(): GetterStore[\\"test\\"] {
+  function test(): ReturnType<GetterStore[\\"test\\"]> {
     return \\"test\\";
   }
 

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -6359,7 +6359,7 @@ const test = computed(() => {
   return \\"test\\";
 });
 
-function getName(): GetterStore[\\"getName\\"] {
+function getName(): ReturnType<GetterStore[\\"getName\\"]> {
   if (name.value === \\"a\\") {
     return \\"b\\";
   }

--- a/packages/core/src/helpers/get-typed-function.ts
+++ b/packages/core/src/helpers/get-typed-function.ts
@@ -16,5 +16,5 @@ export const getTypedFunction = (code: string, typescript?: boolean, typeParamet
   const preType = code.slice(0, firstParenthesisIndex - 1);
   const postType = code.slice(firstParenthesisIndex, code.length);
 
-  return [preType, ': ', typeParameter, postType].join('');
+  return [preType, ': ', `ReturnType<${typeParameter}>`, postType].join('');
 };


### PR DESCRIPTION
## Description

Please provide the following information:

Add [`ReturnType<...>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) to `packages/core/src/helpers/get-typed-function.ts`.

We don't want to return the complete function as a return type. Instead we want to return the return type of the function. 

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
