### PR TITLE
fix: do not set width binding on Builder Column if value is undefined

### DIFF
--- a/.changeset/soft-moons-change.md
+++ b/.changeset/soft-moons-change.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Builder]: Do not set width binding on Column if value is undefined

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -593,7 +593,7 @@ describe('Builder', () => {
     expect(mitosis.trim()).toEqual(code.trim());
   });
 
-  test.only('do not generate empty expression for width on Column', () => {
+  test('do not generate empty expression for width on Column', () => {
     const content = {
       data: {
         blocks: [

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -593,6 +593,43 @@ describe('Builder', () => {
     expect(mitosis.trim()).toEqual(code.trim());
   });
 
+  test.only('do not generate empty expression for width on Column', () => {
+    const content = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            component: {
+              name: 'Columns',
+              options: {
+                columns: [{ blocks: [] }],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const mitosisJson = builderContentToMitosisComponent(content);
+
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: mitosisJson,
+    });
+
+    expect(mitosis).toMatchInlineSnapshot(`
+      "import { Columns, Column } from \\"@components\\";
+
+      export default function MyComponent(props) {
+        return (
+          <Columns>
+            <Column width={} />
+          </Columns>
+        );
+      }
+      "
+    `);
+  });
+
   test('nodes as props', () => {
     const content = {
       data: {

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -602,7 +602,7 @@ describe('Builder', () => {
             component: {
               name: 'Columns',
               options: {
-                columns: [{ blocks: [] }],
+                columns: [{ blocks: [] }, { blocks: [], width: 50 }],
               },
             },
           },
@@ -622,7 +622,8 @@ describe('Builder', () => {
       export default function MyComponent(props) {
         return (
           <Columns>
-            <Column width={} />
+            <Column />
+            <Column width={50} />
           </Columns>
         );
       }

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -347,9 +347,15 @@ const componentMappers: {
       block.component?.options.columns?.map((col: any, index: number) =>
         createMitosisNode({
           name: 'Column',
-          bindings: {
-            width: { code: col.width?.toString() },
-          },
+          /**
+           * If width if undefined, do not create a binding otherwise its JSX will
+           * be <Column width={} /> which is not valid due to the empty expression.
+           */
+          ...(col.width !== undefined && {
+            bindings: {
+              width: { code: col.width.toString() },
+            },
+          }),
           ...(col.link && {
             properties: {
               link: col.link,


### PR DESCRIPTION
## Description

We always create a `width` binding even if the width is undefined. This causes issues when converting a Mitosis node to JSX as it will yield `<Column width={} />`. Empty expressions (`width={}`) are not valid in JSX, so this will crash and JSX parser.

I fixed the issue to only add a width binding when the value is defined.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [ ] format the codebase: from the root, run `yarn fmt:prettier`.
- [ ] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [ ] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
