### PR TITLE
chore: remove console.log

### DIFF
--- a/packages/core/src/generators/mitosis/generator.ts
+++ b/packages/core/src/generators/mitosis/generator.ts
@@ -87,7 +87,6 @@ export const blockToMitosis = (
           .join('\n')}
       ${needsWrapper ? '</>' : ''}
       ))${insideJsx ? '}' : ''}`;
-      console.log(a);
       return a;
     }
     return `<For each={${json.bindings.each?.code}}>


### PR DESCRIPTION
This console log is showing up in apps that consume Mitosis.