### PR TITLE
fix: issue with stencil event type

### DIFF
--- a/.changeset/neat-knives-search.md
+++ b/.changeset/neat-knives-search.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[stencil] Fix issue for `EventEmitter` using Parameters as type instead of ReturnType

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -7545,8 +7545,12 @@ import {
   tag: \\"event-props-component\\",
 })
 export class EventPropsComponent {
-  @Event() getVoid: EventEmitter<Parameters<EventProps[\\"onGetVoid\\"]>[number]>;
-  @Event() enter: EventEmitter<Parameters<EventProps[\\"onEnter\\"]>[number]>;
+  @Event() getVoid: EventEmitter<
+    Parameters<Required<EventProps>[\\"onGetVoid\\"]>[number]
+  > | void;
+  @Event() enter: EventEmitter<
+    Parameters<Required<EventProps>[\\"onEnter\\"]>[number]
+  > | void;
 
   handleClick() {
     if (this.getVoid) {

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -7545,8 +7545,8 @@ import {
   tag: \\"event-props-component\\",
 })
 export class EventPropsComponent {
-  @Event() getVoid: EventEmitter<ReturnType<Required<EventProps>[\\"onGetVoid\\"]>>;
-  @Event() enter: EventEmitter<ReturnType<Required<EventProps>[\\"onEnter\\"]>>;
+  @Event() getVoid: EventEmitter<Parameters<EventProps[\\"onGetVoid\\"]>[number]>;
+  @Event() enter: EventEmitter<Parameters<EventProps[\\"onEnter\\"]>[number]>;
 
   handleClick() {
     if (this.getVoid) {

--- a/packages/core/src/generators/stencil/helpers/index.ts
+++ b/packages/core/src/generators/stencil/helpers/index.ts
@@ -89,7 +89,7 @@ export const getPropsAsCode = ({
         // Stencil adds "on" to every `@Event` so we need to remove "on" from event props
         // https://stenciljs.com/docs/events#using-events-in-jsx
         const eventType = hasTyping
-          ? `EventEmitter<Parameters<${propsTypeRef}["${item}"]>[number]>`
+          ? `EventEmitter<Parameters<Required<${propsTypeRef}>["${item}"]>[number]>`
           : 'any';
 
         return `@Event() ${getEventNameWithoutOn(item)}: ${eventType}${defaultPropString}`;

--- a/packages/core/src/generators/stencil/helpers/index.ts
+++ b/packages/core/src/generators/stencil/helpers/index.ts
@@ -89,7 +89,7 @@ export const getPropsAsCode = ({
         // Stencil adds "on" to every `@Event` so we need to remove "on" from event props
         // https://stenciljs.com/docs/events#using-events-in-jsx
         const eventType = hasTyping
-          ? `EventEmitter<ReturnType<Required<${propsTypeRef}>["${item}"]>>`
+          ? `EventEmitter<Parameters<${propsTypeRef}["${item}"]>[number]>`
           : 'any';
 
         return `@Event() ${getEventNameWithoutOn(item)}: ${eventType}${defaultPropString}`;

--- a/packages/core/src/generators/stencil/helpers/index.ts
+++ b/packages/core/src/generators/stencil/helpers/index.ts
@@ -89,7 +89,7 @@ export const getPropsAsCode = ({
         // Stencil adds "on" to every `@Event` so we need to remove "on" from event props
         // https://stenciljs.com/docs/events#using-events-in-jsx
         const eventType = hasTyping
-          ? `EventEmitter<Parameters<Required<${propsTypeRef}>["${item}"]>[number]>`
+          ? `EventEmitter<Parameters<Required<${propsTypeRef}>["${item}"]>[number]> | void`
           : 'any';
 
         return `@Event() ${getEventNameWithoutOn(item)}: ${eventType}${defaultPropString}`;


### PR DESCRIPTION
## Description

Please provide the following information:

I've made a mistake by using the `ReturnType` of a function for EventEmitter, which will be `void` in most cases.
In fact we try to use the parameters of the functions for the `EventEmitter`.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
