### PR TITLE
fix: Builder generator does not create duplicate component option mappings

### DIFF
--- a/.changeset/silly-cheetahs-tickle.md
+++ b/.changeset/silly-cheetahs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Builder: generator does not generate duplicate option mappings

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -1525,7 +1525,6 @@ exports[`Builder > Regenerate custom Hero 2`] = `
         "@type": "@builder.io/sdk:Element",
         "actions": {},
         "bindings": {
-          "component.options.height": "400",
           "component.options.multiBinding": " return {
   hello: state.message
 }",
@@ -1534,7 +1533,6 @@ exports[`Builder > Regenerate custom Hero 2`] = `
         "code": {
           "actions": {},
           "bindings": {
-            "component.options.height": "400",
             "component.options.multiBinding": "{
   hello: state.message
 }",
@@ -4325,15 +4323,11 @@ exports[`Builder > localization 3`] = `
       {
         "@type": "@builder.io/sdk:Element",
         "actions": {},
-        "bindings": {
-          "component.options.scriptsClientOnly": "false",
-        },
+        "bindings": {},
         "children": [],
         "code": {
           "actions": {},
-          "bindings": {
-            "component.options.scriptsClientOnly": "false",
-          },
+          "bindings": {},
         },
         "component": {
           "name": "Custom Code",

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -1330,6 +1330,48 @@ describe('Builder', () => {
       }
     `);
   });
+
+  test('map each component option to either component.options or bindings but not both', () => {
+    const jsx = `export default function MyComponent(props) {
+      return (
+        <Image aspectRatio={1} src={state.src} />
+      );
+    }`;
+
+    const mitosis = parseJsx(jsx);
+
+    const json = componentToBuilder()({ component: mitosis });
+    expect(json).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "blocks": [
+            {
+              "@type": "@builder.io/sdk:Element",
+              "actions": {},
+              "bindings": {
+                "component.options.src": "state.src",
+              },
+              "children": [],
+              "code": {
+                "actions": {},
+                "bindings": {
+                  "component.options.src": "state.src",
+                },
+              },
+              "component": {
+                "name": "Image",
+                "options": {
+                  "aspectRatio": 1,
+                },
+              },
+            },
+          ],
+          "jsCode": "",
+          "tsCode": "",
+        },
+      }
+    `);
+  });
 });
 
 const bindingJson = {

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -651,14 +651,6 @@ export const blockToBuilder = (
     delete json.bindings.css;
   }
 
-  if (thisIsComponent) {
-    for (const key in json.bindings) {
-      if (!json.slots?.[key]) {
-        builderBindings[`component.options.${key}`] = json.bindings[key]!.code;
-      }
-    }
-  }
-
   const element = el(
     {
       tagName: thisIsComponent ? undefined : json.name,


### PR DESCRIPTION
## Problem

The Builder generator maps options for Builder components to both `component.options` and `bindings`. [Example](https://mitosis.builder.io/playground/?code=KYDwDg9gTgLgBAE2AMwIYFcA29noHYDGMAlhHnALICeAwhALaR7B4wAUYUEYAzgJRwA3gCg4cKMBjoo5NqLFwAPAEl6qAObA4qHmGBEASqhIQAvIICMAXzgB6AHzy%2BAbmFWgA%3D%3D%3D)

In the example above, notice how `aspectRatio` appears on both `component.options` and `bindings['component.options.aspectRatio']`.

## Solution

The Builder generator loops through any component props and [either puts them on `component.options` or `bindings`](https://github.com/BuilderIO/mitosis/blob/57f371d409d2c0167aebe0ea82431b554efc3948/packages/core/src/generators/builder/generator.ts#L606-L611).

However, we later loop through the component props again and then [put them on `bindings`](https://github.com/BuilderIO/mitosis/blob/57f371d409d2c0167aebe0ea82431b554efc3948/packages/core/src/generators/builder/generator.ts#L654-L660), thus leading to the duplicate mapping problem.

I fixed the issue by removing the second loop.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
