### PR TITLE
fix: Builder parser does not strip falsey style values

### DIFF
--- a/.changeset/rich-turkeys-smoke.md
+++ b/.changeset/rich-turkeys-smoke.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[Builder]: parser does not strip falsey style values

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -1673,10 +1673,12 @@ exports[`Builder > Section 1`] = `
     display: flex;
     flex-direction: column;
     position: relative;
+    flex-shrink: 0;
     box-sizing: border-box;
     line-height: normal;
     height: auto;
     text-align: center;
+    margin-top: 0px;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 70px;
@@ -1688,10 +1690,12 @@ exports[`Builder > Section 1`] = `
     display: flex;
     flex-direction: column;
     position: relative;
+    flex-shrink: 0;
     box-sizing: border-box;
     line-height: normal;
     height: auto;
     text-align: center;
+    margin-top: 0px;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 70px;

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -663,6 +663,47 @@ describe('Builder', () => {
     expect(mitosis.trim()).toEqual(code.trim());
   });
 
+  test('do not strip falsey style values', () => {
+    const content = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            responsiveStyles: {
+              large: {
+                background: 'blue',
+                zIndex: '0',
+              },
+            },
+            children: [
+              {
+                '@type': '@builder.io/sdk:Element' as const,
+                component: {
+                  name: 'Text',
+                  options: {
+                    text: 'AI Explained',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const mitosisJson = builderContentToMitosisComponent(content);
+
+    expect(mitosisJson.children[0].bindings).toMatchInlineSnapshot(`
+      {
+        "css": {
+          "bindingType": "expression",
+          "code": "{background:'blue',zIndex:'0'}",
+          "type": "single",
+        },
+      }
+    `);
+  });
+
   test('do not generate empty expression for width on Column', () => {
     const content = {
       data: {

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1243,19 +1243,13 @@ function mapBuilderBindingsToMitosisBindingWithCode(
 
 type Styles = Record<string, any>;
 
-function removeFalsey(obj: Styles) {
-  return omitBy(
-    obj,
-    (value) => !value || value === '0' || value === '0px' || value === 'none' || value === '0%',
-  );
-}
 function combineStyles(parent: Styles, child: Styles) {
   const marginStyles = ['marginTop', 'marginBottom', 'marginLeft', 'marginRight'];
   const paddingStyles = ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'];
   const distanceStylesToCombine = [...paddingStyles, ...marginStyles];
   const merged: Styles = {
-    ...omit(removeFalsey(child), distanceStylesToCombine),
-    ...removeFalsey(parent),
+    ...omit(child, distanceStylesToCombine),
+    ...parent,
   };
   for (const key of distanceStylesToCombine) {
     // Funky things happen if different alignment


### PR DESCRIPTION
## Description

The Builder JSON parser currently strips out falsey style values (I.e. `padding: 0`). The original motivation for this was to cut down on the amount of CSS generated with codegen in Builder. However, our codegen process has improved since then where this is not a big problem anymore.

More importantly, stripping falsey values is causing functional changes to the code because we make the assumption that a value of `0` is the same as not having the CSS declaration to begin with which is not always true. For example, we remove values such as `flex-shrink: 0`. However, the [default value for `flex-shrink` is 1](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink#formal_definition).

Another example can be seen here: https://codepen.io/liamdebeasi/pen/gbOrgJm

In the first block `#text` has `z-index: 0` which causes it to show on top of the square. In the second block ,`#text` does not have `z-index: 0` which causes it to show below the square.

This PR resolves the issue by removing logic that removes falsey CSS values.

For added context, this logic was originally added [via a PR to Mitosis](https://github.com/BuilderIO/mitosis/pull/1273), but this PR was a port [from another repo](https://github.com/BuilderIO/builder-internal/pull/5130).

----

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
