### PR TITLE
fix: preserve bound media query styles when converting builder to mitosis

### DIFF
--- a/.changeset/violet-kangaroos-sing.md
+++ b/.changeset/violet-kangaroos-sing.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Builder] preserve bound media query styles when converting to Mitosis

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -648,6 +648,7 @@ describe('Builder', () => {
               'responsiveStyles.small.left': 'state.left',
               'responsiveStyles.small.top': 'state.top',
               'responsiveStyles.large.color': 'state.color',
+              'style.fontSize': 'state.fontSize',
             },
           },
         ],
@@ -659,7 +660,7 @@ describe('Builder', () => {
       {
         "style": {
           "bindingType": "expression",
-          "code": "{ '@media (max-width: 640px)': {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, '@media (max-width: 1200px)': {\\"color\\":\\"state.color\\"}, }",
+          "code": "{ fontSize: state.fontSize, '@media (max-width: 640px)': {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, '@media (max-width: 1200px)': {\\"color\\":\\"state.color\\"}, }",
           "type": "single",
         },
       }
@@ -671,6 +672,7 @@ describe('Builder', () => {
         return (
           <div
             style={{
+              fontSize: state.fontSize,
               \\"@media (max-width: 640px)\\": {
                 left: \\"state.left\\",
                 top: \\"state.top\\",

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -637,6 +637,54 @@ describe('Builder', () => {
       'world',
     );
   });
+
+  test('preserves bound media query styles when converting to mitosis', () => {
+    const content = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            bindings: {
+              'responsiveStyles.small.left': 'state.left',
+              'responsiveStyles.small.top': 'state.top',
+              'responsiveStyles.large.color': 'state.color',
+            },
+          },
+        ],
+      },
+    };
+
+    const mitosis = builderContentToMitosisComponent(content);
+    expect(mitosis.children[0].bindings).toMatchInlineSnapshot(`
+      {
+        "style": {
+          "bindingType": "expression",
+          "code": "{ '@media (max-width: 640px)': {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, '@media (max-width: 1200px)': {\\"color\\":\\"state.color\\"}, }",
+          "type": "single",
+        },
+      }
+    `);
+
+    const jsx = componentToMitosis()({ component: mitosis });
+    expect(jsx).toMatchInlineSnapshot(`
+      "export default function MyComponent(props) {
+        return (
+          <div
+            style={{
+              \\"@media (max-width: 640px)\\": {
+                left: \\"state.left\\",
+                top: \\"state.top\\",
+              },
+              \\"@media (max-width: 1200px)\\": {
+                color: \\"state.color\\",
+              },
+            }}
+          />
+        );
+      }
+      "
+    `);
+  });
 });
 
 const bindingJson = {

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -660,7 +660,7 @@ describe('Builder', () => {
       {
         "style": {
           "bindingType": "expression",
-          "code": "{ fontSize: state.fontSize, '@media (max-width: 640px)': {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, '@media (max-width: 1200px)': {\\"color\\":\\"state.color\\"}, }",
+          "code": "{ fontSize: state.fontSize, \\"@media (max-width: 640px)\\": {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, \\"@media (max-width: 1200px)\\": {\\"color\\":\\"state.color\\"}, }",
           "type": "single",
         },
       }

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -638,7 +638,7 @@ describe('Builder', () => {
     );
   });
 
-  test('preserves bound media query styles when converting to mitosis', () => {
+  test('preserve bound media query styles when converting to mitosis', () => {
     const content = {
       data: {
         blocks: [

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -108,9 +108,8 @@ const getActionBindingsFromBlock = (
 
 const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosisOptions) => {
   const styleBindings: any = {};
-  let styleString = '';
-
   const responsiveStyles: Record<string, Record<string, string>> = {};
+  let styleString = '';
 
   if (block.bindings) {
     for (const key in block.bindings) {

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -107,10 +107,10 @@ const getActionBindingsFromBlock = (
 };
 
 const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosisOptions) => {
-  let styleBindings: any = {};
+  const styleBindings: any = {};
   let styleString = '';
 
-  const responsiveStyles: Record<string, any> = {};
+  const responsiveStyles: Record<string, Record<string, string>> = {};
 
   if (block.bindings) {
     for (const key in block.bindings) {
@@ -147,13 +147,8 @@ const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosi
 
     // All binding values are strings, so stringify media query objects
     for (const key in responsiveStyles) {
-      responsiveStyles[key] = JSON.stringify(responsiveStyles[key]);
+      styleBindings[key] = JSON.stringify(responsiveStyles[key]);
     }
-
-    styleBindings = {
-      ...styleBindings,
-      ...responsiveStyles,
-    };
   }
 
   const styleKeys = Object.keys(styleBindings);

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -136,7 +136,11 @@ const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosi
         const [_, size, prop] = key.split('.');
         const mediaKey = `@media (max-width: ${sizes[size as Size].max}px)`;
 
-        const objKey = `'${mediaKey}'`;
+        /**
+         * The media query key has spaces/special characters so we need to ensure
+         * that the key is always a string otherwise there will be runtime errors.
+         */
+        const objKey = `"${mediaKey}"`;
         responsiveStyles[objKey] = {
           ...responsiveStyles[objKey],
           [prop]: block.bindings[key],


### PR DESCRIPTION
## Description
https://builder-io.atlassian.net/browse/ENG-7491

Bound media query styles are not preserved when converting Builder to Mitosis. This PR addresses the problem by ensuring that bound media query styles are included in the Mitosis node when bound using `responsiveStyles.[SIZE].[CSS PROP]`.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
