### PR TITLE
Handle key attribute correctly for Svelte

### DIFF
--- a/.changeset/fresh-bulldogs-judge.md
+++ b/.changeset/fresh-bulldogs-judge.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Fix: Added Svelte-specific handling for key attribute due to its unique syntax and absence in the standard props

--- a/.changeset/fresh-bulldogs-judge.md
+++ b/.changeset/fresh-bulldogs-judge.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-Fix: Added Svelte-specific handling for key attribute due to its unique syntax and absence in the standard props
+[Svelte] Bug: Fixed handling for key attribute due to its unique syntax and absence in the standard props

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1108,7 +1108,15 @@ exports[`Svelte > jsx > Javascript Test > Img 1`] = `
 </script>
 
 {#key (Builder.isEditing && imgSrc) || \\"default-key\\"}
-  <img {...attributes} alt={altText} src={imgSrc} />
+  <img
+    style={stringifyStyles({
+      objectFit: backgroundSize || \\"cover\\",
+      objectPosition: backgroundPosition || \\"center\\",
+    })}
+    {...attributes}
+    alt={altText}
+    src={imgSrc}
+  />
 {/key}"
 `;
 
@@ -1548,6 +1556,16 @@ exports[`Svelte > jsx > Javascript Test > Video 1`] = `
 
 {#key video || \\"no-src\\"}
   <video
+    style={stringifyStyles({
+      width: \\"100%\\",
+      height: \\"100%\\",
+      ...attributes?.style,
+      objectFit: fit,
+      objectPosition: position,
+      // Hack to get object fit to work as expected and
+      // not have the video overflow
+      borderRadius: 1,
+    })}
     preload=\\"none\\"
     {...attributes}
     poster={posterImage}
@@ -4701,7 +4719,15 @@ exports[`Svelte > jsx > Typescript Test > Img 1`] = `
 </script>
 
 {#key (Builder.isEditing && imgSrc) || \\"default-key\\"}
-  <img {...attributes} alt={altText} src={imgSrc} />
+  <img
+    style={stringifyStyles({
+      objectFit: backgroundSize || \\"cover\\",
+      objectPosition: backgroundPosition || \\"center\\",
+    })}
+    {...attributes}
+    alt={altText}
+    src={imgSrc}
+  />
 {/key}"
 `;
 
@@ -5306,6 +5332,16 @@ exports[`Svelte > jsx > Typescript Test > Video 1`] = `
 
 {#key video || \\"no-src\\"}
   <video
+    style={stringifyStyles({
+      width: \\"100%\\",
+      height: \\"100%\\",
+      ...attributes?.style,
+      objectFit: fit,
+      objectPosition: position,
+      // Hack to get object fit to work as expected and
+      // not have the video overflow
+      borderRadius: 1,
+    })}
     preload=\\"none\\"
     {...attributes}
     poster={posterImage}

--- a/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/svelte.test.ts.snap
@@ -1079,7 +1079,9 @@ exports[`Svelte > jsx > Javascript Test > Image State 1`] = `
 
 <div>
   {#each images as item, itemIndex}
-    <img class=\\"custom-class\\" src={item} key={itemIndex} />
+    {#key itemIndex}
+      <img class=\\"custom-class\\" src={item} />
+    {/key}
   {/each}
 </div>"
 `;
@@ -1105,16 +1107,9 @@ exports[`Svelte > jsx > Javascript Test > Img 1`] = `
   }
 </script>
 
-<img
-  style={stringifyStyles({
-    objectFit: backgroundSize || \\"cover\\",
-    objectPosition: backgroundPosition || \\"center\\",
-  })}
-  {...attributes}
-  key={(Builder.isEditing && imgSrc) || \\"default-key\\"}
-  alt={altText}
-  src={imgSrc}
-/>"
+{#key (Builder.isEditing && imgSrc) || \\"default-key\\"}
+  <img {...attributes} alt={altText} src={imgSrc} />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Javascript Test > Input 1`] = `
@@ -1131,19 +1126,20 @@ exports[`Svelte > jsx > Javascript Test > Input 1`] = `
   export let onChange;
 </script>
 
-<input
-  {...attributes}
-  key={Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
-  {placeholder}
-  {type}
-  {name}
-  {value}
-  {defaultValue}
-  {required}
-  on:change={(event) => {
-    onChange?.(event.target.value);
-  }}
-/>"
+{#key Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
+  <input
+    {...attributes}
+    {placeholder}
+    {type}
+    {name}
+    {value}
+    {defaultValue}
+    {required}
+    on:change={(event) => {
+      onChange?.(event.target.value);
+    }}
+  />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Javascript Test > InputParent 1`] = `
@@ -1261,19 +1257,15 @@ exports[`Svelte > jsx > Javascript Test > Select 1`] = `
   export let options;
 </script>
 
-<select
-  {...attributes}
-  {value}
-  key={Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
-  {defaultValue}
-  {name}
->
-  {#each options as option, index}
-    <option value={option.value} data-index={index}
-      >{option.name || option.value}</option
-    >
-  {/each}
-</select>"
+{#key Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
+  <select {...attributes} {value} {defaultValue} {name}>
+    {#each options as option, index}
+      <option value={option.value} data-index={index}
+        >{option.name || option.value}</option
+      >
+    {/each}
+  </select>
+{/key}"
 `;
 
 exports[`Svelte > jsx > Javascript Test > SlotDefault 1`] = `"<div><slot><div class=\\"default-slot\\">Default content</div></slot></div>"`;
@@ -1554,26 +1546,17 @@ exports[`Svelte > jsx > Javascript Test > Video 1`] = `
   }
 </script>
 
-<video
-  style={stringifyStyles({
-    width: \\"100%\\",
-    height: \\"100%\\",
-    ...attributes?.style,
-    objectFit: fit,
-    objectPosition: position,
-    // Hack to get object fit to work as expected and
-    // not have the video overflow
-    borderRadius: 1,
-  })}
-  preload=\\"none\\"
-  {...attributes}
-  key={video || \\"no-src\\"}
-  poster={posterImage}
-  autoplay={autoPlay}
-  {muted}
-  {controls}
-  {loop}
-/>"
+{#key video || \\"no-src\\"}
+  <video
+    preload=\\"none\\"
+    {...attributes}
+    poster={posterImage}
+    autoplay={autoPlay}
+    {muted}
+    {controls}
+    {loop}
+  />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
@@ -4670,7 +4653,9 @@ exports[`Svelte > jsx > Typescript Test > Image State 1`] = `
 
 <div>
   {#each images as item, itemIndex}
-    <img class=\\"custom-class\\" src={item} key={itemIndex} />
+    {#key itemIndex}
+      <img class=\\"custom-class\\" src={item} />
+    {/key}
   {/each}
 </div>"
 `;
@@ -4715,16 +4700,9 @@ exports[`Svelte > jsx > Typescript Test > Img 1`] = `
   }
 </script>
 
-<img
-  style={stringifyStyles({
-    objectFit: backgroundSize || \\"cover\\",
-    objectPosition: backgroundPosition || \\"center\\",
-  })}
-  {...attributes}
-  key={(Builder.isEditing && imgSrc) || \\"default-key\\"}
-  alt={altText}
-  src={imgSrc}
-/>"
+{#key (Builder.isEditing && imgSrc) || \\"default-key\\"}
+  <img {...attributes} alt={altText} src={imgSrc} />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Typescript Test > Input 1`] = `
@@ -4754,19 +4732,20 @@ exports[`Svelte > jsx > Typescript Test > Input 1`] = `
   export let onChange: FormInputProps[\\"onChange\\"] = undefined;
 </script>
 
-<input
-  {...attributes}
-  key={Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
-  {placeholder}
-  {type}
-  {name}
-  {value}
-  {defaultValue}
-  {required}
-  on:change={(event) => {
-    onChange?.(event.target.value);
-  }}
-/>"
+{#key Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
+  <input
+    {...attributes}
+    {placeholder}
+    {type}
+    {name}
+    {value}
+    {defaultValue}
+    {required}
+    on:change={(event) => {
+      onChange?.(event.target.value);
+    }}
+  />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Typescript Test > InputParent 1`] = `
@@ -4927,19 +4906,15 @@ exports[`Svelte > jsx > Typescript Test > Select 1`] = `
   export let options: FormSelectProps[\\"options\\"] = undefined;
 </script>
 
-<select
-  {...attributes}
-  {value}
-  key={Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
-  {defaultValue}
-  {name}
->
-  {#each options as option, index}
-    <option value={option.value} data-index={index}
-      >{option.name || option.value}</option
-    >
-  {/each}
-</select>"
+{#key Builder.isEditing && defaultValue ? defaultValue : \\"default-key\\"}
+  <select {...attributes} {value} {defaultValue} {name}>
+    {#each options as option, index}
+      <option value={option.value} data-index={index}
+        >{option.name || option.value}</option
+      >
+    {/each}
+  </select>
+{/key}"
 `;
 
 exports[`Svelte > jsx > Typescript Test > SlotDefault 1`] = `
@@ -5329,26 +5304,17 @@ exports[`Svelte > jsx > Typescript Test > Video 1`] = `
   }
 </script>
 
-<video
-  style={stringifyStyles({
-    width: \\"100%\\",
-    height: \\"100%\\",
-    ...attributes?.style,
-    objectFit: fit,
-    objectPosition: position,
-    // Hack to get object fit to work as expected and
-    // not have the video overflow
-    borderRadius: 1,
-  })}
-  preload=\\"none\\"
-  {...attributes}
-  key={video || \\"no-src\\"}
-  poster={posterImage}
-  autoplay={autoPlay}
-  {muted}
-  {controls}
-  {loop}
-/>"
+{#key video || \\"no-src\\"}
+  <video
+    preload=\\"none\\"
+    {...attributes}
+    poster={posterImage}
+    autoplay={autoPlay}
+    {muted}
+    {controls}
+    {loop}
+  />
+{/key}"
 `;
 
 exports[`Svelte > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `

--- a/packages/core/src/generators/svelte/blocks.ts
+++ b/packages/core/src/generators/svelte/blocks.ts
@@ -262,6 +262,18 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
     });
   }
 
+  // Handling key binding by wrapping the element in a #key block
+  if (json.bindings.key) {
+    const keyCode = json.bindings.key.code;
+    delete json.bindings.key;
+    const str = `
+      {#key ${keyCode}}
+        ${blockToSvelte({ json, options, parentComponent })}
+      {/key}
+      `;
+    return str;
+  }
+
   const tagName = getTagName({ json, parentComponent, options });
 
   if (isChildren({ node: json, extraMatches: ['$$slots.default'] })) {
@@ -311,18 +323,6 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
     str += '>';
     str += BINDINGS_MAPPER.innerHTML(json, options);
     str += `</${tagName}>`;
-    return str;
-  }
-
-  // Handling key binding by wrapping the element in a #key block
-  if (json.bindings.key) {
-    const keyCode = json.bindings.key.code;
-    delete json.bindings.key;
-    const str = `
-      {#key ${keyCode}}
-        ${blockToSvelte({ json, options, parentComponent })}
-      {/key}
-      `;
     return str;
   }
 

--- a/packages/core/src/generators/svelte/blocks.ts
+++ b/packages/core/src/generators/svelte/blocks.ts
@@ -314,6 +314,18 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
     return str;
   }
 
+  // Handling key binding by wrapping the element in a #key block
+  if (json.bindings.key) {
+    const keyCode = json.bindings.key.code;
+    delete json.bindings.key;
+    const str = `
+      {#key ${keyCode}}
+        ${blockToSvelte({ json, options, parentComponent })}
+      {/key}
+      `;
+    return str;
+  }
+
   if (SELF_CLOSING_HTML_TAGS.has(tagName)) {
     return str + ' />';
   }

--- a/packages/core/src/generators/svelte/blocks.ts
+++ b/packages/core/src/generators/svelte/blocks.ts
@@ -254,14 +254,6 @@ const stringifyBinding =
   };
 
 export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent }) => {
-  if (mappers[json.name as keyof typeof mappers]) {
-    return mappers[json.name as keyof typeof mappers]({
-      json: json as any,
-      options,
-      parentComponent,
-    });
-  }
-
   // Handling key binding by wrapping the element in a #key block
   if (json.bindings.key) {
     const keyCode = json.bindings.key.code;
@@ -272,6 +264,14 @@ export const blockToSvelte: BlockToSvelte = ({ json, options, parentComponent })
       {/key}
       `;
     return str;
+  }
+
+  if (mappers[json.name as keyof typeof mappers]) {
+    return mappers[json.name as keyof typeof mappers]({
+      json: json as any,
+      options,
+      parentComponent,
+    });
   }
 
   const tagName = getTagName({ json, parentComponent, options });


### PR DESCRIPTION
## Description

Please provide the following information:

- **What changes you made:**  
I updated `svelteToBlock` to handle the `key` attribute differently for Svelte due to its unique syntax requirements.  

- **Why you made them:**  
Svelte uses a distinct syntax for managing keyed each blocks, and the previous implementation was not compatible, causing issues when dynamically updating content.  

- **Any other useful context:**  
This change ensures proper handling of component updates in Svelte by aligning the `key` management with Svelte's syntax, preventing reactivity issues.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
