### PR TITLE
fix: parseJsx accounts for JSX fragments when generating slots

### DIFF
--- a/.changeset/breezy-tips-scream.md
+++ b/.changeset/breezy-tips-scream.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+parseJsx accounts for JSX fragments when generating slots

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -795,8 +795,7 @@ describe('Builder', () => {
     `);
   });
 
-  // TODO this is not correct
-  test.only('map custom component bindings', () => {
+  test('map custom component bindings', () => {
     const content = {
       data: {
         blocks: [
@@ -832,31 +831,46 @@ describe('Builder', () => {
     };
 
     const mitosis = builderContentToMitosisComponent(content);
-    expect(mitosis.children[0].slots).toMatchInlineSnapshot(`
-      {
-        "actions": [
-          {
-            "@type": "@builder.io/mitosis/node",
-            "bindings": {},
-            "children": [],
-            "meta": {},
-            "name": "Button",
-            "properties": {},
-            "scope": {},
-            "slots": {},
+    expect(mitosis.children).toMatchInlineSnapshot(`
+      [
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {},
+          "children": [],
+          "meta": {},
+          "name": "Header",
+          "properties": {
+            "$tagName": undefined,
+            "description": "Collection description",
+            "variant": "h1",
           },
-          {
-            "@type": "@builder.io/mitosis/node",
-            "bindings": {},
-            "children": [],
-            "meta": {},
-            "name": "Button",
-            "properties": {},
-            "scope": {},
-            "slots": {},
+          "scope": {},
+          "slots": {
+            "actions": [
+              {
+                "@type": "@builder.io/mitosis/node",
+                "bindings": {},
+                "children": [],
+                "meta": {},
+                "name": "Button",
+                "properties": {},
+                "scope": {},
+                "slots": {},
+              },
+              {
+                "@type": "@builder.io/mitosis/node",
+                "bindings": {},
+                "children": [],
+                "meta": {},
+                "name": "Button",
+                "properties": {},
+                "scope": {},
+                "slots": {},
+              },
+            ],
           },
-        ],
-      }
+        },
+      ]
     `);
 
     const jsx = componentToMitosis()({ component: mitosis });
@@ -881,58 +895,62 @@ describe('Builder', () => {
     `);
 
     const backToMitosis = parseJsx(jsx);
-    expect(backToMitosis).toMatchInlineSnapshot(`
-      {
-        "@type": "@builder.io/mitosis/component",
-        "children": [
-          {
-            "@type": "@builder.io/mitosis/node",
-            "bindings": {
-              "actions": {
-                "bindingType": "expression",
-                "code": "<>
+    expect(backToMitosis.children).toMatchInlineSnapshot(`
+      [
+        {
+          "@type": "@builder.io/mitosis/node",
+          "bindings": {
+            "actions": {
+              "bindingType": "expression",
+              "code": "<>
                 <Button />
                 <Button />
               </>",
-                "type": "single",
+              "type": "single",
+            },
+          },
+          "children": [],
+          "meta": {},
+          "name": "Header",
+          "properties": {
+            "description": "Collection description",
+            "variant": "h1",
+          },
+          "scope": {},
+          "slots": {
+            "actions": [
+              {
+                "@type": "@builder.io/mitosis/node",
+                "bindings": {},
+                "children": [
+                  {
+                    "@type": "@builder.io/mitosis/node",
+                    "bindings": {},
+                    "children": [],
+                    "meta": {},
+                    "name": "Button",
+                    "properties": {},
+                    "scope": {},
+                  },
+                  {
+                    "@type": "@builder.io/mitosis/node",
+                    "bindings": {},
+                    "children": [],
+                    "meta": {},
+                    "name": "Button",
+                    "properties": {},
+                    "scope": {},
+                  },
+                ],
+                "meta": {},
+                "name": "Fragment",
+                "properties": {},
+                "scope": {},
               },
-            },
-            "children": [],
-            "meta": {},
-            "name": "Header",
-            "properties": {
-              "description": "Collection description",
-              "variant": "h1",
-            },
-            "scope": {},
+            ],
           },
-        ],
-        "context": {
-          "get": {},
-          "set": {},
         },
-        "exports": {},
-        "hooks": {
-          "onEvent": [],
-          "onMount": [],
-        },
-        "imports": [
-          {
-            "importKind": "value",
-            "imports": {
-              "Button": "Button",
-              "Header": "Header",
-            },
-            "path": "@components",
-          },
-        ],
-        "inputs": [],
-        "meta": {},
-        "name": "MyComponent",
-        "refs": {},
-        "state": {},
-        "subComponents": [],
-      }
+      ]
     `);
 
     const json = componentToBuilder()({ component: backToMitosis });
@@ -943,25 +961,60 @@ describe('Builder', () => {
             {
               "@type": "@builder.io/sdk:Element",
               "actions": {},
-              "bindings": {
-                "component.options.actions": " return <>
-                <Button />
-                <Button />
-              </>",
-              },
+              "bindings": {},
               "children": [],
               "code": {
                 "actions": {},
-                "bindings": {
-                  "component.options.actions": "<>
-                <Button />
-                <Button />
-              </>",
-                },
+                "bindings": {},
               },
               "component": {
                 "name": "Header",
                 "options": {
+                  "actions": [
+                    {
+                      "@type": "@builder.io/sdk:Element",
+                      "actions": {},
+                      "bindings": {},
+                      "children": [
+                        {
+                          "@type": "@builder.io/sdk:Element",
+                          "actions": {},
+                          "bindings": {},
+                          "children": [],
+                          "code": {
+                            "actions": {},
+                            "bindings": {},
+                          },
+                          "component": {
+                            "name": "Button",
+                            "options": {},
+                          },
+                        },
+                        {
+                          "@type": "@builder.io/sdk:Element",
+                          "actions": {},
+                          "bindings": {},
+                          "children": [],
+                          "code": {
+                            "actions": {},
+                            "bindings": {},
+                          },
+                          "component": {
+                            "name": "Button",
+                            "options": {},
+                          },
+                        },
+                      ],
+                      "code": {
+                        "actions": {},
+                        "bindings": {},
+                      },
+                      "component": {
+                        "name": "Fragment",
+                        "options": {},
+                      },
+                    },
+                  ],
                   "description": "Collection description",
                   "variant": "h1",
                 },

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -794,6 +794,186 @@ describe('Builder', () => {
       }
     `);
   });
+
+  // TODO this is not correct
+  test.only('map custom component bindings', () => {
+    const content = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            '@version': 2,
+            component: {
+              name: 'Header',
+              options: {
+                variant: 'h1',
+                description: 'Collection description',
+                actions: [
+                  {
+                    '@type': '@builder.io/sdk:Element',
+                    '@version': 2,
+                    component: {
+                      name: 'Button',
+                    },
+                  },
+                  {
+                    '@type': '@builder.io/sdk:Element',
+                    '@version': 2,
+                    component: {
+                      name: 'Button',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const mitosis = builderContentToMitosisComponent(content);
+    expect(mitosis.children[0].slots).toMatchInlineSnapshot(`
+      {
+        "actions": [
+          {
+            "@type": "@builder.io/mitosis/node",
+            "bindings": {},
+            "children": [],
+            "meta": {},
+            "name": "Button",
+            "properties": {},
+            "scope": {},
+            "slots": {},
+          },
+          {
+            "@type": "@builder.io/mitosis/node",
+            "bindings": {},
+            "children": [],
+            "meta": {},
+            "name": "Button",
+            "properties": {},
+            "scope": {},
+            "slots": {},
+          },
+        ],
+      }
+    `);
+
+    const jsx = componentToMitosis()({ component: mitosis });
+    expect(jsx).toMatchInlineSnapshot(`
+      "import { Header, Button } from \\"@components\\";
+
+      export default function MyComponent(props) {
+        return (
+          <Header
+            variant=\\"h1\\"
+            description=\\"Collection description\\"
+            actions={
+              <>
+                <Button />
+                <Button />
+              </>
+            }
+          />
+        );
+      }
+      "
+    `);
+
+    const backToMitosis = parseJsx(jsx);
+    expect(backToMitosis).toMatchInlineSnapshot(`
+      {
+        "@type": "@builder.io/mitosis/component",
+        "children": [
+          {
+            "@type": "@builder.io/mitosis/node",
+            "bindings": {
+              "actions": {
+                "bindingType": "expression",
+                "code": "<>
+                <Button />
+                <Button />
+              </>",
+                "type": "single",
+              },
+            },
+            "children": [],
+            "meta": {},
+            "name": "Header",
+            "properties": {
+              "description": "Collection description",
+              "variant": "h1",
+            },
+            "scope": {},
+          },
+        ],
+        "context": {
+          "get": {},
+          "set": {},
+        },
+        "exports": {},
+        "hooks": {
+          "onEvent": [],
+          "onMount": [],
+        },
+        "imports": [
+          {
+            "importKind": "value",
+            "imports": {
+              "Button": "Button",
+              "Header": "Header",
+            },
+            "path": "@components",
+          },
+        ],
+        "inputs": [],
+        "meta": {},
+        "name": "MyComponent",
+        "refs": {},
+        "state": {},
+        "subComponents": [],
+      }
+    `);
+
+    const json = componentToBuilder()({ component: backToMitosis });
+    expect(json).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "blocks": [
+            {
+              "@type": "@builder.io/sdk:Element",
+              "actions": {},
+              "bindings": {
+                "component.options.actions": " return <>
+                <Button />
+                <Button />
+              </>",
+              },
+              "children": [],
+              "code": {
+                "actions": {},
+                "bindings": {
+                  "component.options.actions": "<>
+                <Button />
+                <Button />
+              </>",
+                },
+              },
+              "component": {
+                "name": "Header",
+                "options": {
+                  "description": "Collection description",
+                  "variant": "h1",
+                },
+              },
+            },
+          ],
+          "jsCode": "",
+          "tsCode": "",
+        },
+      }
+    `);
+  });
 });
 
 const bindingJson = {

--- a/packages/core/src/parsers/jsx/element-parser.ts
+++ b/packages/core/src/parsers/jsx/element-parser.ts
@@ -253,7 +253,6 @@ export const jsxElementToJson = (
   // const bindings: MitosisNode['bindings'] = {}
   // const slots: MitosisNode['slots'] = {}
 
-  console.log('looking at', node.openingElement);
   const { bindings, properties, slots } = node.openingElement.attributes.reduce<{
     bindings: MitosisNode['bindings'];
     properties: MitosisNode['properties'];

--- a/packages/core/src/parsers/jsx/element-parser.ts
+++ b/packages/core/src/parsers/jsx/element-parser.ts
@@ -253,6 +253,7 @@ export const jsxElementToJson = (
   // const bindings: MitosisNode['bindings'] = {}
   // const slots: MitosisNode['slots'] = {}
 
+  console.log('looking at', node.openingElement);
   const { bindings, properties, slots } = node.openingElement.attributes.reduce<{
     bindings: MitosisNode['bindings'];
     properties: MitosisNode['properties'];
@@ -294,8 +295,9 @@ export const jsxElementToJson = (
             arguments: args.length ? args : undefined,
             bindingType: 'function',
           });
-        } else if (types.isJSXElement(expression)) {
+        } else if (types.isJSXElement(expression) || types.isJSXFragment(expression)) {
           // <Foo myProp={<MoreMitosisNode><div /></MoreMitosisNode>} />
+          // <Foo myProp={<><Node /><Node /></>} />
           const slotNode = jsxElementToJson(expression);
           if (!slotNode) return memo;
 


### PR DESCRIPTION
## Description

Mitosis currently does not account for JSX fragments for slot generation when going from Mitosis JSX --> Mitosis JSON: [Playground](https://mitosis.builder.io/playground/?code=FAUwHgDg9gTgLgAgCYgGYEMCuAbRrMB2AxnAJZQEICyAngMJQC20BIBcAFBDFBAM4BKBAG9gCBDBBxMMShzHiEAHgBiUKAkY0ACjwgBeUYsVKAfAuPilAIUxw4FBAHpzl5S4sIAvs9cIBANzAXkA) (click "json" as the output). When generating outputs such as Builder Content, this causes a crash as data inside of custom components are not being bound correctly.

However, when passing in a JSX Element directly, Mitosis generates slots with the JSX element: [Reproduction](https://mitosis.builder.io/playground/?code=FAUwHgDg9gTgLgAgCYgGYEMCuAbRrMB2AxnAJZQEICyAngMJQC20BIBcAFBDFBAM4BKBAG9gCBDBBxMMShzHiEAHgBiUKAkY0ACjwgBeUYsVKAfAuPilAIUxw4FBAHpzl5S4sIAvs9cIBANzAXkA) (click "json" as the output)

This PR fixes the issue by accounting for JSX Fragments in addition to JSX Elements when generating slots.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
