### PR TITLE
fix: < and > are properly escaped when generating JSX

### DIFF
--- a/.changeset/unlucky-planes-compete.md
+++ b/.changeset/unlucky-planes-compete.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/mitosis': patch
+'@builder.io/mitosis-cli': patch
+---
+
+JSX generator properly escapes single character > and <

--- a/packages/core/src/__tests__/mitosis.test.ts
+++ b/packages/core/src/__tests__/mitosis.test.ts
@@ -65,6 +65,26 @@ describe('Can encode <> in text', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('encode single > character', () => {
+    const result = componentToMitosis()({
+      component: createMitosisComponent({
+        children: [
+          createMitosisNode({
+            properties: { _text: '>' },
+          }),
+        ],
+        hooks: {},
+      }),
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "export default function MyComponent(props) {
+        return <>&amp;gt;</>;
+      }
+      "
+    `);
+  });
+
   it('should not output invalid jsx attributes', () => {
     const result = componentToMitosis()({
       component: createMitosisComponent({


### PR DESCRIPTION
## Description

The code in the included test causes prettier to crash due to its use of the typescript parser. When deciding if we need to escape characters, we previously used the babel parser. However, that does not crash on this code. As a result, I updated this flow to use the typescript parser via prettier to check if we need to do any escaping.

Open to other ideas for how to do this, this just seemed like the best way to fix the issue while making minimal changes.

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
