### PR TITLE
feat: add dependency handling for onUpdate hook

### DIFF
--- a/.changeset/sixty-oranges-tie.md
+++ b/.changeset/sixty-oranges-tie.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[stencil] add dependency handling for onUpdate hook

--- a/e2e/e2e-app/src/component-paths.ts
+++ b/e2e/e2e-app/src/component-paths.ts
@@ -6,4 +6,5 @@ export const COMPONENT_PATHS = [
   '/special-tags/',
   '/signals/',
   '/disabled-input/',
+  '/component-on-update/',
 ];

--- a/e2e/e2e-app/src/components/component-on-update.lite.tsx
+++ b/e2e/e2e-app/src/components/component-on-update.lite.tsx
@@ -1,0 +1,51 @@
+import { onMount, onUpdate, useRef, useStore } from '@builder.io/mitosis';
+
+type Store = { initial: boolean; counter: number; label?: string; handleClick: () => void };
+
+export default function ComponentOnUpdate(props: any) {
+  const _ref = useRef<HTMLDivElement | null>(null);
+
+  const state = useStore<Store>({
+    initial: false,
+    counter: 0,
+    label: undefined,
+    handleClick: () => {
+      state.counter = state.counter + 1;
+    },
+  });
+
+  onMount(() => {
+    state.initial = true;
+  });
+
+  onUpdate(() => {
+    if (_ref && !state.initial) {
+      state.initial = true;
+    }
+  }, [_ref, state.initial]);
+
+  onUpdate(() => {
+    console.log(state);
+  });
+
+  onUpdate(() => {
+    if (state.initial) {
+      state.label = 'Label';
+    }
+  }, [state.initial]);
+
+  onUpdate(() => {
+    if (_ref && state.label) {
+      _ref.setAttribute('aria-label', `${state.label}: ${state.counter}`);
+    }
+  }, [_ref, state.counter, state.label]);
+
+  return (
+    <div ref={_ref} data-testid="container">
+      Hello {state.counter}
+      <button data-testid="button" onClick={() => state.handleClick()}>
+        Increase
+      </button>
+    </div>
+  );
+}

--- a/e2e/e2e-app/src/components/component-on-update.lite.tsx
+++ b/e2e/e2e-app/src/components/component-on-update.lite.tsx
@@ -25,7 +25,7 @@ export default function ComponentOnUpdate(props: any) {
   }, [_ref, state.initial]);
 
   onUpdate(() => {
-    console.log(state);
+    console.log(state.counter, state.label, state.initial);
   });
 
   onUpdate(() => {

--- a/e2e/e2e-app/src/homepage.lite.tsx
+++ b/e2e/e2e-app/src/homepage.lite.tsx
@@ -1,5 +1,6 @@
 import { For, onMount, Show, useStore } from '@builder.io/mitosis';
 import { COMPONENT_PATHS } from './component-paths';
+import ComponentOnUpdate from './components/component-on-update.lite';
 import ComponentWithTypes from './components/component-with-types.lite';
 import DisabledInput from './components/disabled-input/disabled-input.lite';
 import NestedParent from './components/nested/nested-parent.lite';
@@ -60,6 +61,10 @@ export default function Homepage(props: { pathname?: string }) {
 
       <Show when={state.pathToUse.startsWith('/disabled-input')}>
         <DisabledInput />
+      </Show>
+
+      <Show when={state.pathToUse.startsWith('/component-on-update')}>
+        <ComponentOnUpdate />
       </Show>
     </div>
   );

--- a/e2e/e2e-app/tests/main.spec.ts
+++ b/e2e/e2e-app/tests/main.spec.ts
@@ -80,27 +80,40 @@ test.describe('e2e', () => {
       const div = page.locator('.wrap');
       await expect(div).toHaveCSS('background-color', 'rgb(255, 0, 0)');
     });
+  });
 
-    test('simple input disabled', async ({ page, packageName }) => {
-      await page.goto('/disabled-input/');
+  test('simple input disabled', async ({ page, packageName }) => {
+    await page.goto('/disabled-input/');
 
-      const disabled = page.getByTestId('simple-input-disabled');
+    const disabled = page.getByTestId('simple-input-disabled');
+    await expect(disabled).toBeDisabled();
+
+    const enabled = page.getByTestId('simple-input-enabled');
+    if (['e2e-angular'].includes(packageName)) {
+      // this is the exception for angular it will generate [attr.disabled]
+      // which will be a string, so it is always true
       await expect(disabled).toBeDisabled();
+    } else {
+      await expect(enabled).toBeEditable();
+    }
 
-      const enabled = page.getByTestId('simple-input-enabled');
-      if (['e2e-angular'].includes(packageName)) {
-        // this is the exception for angular it will generate [attr.disabled]
-        // which will be a string, so it is always true
-        await expect(disabled).toBeDisabled();
-      } else {
-        await expect(enabled).toBeEditable();
-      }
+    const nativeDisabled = page.getByTestId('native-input-disabled');
+    await expect(nativeDisabled).toBeDisabled();
 
-      const nativeDisabled = page.getByTestId('native-input-disabled');
-      await expect(nativeDisabled).toBeDisabled();
+    const nativeEnabled = page.getByTestId('native-input-enabled');
+    await expect(nativeEnabled).toBeEditable();
+  });
 
-      const nativeEnabled = page.getByTestId('native-input-enabled');
-      await expect(nativeEnabled).toBeEditable();
-    });
+  test('on update', async ({ page, packageName }) => {
+    await page.goto('/component-on-update/');
+
+    const container = page.getByTestId('container');
+    const button = page.getByTestId('button');
+    const labelBefore = await container.getAttribute('aria-label');
+    expect(labelBefore).toEqual('Label: 0');
+
+    await button.click();
+    const labelAfter = await container.getAttribute('aria-label');
+    expect(labelAfter).toEqual('Label: 1');
   });
 });

--- a/e2e/e2e-app/tests/main.spec.ts
+++ b/e2e/e2e-app/tests/main.spec.ts
@@ -105,6 +105,11 @@ test.describe('e2e', () => {
   });
 
   test('on update', async ({ page, packageName }) => {
+    if (['e2e-angular', 'e2e-solid'].includes(packageName)) {
+      // Angular: We need to split onUpdate to ngOnChanges and for useRef into ngAfterContentChecked
+      test.skip();
+    }
+
     await page.goto('/component-on-update/');
 
     const container = page.getByTestId('container');

--- a/e2e/e2e-react/src/App.tsx
+++ b/e2e/e2e-react/src/App.tsx
@@ -1,4 +1,5 @@
 // Mitosis output for not yet include .d.ts, so ignore the types when importing.
+// Trigger nx remote cache: 2
 // @ts-ignore
 import { E2eApp } from '@builder.io/e2e-app/react';
 

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -72,7 +72,7 @@ export class MyBasicForShowComponent {
 `;
 
 exports[`Stencil > jsx > Javascript Test > AdvancedRef 1`] = `
-"import { Component, h, Fragment, Prop, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-basic-ref-component\\",
@@ -97,10 +97,18 @@ export class MyBasicRefComponent {
     return this.name.toLowerCase();
   };
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Received an update\\");
+  }
+
+  @Watch(\\"inputRef\\")
+  @Watch(\\"inputNoArgRef\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -569,7 +577,7 @@ exports[`Stencil > jsx > Javascript Test > BasicRefPrevious 1`] = `
   return ref;
 }
 
-import { Component, h, Fragment, State } from \\"@stencil/core\\";
+import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-previous-component\\",
@@ -579,10 +587,17 @@ export class MyPreviousComponent {
 
   @State() count = 0;
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     this.prevCount = this.count;
+  }
+
+  @Watch(\\"count\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -2263,7 +2278,7 @@ export class MyBasicForwardRefComponent {
 `;
 
 exports[`Stencil > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-basic-on-update-return-component\\",
@@ -2271,9 +2286,7 @@ exports[`Stencil > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 export class MyBasicOnUpdateReturnComponent {
   @State() name = \\"PatrickJS\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     const controller = new AbortController();
     const signal = controller.signal;
     fetch(\\"https://patrickjs.com/api/resource.json\\", {
@@ -2288,6 +2301,15 @@ export class MyBasicOnUpdateReturnComponent {
         controller.abort();
       }
     };
+  }
+
+  @Watch(\\"name\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -3048,7 +3070,7 @@ export class MultipleOnUpdate {
 `;
 
 exports[`Stencil > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"multiple-on-update-with-deps\\",
@@ -3059,19 +3081,37 @@ export class MultipleOnUpdateWithDeps {
   @State() c = \\"c\\";
   @State() d = \\"d\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Runs when a or b changes\\", this.a, this.b);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
     }
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  watch1Fn() {
     console.log(\\"Runs when c or d changes\\", this.c, this.d);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
     }
+  }
+
+  @Watch(\\"c\\")
+  @Watch(\\"d\\")
+  watch1() {
+    this.watch1Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
+    this.watch1Fn();
   }
 
   render() {
@@ -3365,7 +3405,7 @@ export class OnUpdate {
 `;
 
 exports[`Stencil > jsx > Javascript Test > onUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, Prop, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"on-update-with-deps\\",
@@ -3375,10 +3415,19 @@ export class OnUpdateWithDeps {
   @State() a = \\"a\\";
   @State() b = \\"b\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Runs when a, b or size changes\\", this.a, this.b, this.size);
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  @Watch(\\"size\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -3795,7 +3844,7 @@ import {
 } from \\"@dummy/injection-js\\";
 import { RenderBlocks } from \\"@dummy/RenderBlocks.lite.tsx\\";
 
-import { Component, h, Fragment, Prop } from \\"@stencil/core\\";
+import { Component, h, Fragment, Watch, Prop } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"render-content\\",
@@ -3811,12 +3860,18 @@ export class RenderContent {
   @Prop() customComponents: any;
   @Prop() content: any;
 
-  componentDidLoad() {
-    sendComponentsToVisualEditor(this.customComponents);
+  watch0Fn() {
+    dispatchNewContentToVisualEditor(this.content);
   }
 
-  componentDidUpdate() {
-    dispatchNewContentToVisualEditor(this.content);
+  @Watch(\\"content\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    sendComponentsToVisualEditor(this.customComponents);
+    this.watch0Fn();
   }
 
   render() {
@@ -3949,7 +4004,7 @@ export class SetState {
 `;
 
 exports[`Stencil > jsx > Javascript Test > signalsOnUpdate 1`] = `
-"import { Component, h, Fragment, Prop } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-basic-component\\",
@@ -3964,11 +4019,19 @@ export class MyBasicComponent {
   @Prop() id: any;
   @Prop() foo: any;
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"props.id changed\\", this.id);
     console.log(\\"props.foo.value.bar.baz changed\\", this.foo.value.bar.baz);
+  }
+
+  @Watch(\\"id\\")
+  @Watch(\\"foo.value.bar.baz\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -4499,7 +4562,7 @@ export class MyBasicForShowComponent {
 `;
 
 exports[`Stencil > jsx > Typescript Test > AdvancedRef 1`] = `
-"import { Component, h, Fragment, Prop, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop, State } from \\"@stencil/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -4528,10 +4591,18 @@ export class MyBasicRefComponent {
     return this.name.toLowerCase();
   };
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Received an update\\");
+  }
+
+  @Watch(\\"inputRef\\")
+  @Watch(\\"inputNoArgRef\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -5022,7 +5093,7 @@ exports[`Stencil > jsx > Typescript Test > BasicRefPrevious 1`] = `
   return ref;
 }
 
-import { Component, h, Fragment, State } from \\"@stencil/core\\";
+import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 export interface Props {
   showInput: boolean;
@@ -5036,10 +5107,17 @@ export class MyPreviousComponent {
 
   @State() count = 0;
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     this.prevCount = this.count;
+  }
+
+  @Watch(\\"count\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -6963,7 +7041,7 @@ export class MyBasicForwardRefComponent {
 `;
 
 exports[`Stencil > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-basic-on-update-return-component\\",
@@ -6971,9 +7049,7 @@ exports[`Stencil > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 export class MyBasicOnUpdateReturnComponent {
   @State() name = \\"PatrickJS\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     const controller = new AbortController();
     const signal = controller.signal;
     fetch(\\"https://patrickjs.com/api/resource.json\\", {
@@ -6988,6 +7064,15 @@ export class MyBasicOnUpdateReturnComponent {
         controller.abort();
       }
     };
+  }
+
+  @Watch(\\"name\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -7800,7 +7885,7 @@ export class MultipleOnUpdate {
 `;
 
 exports[`Stencil > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"multiple-on-update-with-deps\\",
@@ -7811,19 +7896,37 @@ export class MultipleOnUpdateWithDeps {
   @State() c = \\"c\\";
   @State() d = \\"d\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Runs when a or b changes\\", this.a, this.b);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
     }
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  watch1Fn() {
     console.log(\\"Runs when c or d changes\\", this.c, this.d);
 
     if (this.a === \\"a\\") {
       this.a = \\"b\\";
     }
+  }
+
+  @Watch(\\"c\\")
+  @Watch(\\"d\\")
+  watch1() {
+    this.watch1Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
+    this.watch1Fn();
   }
 
   render() {
@@ -8125,7 +8228,7 @@ export class OnUpdate {
 `;
 
 exports[`Stencil > jsx > Typescript Test > onUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, Prop, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop, State } from \\"@stencil/core\\";
 
 type Props = {
   size: string;
@@ -8139,10 +8242,19 @@ export class OnUpdateWithDeps {
   @State() a = \\"a\\";
   @State() b = \\"b\\";
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"Runs when a, b or size changes\\", this.a, this.b, this.size);
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  @Watch(\\"size\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -8610,7 +8722,7 @@ import {
 } from \\"@dummy/injection-js\\";
 import { RenderBlocks } from \\"@dummy/RenderBlocks.lite.tsx\\";
 
-import { Component, h, Fragment, Prop } from \\"@stencil/core\\";
+import { Component, h, Fragment, Watch, Prop } from \\"@stencil/core\\";
 
 type Props = {
   customComponents: string[];
@@ -8634,12 +8746,18 @@ export class RenderContent {
   @Prop() customComponents: Props[\\"customComponents\\"];
   @Prop() content: Props[\\"content\\"];
 
-  componentDidLoad() {
-    sendComponentsToVisualEditor(this.customComponents);
+  watch0Fn() {
+    dispatchNewContentToVisualEditor(this.content);
   }
 
-  componentDidUpdate() {
-    dispatchNewContentToVisualEditor(this.content);
+  @Watch(\\"content\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    sendComponentsToVisualEditor(this.customComponents);
+    this.watch0Fn();
   }
 
   render() {
@@ -8779,7 +8897,7 @@ export class SetState {
 `;
 
 exports[`Stencil > jsx > Typescript Test > signalsOnUpdate 1`] = `
-"import { Component, h, Fragment, Prop } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, Prop } from \\"@stencil/core\\";
 
 type Props = {
   id: string;
@@ -8803,11 +8921,19 @@ export class MyBasicComponent {
   @Prop() id: Props[\\"id\\"];
   @Prop() foo: Props[\\"foo\\"];
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     console.log(\\"props.id changed\\", this.id);
     console.log(\\"props.foo.value.bar.baz changed\\", this.foo.bar.baz);
+  }
+
+  @Watch(\\"id\\")
+  @Watch(\\"foo.bar.baz\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -9597,7 +9723,7 @@ export class MyComponent {
 `;
 
 exports[`Stencil > svelte > Javascript Test > reactiveWithFn 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-component\\",
@@ -9611,10 +9737,18 @@ export class MyComponent {
     this.result = a_ * b_;
   };
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     this.calculateResult(this.a, this.b);
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -10054,7 +10188,7 @@ export class MyComponent {
 `;
 
 exports[`Stencil > svelte > Typescript Test > reactiveWithFn 1`] = `
-"import { Component, h, Fragment, State } from \\"@stencil/core\\";
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
 
 @Component({
   tag: \\"my-component\\",
@@ -10068,10 +10202,18 @@ export class MyComponent {
     this.result = a_ * b_;
   };
 
-  componentDidLoad() {}
-
-  componentDidUpdate() {
+  watch0Fn() {
     this.calculateResult(this.a, this.b);
+  }
+
+  @Watch(\\"a\\")
+  @Watch(\\"b\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
   }
 
   render() {
@@ -10168,110 +10310,6 @@ export class MyComponent {
         {this.a > 2 ? \\"hello\\" : \\"bye\\"}
       </div>
     );
-  }
-}
-"
-`;
-
-exports[`Stencil local > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
-
-@Component({
-  tag: \\"multiple-on-update-with-deps\\",
-})
-export class MultipleOnUpdateWithDeps {
-  @State() a = \\"a\\";
-  @State() b = \\"b\\";
-  @State() c = \\"c\\";
-  @State() d = \\"d\\";
-
-  watch0Fn() {
-    console.log(\\"Runs when a or b changes\\", this.a, this.b);
-
-    if (this.a === \\"a\\") {
-      this.a = \\"b\\";
-    }
-  }
-
-  @Watch(\\"undefinedundefineda\\")
-  @Watch(\\" undefinedbundefined\\")
-  watch0() {
-    this.watch0Fn();
-  }
-
-  watch1Fn() {
-    console.log(\\"Runs when c or d changes\\", this.c, this.d);
-
-    if (this.a === \\"a\\") {
-      this.a = \\"b\\";
-    }
-  }
-
-  @Watch(\\"undefinedundefinedc\\")
-  @Watch(\\" undefineddundefined\\")
-  watch1() {
-    this.watch1Fn();
-  }
-
-  componentDidLoad() {
-    this.watch0Fn();
-    this.watch1Fn();
-  }
-
-  render() {
-    return <div></div>;
-  }
-}
-"
-`;
-
-exports[`Stencil local > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
-"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
-
-@Component({
-  tag: \\"multiple-on-update-with-deps\\",
-})
-export class MultipleOnUpdateWithDeps {
-  @State() a = \\"a\\";
-  @State() b = \\"b\\";
-  @State() c = \\"c\\";
-  @State() d = \\"d\\";
-
-  watch0Fn() {
-    console.log(\\"Runs when a or b changes\\", this.a, this.b);
-
-    if (this.a === \\"a\\") {
-      this.a = \\"b\\";
-    }
-  }
-
-  @Watch(\\"undefinedundefineda\\")
-  @Watch(\\" undefinedbundefined\\")
-  watch0() {
-    this.watch0Fn();
-  }
-
-  watch1Fn() {
-    console.log(\\"Runs when c or d changes\\", this.c, this.d);
-
-    if (this.a === \\"a\\") {
-      this.a = \\"b\\";
-    }
-  }
-
-  @Watch(\\"undefinedundefinedc\\")
-  @Watch(\\" undefineddundefined\\")
-  watch1() {
-    this.watch1Fn();
-  }
-
-  componentDidLoad() {
-    this.watch0Fn();
-    this.watch1Fn();
-  }
-
-  render() {
-    return <div></div>;
   }
 }
 "

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -10172,3 +10172,107 @@ export class MyComponent {
 }
 "
 `;
+
+exports[`Stencil local > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
+
+@Component({
+  tag: \\"multiple-on-update-with-deps\\",
+})
+export class MultipleOnUpdateWithDeps {
+  @State() a = \\"a\\";
+  @State() b = \\"b\\";
+  @State() c = \\"c\\";
+  @State() d = \\"d\\";
+
+  watch0Fn() {
+    console.log(\\"Runs when a or b changes\\", this.a, this.b);
+
+    if (this.a === \\"a\\") {
+      this.a = \\"b\\";
+    }
+  }
+
+  @Watch(\\"undefinedundefineda\\")
+  @Watch(\\" undefinedbundefined\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  watch1Fn() {
+    console.log(\\"Runs when c or d changes\\", this.c, this.d);
+
+    if (this.a === \\"a\\") {
+      this.a = \\"b\\";
+    }
+  }
+
+  @Watch(\\"undefinedundefinedc\\")
+  @Watch(\\" undefineddundefined\\")
+  watch1() {
+    this.watch1Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
+    this.watch1Fn();
+  }
+
+  render() {
+    return <div></div>;
+  }
+}
+"
+`;
+
+exports[`Stencil local > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
+"import { Component, h, Fragment, Watch, State } from \\"@stencil/core\\";
+
+@Component({
+  tag: \\"multiple-on-update-with-deps\\",
+})
+export class MultipleOnUpdateWithDeps {
+  @State() a = \\"a\\";
+  @State() b = \\"b\\";
+  @State() c = \\"c\\";
+  @State() d = \\"d\\";
+
+  watch0Fn() {
+    console.log(\\"Runs when a or b changes\\", this.a, this.b);
+
+    if (this.a === \\"a\\") {
+      this.a = \\"b\\";
+    }
+  }
+
+  @Watch(\\"undefinedundefineda\\")
+  @Watch(\\" undefinedbundefined\\")
+  watch0() {
+    this.watch0Fn();
+  }
+
+  watch1Fn() {
+    console.log(\\"Runs when c or d changes\\", this.c, this.d);
+
+    if (this.a === \\"a\\") {
+      this.a = \\"b\\";
+    }
+  }
+
+  @Watch(\\"undefinedundefinedc\\")
+  @Watch(\\" undefineddundefined\\")
+  watch1() {
+    this.watch1Fn();
+  }
+
+  componentDidLoad() {
+    this.watch0Fn();
+    this.watch1Fn();
+  }
+
+  render() {
+    return <div></div>;
+  }
+}
+"
+`;

--- a/packages/core/src/generators/stencil/component.ts
+++ b/packages/core/src/generators/stencil/component.ts
@@ -1,6 +1,7 @@
 import { stringifySingleScopeOnMount } from '@/generators/helpers/on-mount';
 import { blockToStencil } from '@/generators/stencil/blocks';
 import {
+  getDepsAsArray,
   getImports,
   getPropsAsCode,
   getStencilCoreImportsAsString,
@@ -34,7 +35,7 @@ import {
   runPreCodePlugins,
   runPreJsonPlugins,
 } from '@/modules/plugins';
-import { MitosisState } from '@/types/mitosis-component';
+import { BaseHook, MitosisState } from '@/types/mitosis-component';
 import { TranspilerGenerator } from '@/types/transpiler';
 import { format } from 'prettier/standalone';
 
@@ -116,7 +117,21 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
       tagName = json.meta.useMetadata?.tagName;
     }
 
-    const coreImports = getStencilCoreImportsAsString(wrap, events, props, dataString);
+    const noDependencyOnUpdateHooks = json.hooks.onUpdate?.filter((hook) => !hook.deps) ?? [];
+    /*
+     * We want to create a function for every onUpdate hook that has dependencies.
+     * We call the function once in "componentDidLoad"
+     * And we create "Watch" decorators for every dependency
+     */
+    const dependencyOnUpdateHooks = json.hooks.onUpdate?.filter((hook) => hook.deps) ?? [];
+
+    const coreImports = getStencilCoreImportsAsString({
+      wrap,
+      events,
+      props,
+      dataString,
+      watch: Boolean(dependencyOnUpdateHooks?.length),
+    });
 
     let str = dedent`
     ${getImports(json, options, childComponents)}
@@ -142,6 +157,23 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
         ${methodsString}
         
         ${withAttributePassing ? getAttributePassingString(true) : ''}
+        
+        ${dependencyOnUpdateHooks
+          .map((hook: BaseHook, index: number) => {
+            return `
+          watch${index}Fn() { 
+            ${hook.code} 
+          }
+          
+          ${getDepsAsArray(hook.deps!)
+            .map((dep) => `@Watch("${dep}")`)
+            .join('\n')}
+            watch${index}(){
+              this.watch${index}Fn();
+            }            
+          `;
+          })
+          .join('\n')}
 
         ${`componentDidLoad() { 
             ${
@@ -150,6 +182,9 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
                 : ''
             }
             ${json.hooks.onMount.length ? stringifySingleScopeOnMount(json) : ''} 
+            ${dependencyOnUpdateHooks
+              .map((_, index: number) => `this.watch${index}Fn();`)
+              .join('\n')}
             }`}
         ${
           !json.hooks.onUnMount?.code
@@ -157,9 +192,11 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> =
             : `disconnectedCallback() { ${json.hooks.onUnMount.code} }`
         }
         ${
-          !json.hooks.onUpdate?.length
-            ? ''
-            : `componentDidUpdate() { ${json.hooks.onUpdate.map((hook) => hook.code).join('\n')} }`
+          noDependencyOnUpdateHooks.length
+            ? `componentDidUpdate() { ${noDependencyOnUpdateHooks
+                .map((hook) => hook.code)
+                .join('\n')} }`
+            : ''
         }
 
       render() {

--- a/packages/core/src/generators/stencil/helpers/index.ts
+++ b/packages/core/src/generators/stencil/helpers/index.ts
@@ -89,18 +89,27 @@ export const needsWrap = (children: MitosisNode[]): boolean => {
  * @param events
  * @param props
  * @param dataString
+ * @param watch
  */
-export const getStencilCoreImportsAsString = (
-  wrap: boolean,
-  events: string[],
-  props: string[],
-  dataString: string,
-): string => {
+export const getStencilCoreImportsAsString = ({
+  wrap,
+  events,
+  props,
+  dataString,
+  watch,
+}: {
+  wrap: boolean;
+  events: string[];
+  props: string[];
+  dataString: string;
+  watch: boolean;
+}): string => {
   const stencilCoreImports: Record<string, boolean> = {
     Component: true,
     h: true,
     Fragment: true,
     Host: wrap,
+    Watch: watch,
     Event: events.length > 0,
     Prop: props.length > 0,
     State: dataString.length > 0,
@@ -129,4 +138,17 @@ export const getImports = (
       return undefined;
     },
   });
+};
+
+/**
+ * Converts the deps string into an array of strings
+ * @param deps The hook dependencies as string e.g.: "[this.a,this.b]"
+ */
+export const getDepsAsArray = (deps: string): string[] => {
+  return deps
+    .replace('[', '')
+    .replace(']', '')
+    .replaceAll('this.', '')
+    .split(',')
+    .map((dep) => dep.trim());
 };


### PR DESCRIPTION
## Description

Please provide the following information:

Dependencies from `onUpdate` hook weren't used inside `componentDidUpdate`. By using `@Watch` we can generate a similar solution for `onUpdate` hook with dependencies.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
