### PR TITLE
fix: bound call expression styles are preserved in Builder generator

### DIFF
--- a/.changeset/shy-bears-invent.md
+++ b/.changeset/shy-bears-invent.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Builder: bound call expression styles are preserved in generator

--- a/.changeset/shy-bears-invent.md
+++ b/.changeset/shy-bears-invent.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-Builder: bound call expression styles are preserved in generator
+[Builder]: bound call expression styles are preserved in generator

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -969,21 +969,21 @@ describe('Builder', () => {
       component: backToMitosis,
     });
     expect(mitosis).toMatchInlineSnapshot(`
-    "import { useStore } from \\"@builder.io/mitosis\\";
-  
-    export default function MyComponent(props) {
-      const state = useStore({
-        getStyles() {
-          return {
-            color: \\"red\\",
-          };
-        },
-      });
-  
-      return <div style={state.getStyles()} />;
-    }
-    "
-  `);
+      "import { useStore } from \\"@builder.io/mitosis\\";
+
+      export default function MyComponent(props) {
+        const state = useStore({
+          getStyles() {
+            return {
+              color: \\"red\\",
+            };
+          },
+        });
+
+        return <div style={state.getStyles()} />;
+      }
+      "
+    `);
   });
 
   test('drop unsupported bound styles to avoid crashes', () => {

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -986,6 +986,34 @@ describe('Builder', () => {
     `);
   });
 
+  test('invalid style values are removed', () => {
+    const code = dedent`  
+    export default function MyComponent(props) {
+      return (
+        <div style={false} />
+      );
+    }
+  `;
+
+    const component = parseJsx(code);
+    const builderJson = componentToBuilder()({ component });
+
+    expect(builderJson.data!.blocks![0]).toMatchInlineSnapshot(`
+      {
+        "@type": "@builder.io/sdk:Element",
+        "actions": {},
+        "bindings": {},
+        "children": [],
+        "code": {
+          "actions": {},
+          "bindings": {},
+        },
+        "properties": {},
+        "tagName": "div",
+      }
+    `);
+  });
+
   test('drop unsupported bound styles to avoid crashes', () => {
     const jsx = `export default function MyComponent(props) {
       return (

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -887,6 +887,105 @@ describe('Builder', () => {
         `);
   });
 
+  test('preserve bound call expressions for styles', () => {
+    const code = dedent`
+    import { useStore } from "@builder.io/mitosis";
+  
+    export default function MyComponent(props) {
+      const state = useStore({
+        getStyles() {
+          return {
+            color: 'red'
+          }
+        }
+      })
+      return (
+        <div style={state.getStyles()} />
+      );
+    }
+  `;
+
+    const component = parseJsx(code);
+
+    expect(component.children[0]).toMatchInlineSnapshot(`
+    {
+      "@type": "@builder.io/mitosis/node",
+      "bindings": {
+        "style": {
+          "bindingType": "expression",
+          "code": "state.getStyles()",
+          "type": "single",
+        },
+      },
+      "children": [],
+      "meta": {},
+      "name": "div",
+      "properties": {},
+      "scope": {},
+    }
+  `);
+
+    const builderJson = componentToBuilder()({ component });
+
+    expect(builderJson.data!.blocks![0]).toMatchInlineSnapshot(`
+    {
+      "@type": "@builder.io/sdk:Element",
+      "actions": {},
+      "bindings": {
+        "style": "state.getStyles()",
+      },
+      "children": [],
+      "code": {
+        "actions": {},
+        "bindings": {},
+      },
+      "properties": {},
+      "tagName": "div",
+    }
+  `);
+
+    const backToMitosis = builderContentToMitosisComponent(builderJson);
+
+    expect(backToMitosis.children[0]).toMatchInlineSnapshot(`
+    {
+      "@type": "@builder.io/mitosis/node",
+      "bindings": {
+        "style": {
+          "bindingType": "expression",
+          "code": "state.getStyles()",
+          "type": "single",
+        },
+      },
+      "children": [],
+      "meta": {},
+      "name": "div",
+      "properties": {},
+      "scope": {},
+      "slots": {},
+    }
+  `);
+
+    const mitosis = componentToMitosis(mitosisOptions)({
+      component: backToMitosis,
+    });
+    expect(mitosis).toMatchInlineSnapshot(`
+    "import { useStore } from \\"@builder.io/mitosis\\";
+  
+    export default function MyComponent(props) {
+      const state = useStore({
+        getStyles() {
+          return {
+            color: \\"red\\",
+          };
+        },
+      });
+  
+      return <div style={state.getStyles()} />;
+    }
+    "
+  `);
+  });
+
   test('drop unsupported bound styles to avoid crashes', () => {
     const jsx = `export default function MyComponent(props) {
       return (

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -502,6 +502,8 @@ const mapBoundStyles = (bindings: { [key: string]: Binding | undefined }) => {
           bindingType: 'expression',
           type: 'single',
         };
+      } else {
+        throw 'unsupported style';
       }
     } catch {
       console.warn(`The following bound styles are invalid and have been removed: ${unparsed}`);


### PR DESCRIPTION
## Description

When [fixing an issue where dynamic styles were not mapped to bindings](https://github.com/BuilderIO/mitosis/commit/a38e5bb4bcdeb4c77a8f4ae36ffa5cba993b4cc4) I inadvertently broke a usecase where a function call could be bound to get the styles (I.e. `style={state.getStyles()}`. This PR resolves the issue by ensuring that call expressions can be set as styles.

It's possible that I am missing other use cases here, so I added a console warning whenever invalid styles are dropped so it's a bit more obvious that this is happening in the future.

Failing test example:
```diff
 FAIL  src/__tests__/builder.test.ts > Builder > preserve bound call expressions for styles
Error: Snapshot `Builder > preserve bound call expressions for styles 2` mismatched

- Expected
+ Received

  {
    "@type": "@builder.io/sdk:Element",
    "actions": {},
-   "bindings": {
-     "style": "state.getStyles()",
-   },
+   "bindings": {},
    "children": [],
    "code": {
      "actions": {},
      "bindings": {},
    },
    "properties": {},
    "tagName": "div",
  }

 ❯ src/__tests__/builder.test.ts:930:42
    928|     const builderJson = componentToBuilder()({ component });
    929| 
    930|     expect(builderJson.data!.blocks![0]).toMatchInlineSnapshot(`
       |                                          ^
    931|     {
    932|       "@type": "@builder.io/sdk:Element",
```

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
