### PR TITLE
fix: Builder generator includes width on Columns components

### DIFF
--- a/.changeset/flat-days-protect.md
+++ b/.changeset/flat-days-protect.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Builder: include Column widths in generator

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -701,7 +701,7 @@ describe('Builder', () => {
     `);
   });
 
-  test.only('map Column widths', () => {
+  test('map Column widths', () => {
     const content = {
       data: {
         blocks: [
@@ -710,7 +710,7 @@ describe('Builder', () => {
             component: {
               name: 'Columns',
               options: {
-                columns: [{ blocks: [], width: 50 }],
+                columns: [{ blocks: [], width: 50 }, { blocks: [] }],
               },
             },
           },
@@ -740,7 +740,10 @@ describe('Builder', () => {
                   "columns": [
                     {
                       "blocks": [],
-                      "width": 50
+                      "width": 50,
+                    },
+                    {
+                      "blocks": [],
                     },
                   ],
                 },

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -701,6 +701,59 @@ describe('Builder', () => {
     `);
   });
 
+  test.only('map Column widths', () => {
+    const content = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            component: {
+              name: 'Columns',
+              options: {
+                columns: [{ blocks: [], width: 50 }],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const mitosisJson = builderContentToMitosisComponent(content);
+
+    const backToBuilder = componentToBuilder()({ component: mitosisJson });
+    expect(backToBuilder).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "blocks": [
+            {
+              "@type": "@builder.io/sdk:Element",
+              "actions": {},
+              "bindings": {},
+              "children": [],
+              "code": {
+                "actions": {},
+                "bindings": {},
+              },
+              "component": {
+                "name": "Columns",
+                "options": {
+                  "columns": [
+                    {
+                      "blocks": [],
+                      "width": 50
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+          "jsCode": "",
+          "tsCode": "",
+        },
+      }
+    `);
+  });
+
   test('nodes as props', () => {
     const content = {
       data: {

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -87,6 +87,7 @@ const componentMappers: {
 
     const columns = block.children!.map((item) => ({
       blocks: item.children,
+      width: item.component?.options?.width,
     }));
 
     block.component!.options.columns = columns;


### PR DESCRIPTION
## Description

The Builder generator does not include the `width` values when going from Mitosis --> Builder. This results in column objects with in the Columns component having the wrong size. See results from the test pushed to this branch:

**Input**

```js
{
  data: {
    blocks: [
      {
        '@type': '@builder.io/sdk:Element',
        component: {
          name: 'Columns',
          options: {
            columns: [{ blocks: [], width: 50 }, { blocks: [] }],
          },
        },
      },
    ],
  },
}
```

**Results**

```diff
 FAIL  src/__tests__/builder.test.ts > Builder > map Column widths
Error: Snapshot `Builder > map Column widths 1` mismatched

- Expected
+ Received

  {
    "data": {
      "blocks": [
        {
          "@type": "@builder.io/sdk:Element",
          "actions": {},
          "bindings": {},
          "children": [],
          "code": {
            "actions": {},
            "bindings": {},
          },
          "component": {
            "name": "Columns",
            "options": {
              "columns": [
                {
                  "blocks": [],
-                 "width": 50,
                },
                {
                  "blocks": [],
                },
              ],
            },
          },
        },
      ],
      "jsCode": "",
      "tsCode": "",
    },
  }

```

This PR fixes the issue by ensuring that the width is preserved when generating column objects in `Columns` Builder elements.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
