### PR TITLE
Only import used ReactNative components

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/context.test.ts.snap
@@ -613,19 +613,7 @@ export default ComponentWithContext;
 
 exports[`Context > Use and set context in components 3`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -2,19 +2,7 @@
 
 exports[`React Native > Vaild react-native styles 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -73,19 +61,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > AdvancedRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 function MyBasicRefComponent(props) {
@@ -145,19 +121,7 @@ export default MyBasicRefComponent;
 
 exports[`React Native > jsx > Javascript Test > Basic 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 export const DEFAULT_VALUES = {
@@ -194,19 +158,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > Basic Context 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useContext, useRef, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
 
@@ -249,19 +201,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > Basic OnMount Update 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 function MyBasicOnMountUpdateComponent(props) {
@@ -293,19 +233,7 @@ export default MyBasicOnMountUpdateComponent;
 
 exports[`React Native > jsx > Javascript Test > Basic Outputs 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOutputsComponent(props) {
@@ -330,19 +258,7 @@ exports[`React Native > jsx > Javascript Test > Basic Outputs Meta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOutputsComponent(props) {
@@ -362,19 +278,7 @@ export default MyBasicOutputsComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicAttribute 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props) {
   return <TextInput autoCapitalize=\\"on\\" autoComplete=\\"on\\" spellCheck />;
@@ -386,19 +290,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicBooleanAttribute 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import MyBooleanAttributeComponent from \\"./basic-boolean-attribute-component.raw\\";
 
 function MyBooleanAttribute(props) {
@@ -423,19 +315,7 @@ export default MyBooleanAttribute;
 
 exports[`React Native > jsx > Javascript Test > BasicChildComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
 import MyBasicOutputsComponent from \\"./basic-outputs.raw\\";
@@ -471,19 +351,7 @@ export default MyBasicChildComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicFor 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicForComponent(props) {
@@ -522,19 +390,7 @@ export default MyBasicForComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
 function MyBasicRefComponent(props) {
@@ -590,19 +446,7 @@ export default MyBasicRefComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicRefAssignment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function MyBasicRefAssignmentComponent(props) {
@@ -628,19 +472,7 @@ export default MyBasicRefAssignmentComponent;
 
 exports[`React Native > jsx > Javascript Test > BasicRefPrevious 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export function usePrevious(value) {
@@ -686,19 +518,7 @@ export default MyPreviousComponent;
 
 exports[`React Native > jsx > Javascript Test > Button 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 function Button(props) {
   return (
@@ -726,19 +546,7 @@ export default Button;
 
 exports[`React Native > jsx > Javascript Test > Columns 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function Column(props) {
   function getColumns() {
@@ -784,19 +592,7 @@ export default Column;
 
 exports[`React Native > jsx > Javascript Test > ContentSlotHtml 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function ContentSlotCode(props) {
   return (
@@ -818,19 +614,7 @@ export default ContentSlotCode;
 
 exports[`React Native > jsx > Javascript Test > ContentSlotJSX 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Pressable } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function ContentSlotJsxCode(props) {
@@ -882,19 +666,7 @@ export default ContentSlotJsxCode;
 
 exports[`React Native > jsx > Javascript Test > CustomCode 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 function CustomCode(props) {
@@ -958,19 +730,7 @@ export default CustomCode;
 
 exports[`React Native > jsx > Javascript Test > Embed 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 function CustomCode(props) {
@@ -1034,19 +794,7 @@ export default CustomCode;
 
 exports[`React Native > jsx > Javascript Test > Form 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 import { Builder, builder } from \\"@builder.io/sdk\\";
 import {
@@ -1300,19 +1048,7 @@ export default FormComponent;
 
 exports[`React Native > jsx > Javascript Test > Image 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image, Text } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 function Image(props) {
@@ -1407,19 +1143,7 @@ export default Image;
 
 exports[`React Native > jsx > Javascript Test > Image State 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function ImgStateComponent(props) {
@@ -1442,19 +1166,7 @@ export default ImgStateComponent;
 
 exports[`React Native > jsx > Javascript Test > Img 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { Image } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function ImgComponent(props) {
@@ -1478,19 +1190,7 @@ export default ImgComponent;
 
 exports[`React Native > jsx > Javascript Test > Input 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function FormInputComponent(props) {
@@ -1519,19 +1219,7 @@ export default FormInputComponent;
 
 exports[`React Native > jsx > Javascript Test > InputParent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props) {
@@ -1554,19 +1242,7 @@ export default Stepper;
 
 exports[`React Native > jsx > Javascript Test > NestedStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function NestedStore(props) {
@@ -1590,19 +1266,7 @@ export default NestedStore;
 
 exports[`React Native > jsx > Javascript Test > RawText 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function RawText(props) {
   return <View dangerouslySetInnerHTML={{ __html: props.text || \\"\\" }} />;
@@ -1614,19 +1278,7 @@ export default RawText;
 
 exports[`React Native > jsx > Javascript Test > Section 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function SectionComponent(props) {
   return (
@@ -1651,19 +1303,7 @@ export default SectionComponent;
 
 exports[`React Native > jsx > Javascript Test > Select 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
 function SelectComponent(props) {
@@ -1694,19 +1334,7 @@ export default SelectComponent;
 
 exports[`React Native > jsx > Javascript Test > SlotDefault 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function SlotCode(props) {
   return (
@@ -1728,19 +1356,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Javascript Test > SlotHtml 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
@@ -1757,19 +1373,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Javascript Test > SlotJsx 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 function SlotCode(props) {
@@ -1792,19 +1396,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Javascript Test > SlotNamed 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function SlotCode(props) {
   return (
@@ -1823,19 +1415,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Javascript Test > Stamped.io 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image, Text, TextInput, Button } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 import { kebabCase, snakeCase } from \\"lodash\\";
 
@@ -1926,19 +1506,7 @@ export default SmileReviews;
 
 exports[`React Native > jsx > Javascript Test > StoreComment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function StringLiteralStore(props) {
@@ -1959,19 +1527,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Javascript Test > StoreShadowVars 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -1994,19 +1550,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > StoreWithState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -2029,19 +1573,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > Submit 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function SubmitButton(props) {
   return (
@@ -2057,19 +1589,7 @@ export default SubmitButton;
 
 exports[`React Native > jsx > Javascript Test > Text 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { Builder } from \\"@builder.io/sdk\\";
 
@@ -2099,19 +1619,7 @@ export default Text;
 
 exports[`React Native > jsx > Javascript Test > Textarea 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function Textarea(props) {
   return (
@@ -2131,19 +1639,7 @@ export default Textarea;
 
 exports[`React Native > jsx > Javascript Test > UseValueAndFnFromStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function UseValueAndFnFromStore(props) {
@@ -2178,19 +1674,7 @@ export default UseValueAndFnFromStore;
 
 exports[`React Native > jsx > Javascript Test > Video 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function Video(props) {
   return (
@@ -2223,19 +1707,7 @@ export default Video;
 
 exports[`React Native > jsx > Javascript Test > arrowFunctionInUseStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -2263,19 +1735,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > basicForFragment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function BasicForFragment(props) {
@@ -2314,19 +1774,7 @@ export default BasicForFragment;
 
 exports[`React Native > jsx > Javascript Test > basicForNoTagReference 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicForNoTagRefComponent(props) {
@@ -2366,19 +1814,7 @@ export default MyBasicForNoTagRefComponent;
 
 exports[`React Native > jsx > Javascript Test > basicForwardRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, TextInput } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
 const MyBasicForwardRefComponent = forwardRef(
@@ -2411,19 +1847,7 @@ exports[`React Native > jsx > Javascript Test > basicForwardRefMetadata 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, TextInput } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
 const MyBasicForwardRefComponent = forwardRef(
@@ -2451,19 +1875,7 @@ export default MyBasicForwardRefComponent;
 
 exports[`React Native > jsx > Javascript Test > basicOnUpdateReturn 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOnUpdateReturnComponent(props) {
@@ -2505,19 +1917,7 @@ exports[`React Native > jsx > Javascript Test > basicRefAttributePassing 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function BasicRefAttributePassingComponent(props) {
@@ -2541,19 +1941,7 @@ exports[`React Native > jsx > Javascript Test > basicRefAttributePassingCustomRe
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function BasicRefAttributePassingCustomRefComponent(props) {
@@ -2574,19 +1962,7 @@ export default BasicRefAttributePassingCustomRefComponent;
 
 exports[`React Native > jsx > Javascript Test > class + ClassName + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import MyComp from \\"./my-component\\";
 
 function MyBasicComponent(props) {
@@ -2610,19 +1986,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > class + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2640,19 +2004,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > className + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2670,19 +2022,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > className 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function ClassNameCode(props) {
@@ -2706,19 +2046,7 @@ export default ClassNameCode;
 
 exports[`React Native > jsx > Javascript Test > classState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -2748,19 +2076,7 @@ exports[`React Native > jsx > Javascript Test > classnameProps 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -2783,19 +2099,7 @@ exports[`React Native > jsx > Javascript Test > complexMeta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function ComplexMetaRaw(props) {
   return <View />;
@@ -2807,19 +2111,7 @@ export default ComplexMetaRaw;
 
 exports[`React Native > jsx > Javascript Test > componentWithContext 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
@@ -2856,19 +2148,7 @@ export default ComponentWithContext;
 
 exports[`React Native > jsx > Javascript Test > componentWithContextMultiRoot 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import Context1 from \\"@dummy/1\\";
 import Context2 from \\"@dummy/2\\";
@@ -2910,19 +2190,7 @@ export default ComponentWithContext;
 
 exports[`React Native > jsx > Javascript Test > contentState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
 
@@ -2947,19 +2215,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Javascript Test > defaultProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 function Button(props) {
   props = {
@@ -3000,19 +2256,7 @@ export default Button;
 
 exports[`React Native > jsx > Javascript Test > defaultPropsOutsideComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 function Button(props) {
   props = {
@@ -3051,19 +2295,7 @@ export default Button;
 
 exports[`React Native > jsx > Javascript Test > defaultValsWithTypes 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 const DEFAULT_VALUES = {
   name: \\"Sami\\",
@@ -3084,19 +2316,7 @@ export default ComponentWithTypes;
 
 exports[`React Native > jsx > Javascript Test > eventInputAndChange 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function EventInputAndChange(props) {
@@ -3123,19 +2343,7 @@ export default EventInputAndChange;
 
 exports[`React Native > jsx > Javascript Test > eventProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function EventPropsComponent(props) {
   function handleClick() {
@@ -3165,19 +2373,7 @@ export default EventPropsComponent;
 
 exports[`React Native > jsx > Javascript Test > expressionState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -3203,19 +2399,7 @@ exports[`React Native > jsx > Javascript Test > figmaMeta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function FigmaButton(props) {
   return (
@@ -3236,19 +2420,7 @@ export default FigmaButton;
 
 exports[`React Native > jsx > Javascript Test > functionProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -3279,19 +2451,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > getterState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function Button(props) {
   function foo2() {
@@ -3327,19 +2487,7 @@ export default Button;
 
 exports[`React Native > jsx > Javascript Test > import types 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import RenderBlock from \\"./builder-render-block.raw\\";
 
 function RenderContent(props) {
@@ -3363,19 +2511,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Javascript Test > inputToTextInputRN 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -3401,19 +2537,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > layerName 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyLayerNameComponent(props) {
   return (
@@ -3433,19 +2557,7 @@ export default MyLayerNameComponent;
 
 exports[`React Native > jsx > Javascript Test > multipleOnUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function MultipleOnUpdate(props) {
@@ -3465,19 +2577,7 @@ export default MultipleOnUpdate;
 
 exports[`React Native > jsx > Javascript Test > multipleOnUpdateWithDeps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MultipleOnUpdateWithDeps(props) {
@@ -3513,19 +2613,7 @@ export default MultipleOnUpdateWithDeps;
 
 exports[`React Native > jsx > Javascript Test > multipleSpreads 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -3542,19 +2630,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > nestedShow 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function NestedShow(props) {
   return (
@@ -3586,19 +2662,7 @@ export default NestedShow;
 
 exports[`React Native > jsx > Javascript Test > nestedStyles 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function NestedStyles(props) {
   return (
@@ -3627,19 +2691,7 @@ export default NestedStyles;
 
 exports[`React Native > jsx > Javascript Test > normalizeLayerNames 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyNormalizedLayerNamesComponent(props) {
   return (
@@ -3699,19 +2751,7 @@ export default MyNormalizedLayerNamesComponent;
 
 exports[`React Native > jsx > Javascript Test > onClickToPressable 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -3729,19 +2769,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > onEvent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
 function Embed(props) {
@@ -3783,19 +2811,7 @@ export default Embed;
 
 exports[`React Native > jsx > Javascript Test > onInit & onMount 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
 function OnInit(props) {
@@ -3818,19 +2834,7 @@ export default OnInit;
 
 exports[`React Native > jsx > Javascript Test > onInit 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
 export const defaultValues = {
@@ -3861,19 +2865,7 @@ export default OnInit;
 
 exports[`React Native > jsx > Javascript Test > onInitPlain 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function OnInitPlain(props) {
@@ -3892,19 +2884,7 @@ export default OnInitPlain;
 
 exports[`React Native > jsx > Javascript Test > onMount 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function Comp(props) {
@@ -3927,19 +2907,7 @@ export default Comp;
 
 exports[`React Native > jsx > Javascript Test > onMountMultiple 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function Comp(props) {
@@ -3962,19 +2930,7 @@ export default Comp;
 
 exports[`React Native > jsx > Javascript Test > onUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function OnUpdate(props) {
@@ -3991,19 +2947,7 @@ export default OnUpdate;
 
 exports[`React Native > jsx > Javascript Test > onUpdateWithDeps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function OnUpdateWithDeps(props) {
@@ -4024,19 +2968,7 @@ export default OnUpdateWithDeps;
 
 exports[`React Native > jsx > Javascript Test > preserveExportOrLocalStatement 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 const b = 3;
 const foo = () => {};
@@ -4054,19 +2986,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > preserveTyping 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -4083,19 +3003,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > propsDestructure 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -4116,19 +3024,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > propsInterface 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -4145,19 +3041,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > propsType 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return (
@@ -4174,19 +3058,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > referencingFunInsideHook 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function OnUpdate(props) {
@@ -4215,19 +3087,7 @@ export default OnUpdate;
 
 exports[`React Native > jsx > Javascript Test > renderBlock 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import { useState } from \\"react\\";
 import { TARGET } from \\"../../constants/target.js\\";
 import { evaluate } from \\"../../functions/evaluate.js\\";
@@ -4488,19 +3348,7 @@ export default RenderBlock;
 
 exports[`React Native > jsx > Javascript Test > renderContentExample 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { Pressable } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
 import {
@@ -4550,19 +3398,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Javascript Test > rootFragmentMultiNode 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 function Button(props) {
   return (
@@ -4590,19 +3426,7 @@ export default Button;
 
 exports[`React Native > jsx > Javascript Test > rootShow 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function RenderStyles(props) {
   return (
@@ -4628,19 +3452,7 @@ export default RenderStyles;
 
 exports[`React Native > jsx > Javascript Test > self-referencing component 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -4657,19 +3469,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > self-referencing component with children 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -4693,19 +3493,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > setState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function SetState(props) {
@@ -4730,19 +3518,7 @@ export default SetState;
 
 exports[`React Native > jsx > Javascript Test > showExpressions 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function ShowWithOtherValues(props) {
   return (
@@ -4907,19 +3683,7 @@ export default ShowWithOtherValues;
 
 exports[`React Native > jsx > Javascript Test > showWithFor 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function NestedShow(props) {
   return (
@@ -4947,19 +3711,7 @@ export default NestedShow;
 
 exports[`React Native > jsx > Javascript Test > showWithOtherValues 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function ShowWithOtherValues(props) {
   return (
@@ -5016,19 +3768,7 @@ export default ShowWithOtherValues;
 
 exports[`React Native > jsx > Javascript Test > showWithRootText 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function ShowRootText(props) {
   return (
@@ -5052,19 +3792,7 @@ export default ShowRootText;
 
 exports[`React Native > jsx > Javascript Test > signalsOnUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -5089,19 +3817,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > spreadAttrs 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return <TextInput {...attrs} />;
@@ -5113,19 +3829,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > spreadNestedProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return <TextInput {...props.nested} />;
@@ -5137,19 +3841,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > spreadProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props) {
   return <TextInput {...props} />;
@@ -5161,19 +3853,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Javascript Test > store-async-function 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function StringLiteralStore(props) {
   async function arrowFunction() {
@@ -5197,19 +3877,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Javascript Test > string-literal-store 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function StringLiteralStore(props) {
@@ -5228,19 +3896,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Javascript Test > styleClassAndCss 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -5263,19 +3919,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > stylePropClassAndCss 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function StylePropClassAndCss(props) {
   return <View style={{ ...styles.view1, ...props.attributes.style }} />;
@@ -5291,19 +3935,7 @@ export default StylePropClassAndCss;
 
 exports[`React Native > jsx > Javascript Test > subComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props) {
@@ -5316,19 +3948,7 @@ export default SubComponent;
 
 exports[`React Native > jsx > Javascript Test > svgComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function SvgComponent(props) {
   return (
@@ -5356,19 +3976,7 @@ export default SvgComponent;
 
 exports[`React Native > jsx > Javascript Test > typeDependency 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function TypeDependency(props) {
   return (
@@ -5384,19 +3992,7 @@ export default TypeDependency;
 
 exports[`React Native > jsx > Javascript Test > typeExternalProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function TypeExternalProps(props) {
   return (
@@ -5414,19 +4010,7 @@ export default TypeExternalProps;
 
 exports[`React Native > jsx > Javascript Test > typeExternalStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function TypeExternalStore(props) {
@@ -5447,19 +4031,7 @@ export default TypeExternalStore;
 
 exports[`React Native > jsx > Javascript Test > typeGetterStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function TypeGetterStore(props) {
@@ -5492,19 +4064,7 @@ export default TypeGetterStore;
 
 exports[`React Native > jsx > Javascript Test > use-style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -5522,19 +4082,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > use-style-and-css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -5554,19 +4102,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -5584,19 +4120,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > useTarget 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function UseTargetComponent(props) {
@@ -5627,19 +4151,7 @@ export default UseTargetComponent;
 
 exports[`React Native > jsx > Javascript Test > webComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useRef } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
 
@@ -5671,19 +4183,7 @@ export default MyBasicWebComponent;
 
 exports[`React Native > jsx > Remove Internal mitosis package 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props) {
@@ -5704,19 +4204,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > AdvancedRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export interface Props {
@@ -5780,19 +4268,7 @@ export default MyBasicRefComponent;
 
 exports[`React Native > jsx > Typescript Test > Basic 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 export interface MyBasicComponentProps {
@@ -5833,19 +4309,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > Basic Context 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useContext, useRef, useEffect } from \\"react\\";
 import { Injector, MyService, createInjector } from \\"@dummy/injection-js\\";
 
@@ -5888,19 +4352,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > Basic OnMount Update 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export interface Props {
@@ -5937,19 +4389,7 @@ export default MyBasicOnMountUpdateComponent;
 
 exports[`React Native > jsx > Typescript Test > Basic Outputs 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOutputsComponent(props: any) {
@@ -5974,19 +4414,7 @@ exports[`React Native > jsx > Typescript Test > Basic Outputs Meta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOutputsComponent(props: any) {
@@ -6006,19 +4434,7 @@ export default MyBasicOutputsComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicAttribute 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return <TextInput autoCapitalize=\\"on\\" autoComplete=\\"on\\" spellCheck />;
@@ -6030,19 +4446,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicBooleanAttribute 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   children: any;
@@ -6072,19 +4476,7 @@ export default MyBooleanAttribute;
 
 exports[`React Native > jsx > Typescript Test > BasicChildComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 import MyBasicOnMountUpdateComponent from \\"./basic-onMount-update.raw\\";
 import MyBasicOutputsComponent from \\"./basic-outputs.raw\\";
@@ -6120,19 +4512,7 @@ export default MyBasicChildComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicFor 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicForComponent(props: any) {
@@ -6171,19 +4551,7 @@ export default MyBasicForComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
 export interface Props {
@@ -6243,19 +4611,7 @@ export default MyBasicRefComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicRefAssignment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 export interface Props {
@@ -6285,19 +4641,7 @@ export default MyBasicRefAssignmentComponent;
 
 exports[`React Native > jsx > Typescript Test > BasicRefPrevious 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export interface Props {
@@ -6347,19 +4691,7 @@ export default MyPreviousComponent;
 
 exports[`React Native > jsx > Typescript Test > Button 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -6394,19 +4726,7 @@ export default Button;
 
 exports[`React Native > jsx > Typescript Test > Columns 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Column = {
   content: any; // TODO: Implement this when support for dynamic CSS lands
@@ -6467,19 +4787,7 @@ export default Column;
 
 exports[`React Native > jsx > Typescript Test > ContentSlotHtml 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 type Props = {
   [key: string]: string | JSX.Element;
@@ -6507,19 +4815,7 @@ export default ContentSlotCode;
 
 exports[`React Native > jsx > Typescript Test > ContentSlotJSX 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Pressable } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 type Props = {
@@ -6576,19 +4872,7 @@ export default ContentSlotJsxCode;
 
 exports[`React Native > jsx > Typescript Test > CustomCode 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export interface CustomCodeProps {
@@ -6657,19 +4941,7 @@ export default CustomCode;
 
 exports[`React Native > jsx > Typescript Test > Embed 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 export interface CustomCodeProps {
@@ -6738,19 +5010,7 @@ export default CustomCode;
 
 exports[`React Native > jsx > Typescript Test > Form 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
 export interface FormProps {
@@ -7035,19 +5295,7 @@ export default FormComponent;
 
 exports[`React Native > jsx > Typescript Test > Image 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image, Text } from \\"react-native\\";
 import { useState, useRef, useEffect } from \\"react\\";
 
 // TODO: AMP Support?
@@ -7161,19 +5409,7 @@ export default Image;
 
 exports[`React Native > jsx > Typescript Test > Image State 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function ImgStateComponent(props: any) {
@@ -7196,19 +5432,7 @@ export default ImgStateComponent;
 
 exports[`React Native > jsx > Typescript Test > Img 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { Image } from \\"react-native\\";
 
 export interface ImgProps {
   attributes?: any;
@@ -7250,19 +5474,7 @@ export default ImgComponent;
 
 exports[`React Native > jsx > Typescript Test > Input 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 export interface FormInputProps {
   type?: string;
@@ -7303,19 +5515,7 @@ export default FormInputComponent;
 
 exports[`React Native > jsx > Typescript Test > InputParent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import FormInputComponent from \\"./input.raw\\";
 
 function Stepper(props: any) {
@@ -7338,19 +5538,7 @@ export default Stepper;
 
 exports[`React Native > jsx > Typescript Test > NestedStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 type MyStore = {
@@ -7381,19 +5569,7 @@ export default NestedStore;
 
 exports[`React Native > jsx > Typescript Test > RawText 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 export interface RawTextProps {
   attributes?: any;
@@ -7410,19 +5586,7 @@ export default RawText;
 
 exports[`React Native > jsx > Typescript Test > Section 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export interface SectionProps {
   maxWidth?: number;
@@ -7453,19 +5617,7 @@ export default SectionComponent;
 
 exports[`React Native > jsx > Typescript Test > Select 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export interface FormSelectProps {
   options?: {
@@ -7508,19 +5660,7 @@ export default SelectComponent;
 
 exports[`React Native > jsx > Typescript Test > SlotDefault 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   [key: string]: string;
@@ -7546,19 +5686,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Typescript Test > SlotHtml 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   [key: string]: string;
@@ -7579,19 +5707,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Typescript Test > SlotJsx 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   [key: string]: string;
@@ -7618,19 +5734,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Typescript Test > SlotNamed 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   [key: string]: string;
@@ -7653,19 +5757,7 @@ export default SlotCode;
 
 exports[`React Native > jsx > Typescript Test > Stamped.io 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Image, Text, TextInput, Button } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 type SmileReviewsProps = {
@@ -7761,19 +5853,7 @@ export default SmileReviews;
 
 exports[`React Native > jsx > Typescript Test > StoreComment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function StringLiteralStore(props: any) {
@@ -7794,19 +5874,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Typescript Test > StoreShadowVars 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -7829,19 +5897,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > StoreWithState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -7864,19 +5920,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > Submit 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -7897,19 +5941,7 @@ export default SubmitButton;
 
 exports[`React Native > jsx > Typescript Test > Text 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 export interface TextProps {
@@ -7948,19 +5980,7 @@ export default Text;
 
 exports[`React Native > jsx > Typescript Test > Textarea 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 export interface TextareaProps {
   attributes?: any;
@@ -7988,19 +6008,7 @@ export default Textarea;
 
 exports[`React Native > jsx > Typescript Test > UseValueAndFnFromStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 type MyProps = {
@@ -8044,19 +6052,7 @@ export default UseValueAndFnFromStore;
 
 exports[`React Native > jsx > Typescript Test > Video 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 export interface VideoProps {
   attributes?: any;
@@ -8115,19 +6111,7 @@ export default Video;
 
 exports[`React Native > jsx > Typescript Test > arrowFunctionInUseStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -8155,19 +6139,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > basicForFragment 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function BasicForFragment(props: any) {
@@ -8206,19 +6178,7 @@ export default BasicForFragment;
 
 exports[`React Native > jsx > Typescript Test > basicForNoTagReference 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicForNoTagRefComponent(props: any) {
@@ -8258,19 +6218,7 @@ export default MyBasicForNoTagRefComponent;
 
 exports[`React Native > jsx > Typescript Test > basicForwardRef 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, TextInput } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
 export interface Props {
@@ -8308,19 +6256,7 @@ exports[`React Native > jsx > Typescript Test > basicForwardRefMetadata 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, TextInput } from \\"react-native\\";
 import { useState, forwardRef } from \\"react\\";
 
 export interface Props {
@@ -8353,19 +6289,7 @@ export default MyBasicForwardRefComponent;
 
 exports[`React Native > jsx > Typescript Test > basicOnUpdateReturn 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyBasicOnUpdateReturnComponent(props: any) {
@@ -8407,19 +6331,7 @@ exports[`React Native > jsx > Typescript Test > basicRefAttributePassing 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function BasicRefAttributePassingComponent(props: any) {
@@ -8443,19 +6355,7 @@ exports[`React Native > jsx > Typescript Test > basicRefAttributePassingCustomRe
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function BasicRefAttributePassingCustomRefComponent(props: any) {
@@ -8476,19 +6376,7 @@ export default BasicRefAttributePassingCustomRefComponent;
 
 exports[`React Native > jsx > Typescript Test > class + ClassName + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import MyComp from \\"./my-component\\";
 
 function MyBasicComponent(props: any) {
@@ -8512,19 +6400,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > class + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
   return (
@@ -8542,19 +6418,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > className + css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
   return (
@@ -8572,19 +6436,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > className 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 type Props = {
@@ -8614,19 +6466,7 @@ export default ClassNameCode;
 
 exports[`React Native > jsx > Typescript Test > classState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props: any) {
@@ -8656,19 +6496,7 @@ exports[`React Native > jsx > Typescript Test > classnameProps 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   children: any;
@@ -8697,19 +6525,7 @@ exports[`React Native > jsx > Typescript Test > complexMeta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function ComplexMetaRaw(props: any) {
   return <View />;
@@ -8721,19 +6537,7 @@ export default ComplexMetaRaw;
 
 exports[`React Native > jsx > Typescript Test > componentWithContext 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
 export interface ComponentWithContextProps {
@@ -8775,19 +6579,7 @@ export default ComponentWithContext;
 
 exports[`React Native > jsx > Typescript Test > componentWithContextMultiRoot 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 
 export interface ComponentWithContextProps {
@@ -8834,19 +6626,7 @@ export default ComponentWithContext;
 
 exports[`React Native > jsx > Typescript Test > contentState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useContext } from \\"react\\";
 import BuilderContext from \\"@dummy/context.js\\";
 
@@ -8871,19 +6651,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Typescript Test > defaultProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -8934,19 +6702,7 @@ export default Button;
 
 exports[`React Native > jsx > Typescript Test > defaultPropsOutsideComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -8993,19 +6749,7 @@ export default Button;
 
 exports[`React Native > jsx > Typescript Test > defaultValsWithTypes 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Props = {
   name: string;
@@ -9030,19 +6774,7 @@ export default ComponentWithTypes;
 
 exports[`React Native > jsx > Typescript Test > eventInputAndChange 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function EventInputAndChange(props: any) {
@@ -9069,19 +6801,7 @@ export default EventInputAndChange;
 
 exports[`React Native > jsx > Typescript Test > eventProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { EventProps, EventState } from \\"./event-props.type\\";
 
 function EventPropsComponent(props: EventProps) {
@@ -9112,19 +6832,7 @@ export default EventPropsComponent;
 
 exports[`React Native > jsx > Typescript Test > expressionState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -9150,19 +6858,7 @@ exports[`React Native > jsx > Typescript Test > figmaMeta 1`] = `
           */
 
 import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function FigmaButton(props: any) {
   return (
@@ -9183,19 +6879,7 @@ export default FigmaButton;
 
 exports[`React Native > jsx > Typescript Test > functionProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 export interface MyBasicComponentProps {
   id: string;
@@ -9230,19 +6914,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > getterState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export interface ButtonProps {
   foo: string;
@@ -9282,19 +6954,7 @@ export default Button;
 
 exports[`React Native > jsx > Typescript Test > import types 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 
 type RenderContentProps = {
   options?: GetContentOptions;
@@ -9325,19 +6985,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Typescript Test > inputToTextInputRN 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -9363,19 +7011,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > layerName 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyLayerNameComponent(props: any) {
   return (
@@ -9395,19 +7031,7 @@ export default MyLayerNameComponent;
 
 exports[`React Native > jsx > Typescript Test > multipleOnUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function MultipleOnUpdate(props: any) {
@@ -9427,19 +7051,7 @@ export default MultipleOnUpdate;
 
 exports[`React Native > jsx > Typescript Test > multipleOnUpdateWithDeps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MultipleOnUpdateWithDeps(props: any) {
@@ -9475,19 +7087,7 @@ export default MultipleOnUpdateWithDeps;
 
 exports[`React Native > jsx > Typescript Test > multipleSpreads 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyBasicComponent(props: any) {
@@ -9504,19 +7104,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > nestedShow 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Props {
   conditionA: boolean;
@@ -9553,19 +7141,7 @@ export default NestedShow;
 
 exports[`React Native > jsx > Typescript Test > nestedStyles 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function NestedStyles(props: any) {
   return (
@@ -9594,19 +7170,7 @@ export default NestedStyles;
 
 exports[`React Native > jsx > Typescript Test > normalizeLayerNames 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export interface MyNormalizedLayerNamesComponentProps {
   id: string;
@@ -9672,19 +7236,7 @@ export default MyNormalizedLayerNamesComponent;
 
 exports[`React Native > jsx > Typescript Test > onClickToPressable 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -9702,19 +7254,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > onEvent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
 function Embed(props: any) {
@@ -9756,19 +7296,7 @@ export default Embed;
 
 exports[`React Native > jsx > Typescript Test > onInit & onMount 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useRef, useEffect } from \\"react\\";
 
 function OnInit(props: any) {
@@ -9791,19 +7319,7 @@ export default OnInit;
 
 exports[`React Native > jsx > Typescript Test > onInit 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useRef } from \\"react\\";
 
 type Props = {
@@ -9838,19 +7354,7 @@ export default OnInit;
 
 exports[`React Native > jsx > Typescript Test > onInitPlain 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useRef } from \\"react\\";
 
 function OnInitPlain(props: any) {
@@ -9869,19 +7373,7 @@ export default OnInitPlain;
 
 exports[`React Native > jsx > Typescript Test > onMount 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function Comp(props: any) {
@@ -9904,19 +7396,7 @@ export default Comp;
 
 exports[`React Native > jsx > Typescript Test > onMountMultiple 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function Comp(props: any) {
@@ -9939,19 +7419,7 @@ export default Comp;
 
 exports[`React Native > jsx > Typescript Test > onUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function OnUpdate(props: any) {
@@ -9968,19 +7436,7 @@ export default OnUpdate;
 
 exports[`React Native > jsx > Typescript Test > onUpdateWithDeps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 type Props = {
@@ -10005,19 +7461,7 @@ export default OnUpdateWithDeps;
 
 exports[`React Native > jsx > Typescript Test > preserveExportOrLocalStatement 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 type Types = {
   s: any[];
@@ -10045,19 +7489,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > preserveTyping 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export type A = \\"test\\";
 export interface C {
@@ -10087,19 +7519,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > propsDestructure 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 type Props = {
@@ -10125,19 +7545,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > propsInterface 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Person {
   name: string;
@@ -10159,19 +7567,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > propsType 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 type Person = {
   name: string;
@@ -10193,19 +7589,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > referencingFunInsideHook 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function OnUpdate(props: any) {
@@ -10234,19 +7618,7 @@ export default OnUpdate;
 
 exports[`React Native > jsx > Typescript Test > renderBlock 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import { useState } from \\"react\\";
 
 export type RenderBlockProps = {
@@ -10520,19 +7892,7 @@ export default RenderBlock;
 
 exports[`React Native > jsx > Typescript Test > renderContentExample 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { Pressable } from \\"react-native\\";
 import { useContext, useEffect } from \\"react\\";
 
 type Props = {
@@ -10590,19 +7950,7 @@ export default RenderContent;
 
 exports[`React Native > jsx > Typescript Test > rootFragmentMultiNode 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TouchableOpacity, Button } from \\"react-native\\";
 
 export interface ButtonProps {
   attributes?: any;
@@ -10637,19 +7985,7 @@ export default Button;
 
 exports[`React Native > jsx > Typescript Test > rootShow 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export interface RenderStylesProps {
   foo: string;
@@ -10679,19 +8015,7 @@ export default RenderStyles;
 
 exports[`React Native > jsx > Typescript Test > self-referencing component 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -10708,19 +8032,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > self-referencing component with children 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -10744,19 +8056,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > setState 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function SetState(props: any) {
@@ -10781,19 +8081,7 @@ export default SetState;
 
 exports[`React Native > jsx > Typescript Test > showExpressions 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Props {
   conditionA: boolean;
@@ -10963,19 +8251,7 @@ export default ShowWithOtherValues;
 
 exports[`React Native > jsx > Typescript Test > showWithFor 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Props {
   conditionA: boolean;
@@ -11008,19 +8284,7 @@ export default NestedShow;
 
 exports[`React Native > jsx > Typescript Test > showWithOtherValues 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Props {
   conditionA: boolean;
@@ -11081,19 +8345,7 @@ export default ShowWithOtherValues;
 
 exports[`React Native > jsx > Typescript Test > showWithRootText 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 interface Props {
   conditionA: boolean;
@@ -11121,19 +8373,7 @@ export default ShowRootText;
 
 exports[`React Native > jsx > Typescript Test > signalsOnUpdate 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 type Props = {
@@ -11167,19 +8407,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > spreadAttrs 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
   return <TextInput {...attrs} />;
@@ -11191,19 +8419,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > spreadNestedProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
   return <TextInput {...props.nested} />;
@@ -11215,19 +8431,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > spreadProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyBasicComponent(props: any) {
   return <TextInput {...props} />;
@@ -11239,19 +8443,7 @@ export default MyBasicComponent;
 
 exports[`React Native > jsx > Typescript Test > store-async-function 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function StringLiteralStore(props: any) {
   async function arrowFunction() {
@@ -11275,19 +8467,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Typescript Test > string-literal-store 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function StringLiteralStore(props: any) {
@@ -11306,19 +8486,7 @@ export default StringLiteralStore;
 
 exports[`React Native > jsx > Typescript Test > styleClassAndCss 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -11341,19 +8509,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > stylePropClassAndCss 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function StylePropClassAndCss(props: any) {
   return <View style={{ ...styles.view1, ...props.attributes.style }} />;
@@ -11369,19 +8525,7 @@ export default StylePropClassAndCss;
 
 exports[`React Native > jsx > Typescript Test > subComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import {} from \\"react-native\\";
 import Foo from \\"./foo-sub-component\\";
 
 function SubComponent(props: any) {
@@ -11394,19 +8538,7 @@ export default SubComponent;
 
 exports[`React Native > jsx > Typescript Test > svgComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 
 function SvgComponent(props: any) {
   return (
@@ -11434,19 +8566,7 @@ export default SvgComponent;
 
 exports[`React Native > jsx > Typescript Test > typeDependency 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 export type TypeDependencyProps = {
   foo: Foo;
@@ -11469,19 +8589,7 @@ export default TypeDependency;
 
 exports[`React Native > jsx > Typescript Test > typeExternalProps 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { FooProps } from \\"./foo-props\\";
 
 function TypeExternalProps(props: FooProps) {
@@ -11500,19 +8608,7 @@ export default TypeExternalProps;
 
 exports[`React Native > jsx > Typescript Test > typeExternalStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 import { FooStore } from \\"./foo-store\\";
 
@@ -11534,19 +8630,7 @@ export default TypeExternalStore;
 
 exports[`React Native > jsx > Typescript Test > typeGetterStore 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 type GetterStore = {
@@ -11585,19 +8669,7 @@ export default TypeGetterStore;
 
 exports[`React Native > jsx > Typescript Test > use-style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -11615,19 +8687,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > use-style-and-css 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -11647,19 +8707,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -11677,19 +8725,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > useTarget 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function UseTargetComponent(props: any) {
@@ -11720,19 +8756,7 @@ export default UseTargetComponent;
 
 exports[`React Native > jsx > Typescript Test > webComponent 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useRef } from \\"react\\";
 import { register } from \\"swiper/element/bundle\\";
 
@@ -11764,19 +8788,7 @@ export default MyBasicWebComponent;
 
 exports[`React Native > native-wind style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -11794,19 +8806,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > basic 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -11829,19 +8829,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > bindGroup 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -11913,19 +8901,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > bindProperty 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -11940,19 +8916,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > classDirective 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -11978,19 +8942,7 @@ exports[`React Native > svelte > Javascript Test > context 1`] = `
 
 exports[`React Native > svelte > Javascript Test > each 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -12013,19 +8965,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > eventHandlers 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   function log(msg = \\"hello\\") {
@@ -12053,19 +8993,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > html 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -12080,19 +9008,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > ifElse 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -12125,19 +9041,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > imports 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
 
@@ -12159,19 +9063,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > lifecycleHooks 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function MyComponent(props) {
@@ -12196,19 +9088,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > reactive 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -12233,19 +9113,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > reactiveWithFn 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyComponent(props) {
@@ -12287,19 +9155,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > slots 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -12322,19 +9178,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props) {
   return <TextInput />;
@@ -12348,19 +9192,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > textExpressions 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props) {
@@ -12385,19 +9217,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > basic 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12420,19 +9240,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > bindGroup 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12504,19 +9312,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > bindProperty 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12531,19 +9327,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > classDirective 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12569,19 +9353,7 @@ exports[`React Native > svelte > Typescript Test > context 1`] = `
 
 exports[`React Native > svelte > Typescript Test > each 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12604,19 +9376,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > eventHandlers 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   function log(msg = \\"hello\\") {
@@ -12644,19 +9404,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > html 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12671,19 +9419,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > ifElse 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12716,19 +9452,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > imports 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useState } from \\"react\\";
 import Button from \\"./Button\\";
 
@@ -12750,19 +9474,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > lifecycleHooks 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View } from \\"react-native\\";
 import { useEffect } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12787,19 +9499,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > reactive 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12824,19 +9524,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > reactiveWithFn 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, TextInput } from \\"react-native\\";
 import { useState, useEffect } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12878,19 +9566,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > slots 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -12913,19 +9589,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return <TextInput />;
@@ -12939,19 +9603,7 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > textExpressions 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 
 function MyComponent(props: any) {
@@ -12976,19 +9628,7 @@ export default MyComponent;
 
 exports[`React Native > twrnc state complex style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { Text, Button } from \\"react-native\\";
 import tw from \\"twrnc\\";
 import { clsx } from \\"clsx\\";
 
@@ -13016,19 +9656,7 @@ export default Button;
 
 exports[`React Native > twrnc state style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text } from \\"react-native\\";
 import { useState } from \\"react\\";
 import tw from \\"twrnc\\";
 
@@ -13048,19 +9676,7 @@ export default MyBasicComponent;
 
 exports[`React Native > twrnc style 1`] = `
 "import * as React from \\"react\\";
-import {
-  FlatList,
-  ScrollView,
-  View,
-  StyleSheet,
-  Image,
-  Text,
-  Pressable,
-  TextInput,
-  TouchableOpacity,
-  Button,
-  Linking,
-} from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 import tw from \\"twrnc\\";
 
 function MyComponent(props) {

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -458,7 +458,7 @@ const _componentToReact = (
 
   const str = dedent`
   ${shouldAddUseClientDirective ? `'use client';` : ''}
-  ${getDefaultImport(options)}
+  ${getDefaultImport(options, json)}
   ${styledComponentsCode ? `import styled from 'styled-components';\n` : ''}
   ${
     reactLibImports.size


### PR DESCRIPTION
## Description

Limit imports in ReactNative to only include used components and to not import components from React Native that are already imported from elsewhere.

https://builder-io.atlassian.net/browse/ENG-9380