### PR TITLE
Don't output JSX attributes for Mitosis generator that are invalid (eg. start with @ or :)

### DIFF
--- a/.changeset/heavy-forks-compare.md
+++ b/.changeset/heavy-forks-compare.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Don't output JSX attributes for Mitosis generator that are invalid (e.g. start with @ or :)

--- a/packages/core/src/__tests__/__snapshots__/mitosis.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/mitosis.test.ts.snap
@@ -18,6 +18,13 @@ exports[`Can encode <> in text > should not encode valid jsx 1`] = `
 "
 `;
 
+exports[`Can encode <> in text > should not output invalid jsx attributes 1`] = `
+"export default function MyComponent(props) {
+  return <div />;
+}
+"
+`;
+
 exports[`Mitosis, format: legacy (native loops and conditionals) > jsx > Javascript Test > Advanced 1`] = `
 "import { useStore } from \\"@builder.io/mitosis\\";
 import { For } from \\"@components\\";

--- a/packages/core/src/__tests__/mitosis.test.ts
+++ b/packages/core/src/__tests__/mitosis.test.ts
@@ -1,4 +1,5 @@
 import { componentToMitosis } from '@/generators/mitosis';
+import { createSingleBinding } from '@/helpers/bindings';
 import { createMitosisComponent } from '@/helpers/create-mitosis-component';
 import { createMitosisNode } from '@/helpers/create-mitosis-node';
 import { runTestsForTarget } from './test-generator';
@@ -55,6 +56,24 @@ describe('Can encode <> in text', () => {
         children: [
           createMitosisNode({
             properties: { _text: 'hello <b>world</b>' },
+          }),
+        ],
+        hooks: {},
+      }),
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should not output invalid jsx attributes', () => {
+    const result = componentToMitosis()({
+      component: createMitosisComponent({
+        children: [
+          createMitosisNode({
+            properties: { ':click': 'onClick()', '@click': 'onClick()' },
+            bindings: {
+              ':key': createSingleBinding({ code: '1' }),
+            },
           }),
         ],
         hooks: {},

--- a/packages/core/src/generators/mitosis/generator.ts
+++ b/packages/core/src/generators/mitosis/generator.ts
@@ -35,6 +35,14 @@ const isValidAttributeName = (str: string) => {
   return Boolean(str && /^[$a-z0-9\-_:]+$/i.test(str));
 };
 
+const isInvalidJsxAttributeName = (str: string) => {
+  let attr = str.trim();
+  if (attr.startsWith(':') || str.startsWith('@')) {
+    return true;
+  }
+  return false;
+};
+
 export const blockToMitosis = (
   json: MitosisNode,
   toMitosisOptions: Partial<ToMitosisOptions> = {},
@@ -158,6 +166,10 @@ export const blockToMitosis = (
   str += `<${json.name} `;
 
   for (const key in json.properties) {
+    if (isInvalidJsxAttributeName(key)) {
+      console.warn('Skipping invalid attribute name:', key);
+      continue;
+    }
     const value = (json.properties[key] || '').replace(/"/g, '&quot;').replace(/\n/g, '\\n');
 
     if (!isValidAttributeName(key)) {
@@ -167,6 +179,10 @@ export const blockToMitosis = (
     }
   }
   for (const key in json.bindings) {
+    if (isInvalidJsxAttributeName(key)) {
+      console.warn('Skipping invalid attribute name:', key);
+      continue;
+    }
     const value = json.bindings[key]?.code as string;
 
     if (!value || json.slots?.[key]) {


### PR DESCRIPTION
I left the check intentionally minimal to the cases we know we encounter right now to not inadvertently break anything
