### PR TITLE
fix: bound media query styles are not converted to strings

### DIFF
--- a/.changeset/shy-windows-rest.md
+++ b/.changeset/shy-windows-rest.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Builder]: bound media query styles are not converted to strings

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -688,6 +688,11 @@ describe('Builder', () => {
               'responsiveStyles.large.color': 'state.color',
               'style.fontSize': 'state.fontSize',
             },
+            responsiveStyles: {
+              medium: {
+                color: 'red',
+              },
+            },
           },
         ],
       },
@@ -696,9 +701,14 @@ describe('Builder', () => {
     const mitosis = builderContentToMitosisComponent(content);
     expect(mitosis.children[0].bindings).toMatchInlineSnapshot(`
       {
+        "css": {
+          "bindingType": "expression",
+          "code": "{\\"@media (max-width: 991px)\\":{\\"color\\":\\"red\\"}}",
+          "type": "single",
+        },
         "style": {
           "bindingType": "expression",
-          "code": "{ fontSize: state.fontSize, \\"@media (max-width: 640px)\\": {\\"left\\":\\"state.left\\",\\"top\\":\\"state.top\\"}, \\"@media (max-width: 1200px)\\": {\\"color\\":\\"state.color\\"}, }",
+          "code": "{ fontSize: state.fontSize, \\"@media (max-width: 640px)\\": { left: state.left, top: state.top }, \\"@media (max-width: 1200px)\\": { color: state.color }, }",
           "type": "single",
         },
       }
@@ -712,11 +722,16 @@ describe('Builder', () => {
             style={{
               fontSize: state.fontSize,
               \\"@media (max-width: 640px)\\": {
-                left: \\"state.left\\",
-                top: \\"state.top\\",
+                left: state.left,
+                top: state.top,
               },
               \\"@media (max-width: 1200px)\\": {
-                color: \\"state.color\\",
+                color: state.color,
+              },
+            }}
+            css={{
+              \\"@media (max-width: 991px)\\": {
+                color: \\"red\\",
               },
             }}
           />

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -688,11 +688,6 @@ describe('Builder', () => {
               'responsiveStyles.large.color': 'state.color',
               'style.fontSize': 'state.fontSize',
             },
-            responsiveStyles: {
-              medium: {
-                color: 'red',
-              },
-            },
           },
         ],
       },
@@ -701,11 +696,6 @@ describe('Builder', () => {
     const mitosis = builderContentToMitosisComponent(content);
     expect(mitosis.children[0].bindings).toMatchInlineSnapshot(`
       {
-        "css": {
-          "bindingType": "expression",
-          "code": "{\\"@media (max-width: 991px)\\":{\\"color\\":\\"red\\"}}",
-          "type": "single",
-        },
         "style": {
           "bindingType": "expression",
           "code": "{ fontSize: state.fontSize, \\"@media (max-width: 640px)\\": { left: state.left, top: state.top }, \\"@media (max-width: 1200px)\\": { color: state.color }, }",
@@ -727,11 +717,6 @@ describe('Builder', () => {
               },
               \\"@media (max-width: 1200px)\\": {
                 color: state.color,
-              },
-            }}
-            css={{
-              \\"@media (max-width: 991px)\\": {
-                color: \\"red\\",
               },
             }}
           />

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -128,8 +128,8 @@ const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosi
          * responsiveStyles.large.background: "state.background"
          * Should get mapped to:
          * @media (max-width: 1200px): {
-         *   color: "state.color",
-         *   background: "state.background"
+         *   color: state.color,
+         *   background: state.background
          * }
          */
       } else if (key.includes('responsiveStyles')) {
@@ -148,9 +148,16 @@ const getStyleStringFromBlock = (block: BuilderElement, options: BuilderToMitosi
       }
     }
 
-    // All binding values are strings, so stringify media query objects
+    /**
+     * All binding values are strings, but we don't want to stringify the values
+     * within the style object otherwise the bindings will be evaluated as strings.
+     * As a result, do not use JSON.stringify here.
+     */
     for (const key in responsiveStyles) {
-      styleBindings[key] = JSON.stringify(responsiveStyles[key]);
+      const styles = Object.keys(responsiveStyles[key]);
+      const keyValues = styles.map((prop) => `${prop}: ${responsiveStyles[key][prop]}`);
+      const stringifiedObject = `{ ${keyValues.join(', ')} }`;
+      styleBindings[key] = stringifiedObject;
     }
   }
 


### PR DESCRIPTION
## Description

Bound media query styles in the Builder parser are incorrectly transformed into strings. This means that `color: state.color` becomes `color: "state.color"` and the color prop on an element is set to the `"state.color"` string literal instead of being evaluated to the value of `state.color`.

This PR fixes the issue by ensuring that bound values remain bound and are not converted to strings.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
