### PR TITLE
feat: add job to regenerate snapshots in ci

### DIFF
--- a/.changeset/lemon-hornets-laugh.md
+++ b/.changeset/lemon-hornets-laugh.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[CICD] regenerate test snapshots on fail to download them into local environment

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,6 +73,36 @@ jobs:
       - name: Run tests
         run: yarn ci:test
 
+  test-update:
+    if: always() && (needs.test.result == 'failure')
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: 📥 Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+        with:
+          cache-node-modules: true
+          cache-install-state: true
+
+      - name: 🏃🆙⏲️ Run test-update
+        run: yarn test:update
+
+      - name: 🆙 Upload snapshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots-updates
+          path: ./packages/core/src/__tests__/__snapshots__
+          retention-days: 30
+
   site:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ From there, you can keep iterating until the snapshots look as expected, and the
 Before submitting your PR, please make sure to format the codebase and update all snapshots:
 
 - format the codebase: from the root, run `yarn fmt:prettier`.
-- update all snapshots (in core & CLI): from the root, run `yarn test:update`. This will run an Nx command that will update all the snapshots in the `core` and `cli` packages. while making sure all required dependencies are built beforehand.
+- update all snapshots (in core & CLI): from the root, run `yarn test:update`. This will run a Nx command that will update all the snapshots in the `core` and `cli` packages. while making sure all required dependencies are built beforehand. If there are some difference between the generated snapshots in your local environment and GitHub Action you are able to download the correct snapshots via 'Summary' in the pipeline run. Wait until the job `test-update` is done, scroll to the bottom and download `snapshots-updates`. You should be able to copy&past the snapshots to `packages/core/src/__tests__/__snapshots__`.
 - add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions.
 
 #### Changeset format

--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -1,7 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Alpine.js > jsx > Javascript Test > Advanced 1`] = `
-
+"<main x-data=\\"myBasicForShowComponent()\\">
+  <template x-for=\\"person in names\\">
+    <div>
+      <span x-html=\\"i\\"></span>
+      :
+      <span x-html=\\"person\\"></span>
+    </div>
+  </template>
   <template x-for=\\"person in names\\">
     <span><span x-html=\\"person\\"></span></span>
   </template>

--- a/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/alpine.test.ts.snap
@@ -1,14 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Alpine.js > jsx > Javascript Test > Advanced 1`] = `
-"<main x-data=\\"myBasicForShowComponent()\\">
-  <template x-for=\\"person in names\\">
-    <div>
-      <span x-html=\\"i\\"></span>
-      :
-      <span x-html=\\"person\\"></span>
-    </div>
-  </template>
+
   <template x-for=\\"person in names\\">
     <span><span x-html=\\"person\\"></span></span>
   </template>


### PR DESCRIPTION
## Description

Please provide the following information:

Add a new job in workflows to regenerate snapshots if the tests fail.
This would allow contributors to download the artifact with the snaphots, no matter which environment they use locally.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
