### PR TITLE
fix: Builder Symbol information is preserved

### DIFF
--- a/.changeset/purple-stingrays-invite.md
+++ b/.changeset/purple-stingrays-invite.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+Builder: Symbol information is preserved

--- a/packages/core/src/__tests__/builder/symbols.test.ts
+++ b/packages/core/src/__tests__/builder/symbols.test.ts
@@ -1,9 +1,11 @@
+import { componentToBuilder } from '@/generators/builder';
 import { componentToMitosis } from '@/generators/mitosis';
 import { builderContentToMitosisComponent } from '@/parsers/builder';
+import { parseJsx } from '@/parsers/jsx';
 import { describe, test } from 'vitest';
 
 describe('Builder Symbols', () => {
-  test('invalid CSS binding is dropped', () => {
+  test('no data loss occurs when parsing and generating symbols', () => {
     const builderJson = {
       data: {
         blocks: [
@@ -34,7 +36,7 @@ describe('Builder Symbols', () => {
         "bindings": {
           "symbol": {
             "bindingType": "expression",
-            "code": "{\\"data\\":{}}",
+            "code": "{\\"data\\":{},\\"model\\":\\"symbol\\",\\"entry\\":\\"ce58d5d74c21469496725f27b8781498\\",\\"ownerId\\":\\"YJIGb4i01jvw0SRdL5Bt\\",\\"global\\":false}",
             "type": "single",
           },
         },
@@ -57,11 +59,44 @@ describe('Builder Symbols', () => {
           <Symbol
             symbol={{
               data: {},
+              model: \\"symbol\\",
+              entry: \\"ce58d5d74c21469496725f27b8781498\\",
+              ownerId: \\"YJIGb4i01jvw0SRdL5Bt\\",
+              global: false,
             }}
           />
         );
       }
       "
     `);
+
+    const backToMitosis = parseJsx(mitosis);
+    expect(backToMitosis.children[0]).toMatchInlineSnapshot(`
+      {
+        "@type": "@builder.io/mitosis/node",
+        "bindings": {
+          "symbol": {
+            "bindingType": "expression",
+            "code": "{
+        data: {},
+        model: \\"symbol\\",
+        entry: \\"ce58d5d74c21469496725f27b8781498\\",
+        ownerId: \\"YJIGb4i01jvw0SRdL5Bt\\",
+        global: false
+      }",
+            "type": "single",
+          },
+        },
+        "children": [],
+        "meta": {},
+        "name": "Symbol",
+        "properties": {},
+        "scope": {},
+      }
+    `);
+
+    const backToBuilder = componentToBuilder()({ component: backToMitosis });
+    // no data loss means the component payloads are exactly the same
+    expect(backToBuilder.data!.blocks![0].component).toEqual(builderJson.data.blocks[0].component);
   });
 });

--- a/packages/core/src/__tests__/builder/symbols.test.ts
+++ b/packages/core/src/__tests__/builder/symbols.test.ts
@@ -1,0 +1,67 @@
+import { componentToMitosis } from '@/generators/mitosis';
+import { builderContentToMitosisComponent } from '@/parsers/builder';
+import { describe, test } from 'vitest';
+
+describe('Builder Symbols', () => {
+  test('invalid CSS binding is dropped', () => {
+    const builderJson = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            id: 'builder-281c8c0da7be4f8a923f872d4825f14d',
+            component: {
+              name: 'Symbol',
+              options: {
+                symbol: {
+                  data: {},
+                  model: 'symbol',
+                  entry: 'ce58d5d74c21469496725f27b8781498',
+                  ownerId: 'YJIGb4i01jvw0SRdL5Bt',
+                  global: false,
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+    const builderToMitosis = builderContentToMitosisComponent(builderJson);
+
+    expect(builderToMitosis.children[0]).toMatchInlineSnapshot(`
+      {
+        "@type": "@builder.io/mitosis/node",
+        "bindings": {
+          "symbol": {
+            "bindingType": "expression",
+            "code": "{\\"data\\":{}}",
+            "type": "single",
+          },
+        },
+        "children": [],
+        "meta": {},
+        "name": "Symbol",
+        "properties": {},
+        "scope": {},
+      }
+    `);
+
+    const mitosis = componentToMitosis({})({
+      component: builderToMitosis,
+    });
+    expect(mitosis).toMatchInlineSnapshot(`
+      "import { Symbol } from \\"@components\\";
+
+      export default function MyComponent(props) {
+        return (
+          <Symbol
+            symbol={{
+              data: {},
+            }}
+          />
+        );
+      }
+      "
+    `);
+  });
+});

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -321,8 +321,7 @@ const componentMappers: {
     const bindings: Dictionary<Binding> = {
       symbol: createSingleBinding({
         code: JSON.stringify({
-          data: block.component?.options.symbol.data,
-          content: block.component?.options.symbol.content,
+          ...block.component?.options.symbol,
         }),
       }),
       ...actionBindings,


### PR DESCRIPTION
Symbol data is not being preserved when parsing as Mitosis. As a result, when going back to Builder JSON the symbol data is not there which causes rendering problems.


Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
