### PR TITLE
feat: ENG-9021 Remove Circular References for `componentToBuilder` generator

### DIFF
--- a/.changeset/funny-donuts-mate.md
+++ b/.changeset/funny-donuts-mate.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/mitosis': patch
+'@builder.io/mitosis-cli': patch
+---
+
+add `removeCircularReferences` option for `componentToBuilder` generator

--- a/.changeset/funny-donuts-mate.md
+++ b/.changeset/funny-donuts-mate.md
@@ -3,4 +3,4 @@
 '@builder.io/mitosis-cli': patch
 ---
 
-add `removeCircularReferences` option for `componentToBuilder` generator
+remove Circular References for `componentToBuilder` generator

--- a/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
@@ -3913,6 +3913,282 @@ alert('hi');",
 }
 `;
 
+exports[`Builder > handles recursive component structure 1`] = `
+{
+  "data": {
+    "blocks": [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "actions": {},
+        "bindings": {},
+        "children": [],
+        "code": {
+          "actions": {},
+          "bindings": {},
+        },
+        "component": {
+          "name": "LocationTree",
+          "options": {
+            "symbol": {
+              "content": {
+                "data": {
+                  "blocks": [
+                    {
+                      "@type": "@builder.io/sdk:Element",
+                      "actions": {},
+                      "bindings": {},
+                      "children": [
+                        {
+                          "@type": "@builder.io/sdk:Element",
+                          "bindings": {
+                            "show": "location.child",
+                          },
+                          "children": [
+                            {
+                              "@type": "@builder.io/sdk:Element",
+                              "actions": {},
+                              "bindings": {
+                                "component.options.location": "location.child",
+                              },
+                              "children": [],
+                              "code": {
+                                "actions": {},
+                                "bindings": {
+                                  "component.options.location": "location.child",
+                                },
+                              },
+                              "component": {
+                                "name": "LocationTree",
+                                "options": {
+                                  "symbol": {
+                                    "content": {
+                                      "data": {
+                                        "blocks": [
+                                          {
+                                            "@type": "@builder.io/sdk:Element",
+                                            "actions": {},
+                                            "bindings": {},
+                                            "children": [
+                                              {
+                                                "@type": "@builder.io/sdk:Element",
+                                                "bindings": {
+                                                  "show": "location.child",
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "@builder.io/sdk:Element",
+                                                    "actions": {},
+                                                    "bindings": {
+                                                      "component.options.location": "location.child",
+                                                    },
+                                                    "children": [],
+                                                    "code": {
+                                                      "actions": {},
+                                                      "bindings": {
+                                                        "component.options.location": "location.child",
+                                                      },
+                                                    },
+                                                    "component": {
+                                                      "name": "LocationTree",
+                                                      "options": {
+                                                        "symbol": {
+                                                          "content": {
+                                                            "data": {
+                                                              "blocks": [
+                                                                {
+                                                                  "@type": "@builder.io/sdk:Element",
+                                                                  "actions": {},
+                                                                  "bindings": {},
+                                                                  "children": [
+                                                                    {
+                                                                      "@type": "@builder.io/sdk:Element",
+                                                                      "bindings": {
+                                                                        "show": "location.child",
+                                                                      },
+                                                                      "children": [
+                                                                        {
+                                                                          "@type": "@builder.io/sdk:Element",
+                                                                          "actions": {},
+                                                                          "bindings": {
+                                                                            "component.options.location": "location.child",
+                                                                          },
+                                                                          "children": [],
+                                                                          "code": {
+                                                                            "actions": {},
+                                                                            "bindings": {
+                                                                              "component.options.location": "location.child",
+                                                                            },
+                                                                          },
+                                                                          "component": {
+                                                                            "name": "LocationTree",
+                                                                            "options": {
+                                                                              "symbol": {
+                                                                                "content": {
+                                                                                  "data": {
+                                                                                    "blocks": [
+                                                                                      {
+                                                                                        "@type": "@builder.io/sdk:Element",
+                                                                                        "actions": {},
+                                                                                        "bindings": {},
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "@type": "@builder.io/sdk:Element",
+                                                                                            "bindings": {
+                                                                                              "show": "location.child",
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "@type": "@builder.io/sdk:Element",
+                                                                                                "actions": {},
+                                                                                                "bindings": {
+                                                                                                  "component.options.location": "location.child",
+                                                                                                },
+                                                                                                "children": [],
+                                                                                                "code": {
+                                                                                                  "actions": {},
+                                                                                                  "bindings": {
+                                                                                                    "component.options.location": "location.child",
+                                                                                                  },
+                                                                                                },
+                                                                                                "component": {
+                                                                                                  "name": "LocationTree",
+                                                                                                  "options": {
+                                                                                                    "symbol": {
+                                                                                                      "content": {
+                                                                                                        "data": {
+                                                                                                          "blocks": [
+                                                                                                            {
+                                                                                                              "@type": "@builder.io/sdk:Element",
+                                                                                                              "actions": {},
+                                                                                                              "bindings": {},
+                                                                                                              "children": [
+                                                                                                                {
+                                                                                                                  "@type": "@builder.io/sdk:Element",
+                                                                                                                  "bindings": {
+                                                                                                                    "show": "location.child",
+                                                                                                                  },
+                                                                                                                  "children": [],
+                                                                                                                  "component": {
+                                                                                                                    "name": "Core:Fragment",
+                                                                                                                  },
+                                                                                                                },
+                                                                                                              ],
+                                                                                                              "code": {
+                                                                                                                "actions": {},
+                                                                                                                "bindings": {},
+                                                                                                              },
+                                                                                                              "component": {
+                                                                                                                "name": "Core:Fragment",
+                                                                                                              },
+                                                                                                            },
+                                                                                                          ],
+                                                                                                          "jsCode": "",
+                                                                                                          "tsCode": "",
+                                                                                                        },
+                                                                                                      },
+                                                                                                    },
+                                                                                                  },
+                                                                                                },
+                                                                                              },
+                                                                                            ],
+                                                                                            "component": {
+                                                                                              "name": "Core:Fragment",
+                                                                                            },
+                                                                                          },
+                                                                                        ],
+                                                                                        "code": {
+                                                                                          "actions": {},
+                                                                                          "bindings": {},
+                                                                                        },
+                                                                                        "component": {
+                                                                                          "name": "Core:Fragment",
+                                                                                        },
+                                                                                      },
+                                                                                    ],
+                                                                                    "jsCode": "",
+                                                                                    "tsCode": "",
+                                                                                  },
+                                                                                },
+                                                                              },
+                                                                            },
+                                                                          },
+                                                                        },
+                                                                      ],
+                                                                      "component": {
+                                                                        "name": "Core:Fragment",
+                                                                      },
+                                                                    },
+                                                                  ],
+                                                                  "code": {
+                                                                    "actions": {},
+                                                                    "bindings": {},
+                                                                  },
+                                                                  "component": {
+                                                                    "name": "Core:Fragment",
+                                                                  },
+                                                                },
+                                                              ],
+                                                              "jsCode": "",
+                                                              "tsCode": "",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                ],
+                                                "component": {
+                                                  "name": "Core:Fragment",
+                                                },
+                                              },
+                                            ],
+                                            "code": {
+                                              "actions": {},
+                                              "bindings": {},
+                                            },
+                                            "component": {
+                                              "name": "Core:Fragment",
+                                            },
+                                          },
+                                        ],
+                                        "jsCode": "",
+                                        "tsCode": "",
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                          "component": {
+                            "name": "Core:Fragment",
+                          },
+                        },
+                      ],
+                      "code": {
+                        "actions": {},
+                        "bindings": {},
+                      },
+                      "component": {
+                        "name": "Core:Fragment",
+                      },
+                    },
+                  ],
+                  "jsCode": "",
+                  "tsCode": "",
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+    "jsCode": "",
+    "tsCode": "",
+  },
+}
+`;
+
 exports[`Builder > localization 1`] = `
 {
   "@type": "@builder.io/mitosis/component",

--- a/packages/core/src/__tests__/builder/builder.test.ts
+++ b/packages/core/src/__tests__/builder/builder.test.ts
@@ -1497,125 +1497,6 @@ describe('Builder', () => {
     expect(backToBuilder.data?.blocks?.[0]?.layerName).toBe('test-layer');
   });
 
-  test('handles recursive component structure', () => {
-    const mitosisComponent: MitosisComponent = {
-      '@type': '@builder.io/mitosis/component' as const,
-      imports: [],
-      exports: {
-        LocationTree: {
-          code: 'function LocationTree(location) {\n  return <>\n      {location.child && <LocationTree location={location.child} />}\n    </>;\n}',
-          isFunction: true,
-          usedInLocal: false,
-        },
-      },
-      inputs: [],
-      meta: {},
-      refs: {},
-      state: {},
-      children: [
-        {
-          '@type': '@builder.io/mitosis/node',
-          name: 'LocationTree',
-          meta: {},
-          scope: {},
-          properties: {},
-          bindings: {},
-          children: [],
-        },
-      ],
-      context: {
-        get: {},
-        set: {},
-      },
-      subComponents: [
-        {
-          '@type': '@builder.io/mitosis/component',
-          imports: [],
-          exports: {},
-          inputs: [],
-          meta: {},
-          refs: {},
-          state: {},
-          children: [
-            {
-              '@type': '@builder.io/mitosis/node',
-              name: 'Fragment',
-              meta: {},
-              scope: {},
-              properties: {},
-              bindings: {},
-              children: [
-                {
-                  '@type': '@builder.io/mitosis/node',
-                  name: 'Show',
-                  meta: {},
-                  scope: {},
-                  properties: {},
-                  bindings: {
-                    when: {
-                      code: 'location.child',
-                      bindingType: 'expression',
-                      type: 'single',
-                    },
-                  },
-                  children: [
-                    {
-                      '@type': '@builder.io/mitosis/node',
-                      name: 'LocationTree',
-                      meta: {},
-                      scope: {},
-                      properties: {},
-                      bindings: {
-                        location: {
-                          code: 'location.child',
-                          bindingType: 'expression',
-                          type: 'single',
-                        },
-                      },
-                      children: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          context: {
-            get: {},
-            set: {},
-          },
-          subComponents: [],
-          name: 'LocationTree',
-          hooks: {
-            onMount: [],
-            onEvent: [],
-          },
-        },
-      ],
-      name: 'ExploreKaryakar',
-      hooks: {
-        onMount: [],
-        onEvent: [],
-      },
-    };
-
-    const builderJson = componentToBuilder({})({
-      component: mitosisComponent,
-    });
-    expect(builderJson.data?.blocks?.[0]?.component?.name).toBe('LocationTree');
-    let tempElement = builderJson.data?.blocks?.[0];
-    for (let i = 0; i < 5; i++) {
-      expect(tempElement?.component?.name).toBe('LocationTree');
-      tempElement = get(
-        tempElement,
-        'component.options.symbol.content.data.blocks[0].children[0].children[0]',
-      );
-    }
-    expect(tempElement).toBeUndefined();
-    expect(builderJson).toMatchSnapshot();
-
-    expect(() => builderContentToMitosisComponent(builderJson)).not.toThrow();
-  });
-
   test('converts <For> loop to Builder format', () => {
     const mitosisComponent: MitosisComponent = {
       '@type': '@builder.io/mitosis/component' as const,
@@ -1984,6 +1865,125 @@ describe('Builder', () => {
     expect(backToMitosis.state?.booleanValue?.code).toBe('true');
     expect(backToMitosis.state?.nullValue?.code).toBe('null');
     expect(backToMitosis.state?.undefinedValue?.code).toBe('undefined');
+  });
+
+  test('handles recursive component structure', () => {
+    const mitosisComponent: MitosisComponent = {
+      '@type': '@builder.io/mitosis/component' as const,
+      imports: [],
+      exports: {
+        LocationTree: {
+          code: 'function LocationTree(location) {\n  return <>\n      {location.child && <LocationTree location={location.child} />}\n    </>;\n}',
+          isFunction: true,
+          usedInLocal: false,
+        },
+      },
+      inputs: [],
+      meta: {},
+      refs: {},
+      state: {},
+      children: [
+        {
+          '@type': '@builder.io/mitosis/node',
+          name: 'LocationTree',
+          meta: {},
+          scope: {},
+          properties: {},
+          bindings: {},
+          children: [],
+        },
+      ],
+      context: {
+        get: {},
+        set: {},
+      },
+      subComponents: [
+        {
+          '@type': '@builder.io/mitosis/component',
+          imports: [],
+          exports: {},
+          inputs: [],
+          meta: {},
+          refs: {},
+          state: {},
+          children: [
+            {
+              '@type': '@builder.io/mitosis/node',
+              name: 'Fragment',
+              meta: {},
+              scope: {},
+              properties: {},
+              bindings: {},
+              children: [
+                {
+                  '@type': '@builder.io/mitosis/node',
+                  name: 'Show',
+                  meta: {},
+                  scope: {},
+                  properties: {},
+                  bindings: {
+                    when: {
+                      code: 'location.child',
+                      bindingType: 'expression',
+                      type: 'single',
+                    },
+                  },
+                  children: [
+                    {
+                      '@type': '@builder.io/mitosis/node',
+                      name: 'LocationTree',
+                      meta: {},
+                      scope: {},
+                      properties: {},
+                      bindings: {
+                        location: {
+                          code: 'location.child',
+                          bindingType: 'expression',
+                          type: 'single',
+                        },
+                      },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          context: {
+            get: {},
+            set: {},
+          },
+          subComponents: [],
+          name: 'LocationTree',
+          hooks: {
+            onMount: [],
+            onEvent: [],
+          },
+        },
+      ],
+      name: 'ExploreKaryakar',
+      hooks: {
+        onMount: [],
+        onEvent: [],
+      },
+    };
+
+    const builderJson = componentToBuilder({})({
+      component: mitosisComponent,
+    });
+    expect(builderJson.data?.blocks?.[0]?.component?.name).toBe('LocationTree');
+    let tempElement = builderJson.data?.blocks?.[0];
+    for (let i = 0; i < 5; i++) {
+      expect(tempElement?.component?.name).toBe('LocationTree');
+      tempElement = get(
+        tempElement,
+        'component.options.symbol.content.data.blocks[0].children[0].children[0]',
+      );
+    }
+    expect(tempElement).toBeUndefined();
+    expect(builderJson).toMatchSnapshot();
+
+    expect(() => builderContentToMitosisComponent(builderJson)).not.toThrow();
   });
 });
 

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -932,9 +932,14 @@ export const componentToBuilder =
       if (isBuilderElement(el) && !el.meta?.preventRecursion) {
         const value = subComponentMap[el.component?.name!];
         if (value) {
+          // Recursive Components are handled in the following steps :
+          // 1. Find out the path in which the component is self-referenced ( where that component reoccurs within it’s tree ).
+          // 2. We populate that component recursively for 4 times in a row.
+          // 3. Finally remove the recursive part from the last component which was populated.
+          // Also note that it doesn’t mean that component will render that many times, the rendering logic depends on the logic in it's parent. (Eg. show property binding)
+
           const path = recursivelyCheckForChildrenWithSameComponent(value, el.component?.name!);
           if (path) {
-            // recursively set the value at the path 4 times.
             let tempElement = el;
             for (let i = 0; i < 4; i++) {
               const tempValue = cloneDeep(value);

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -819,14 +819,14 @@ export const blockToBuilder = (
 };
 
 const recursivelyCheckForChildrenWithSameComponent = (
-  builderContent: BuilderContent,
+  elementOrContent: BuilderContent | BuilderElement,
   componentName: string,
   path: string = '',
 ): string => {
-  if (builderContent.data?.blocks) {
+  if ((elementOrContent as BuilderContent).data?.blocks) {
     return (
-      builderContent.data.blocks
-        .map((block, index) =>
+      (elementOrContent as BuilderContent).data?.blocks
+        ?.map((block, index) =>
           recursivelyCheckForChildrenWithSameComponent(
             block,
             componentName,
@@ -835,14 +835,14 @@ const recursivelyCheckForChildrenWithSameComponent = (
         )
         .find(Boolean) || ''
     );
-  } else if (isBuilderElement(builderContent)) {
-    if (builderContent.component?.name === componentName) {
+  } else {
+    if ((elementOrContent as BuilderElement).component?.name === componentName) {
       return path;
     }
-    if (builderContent.children) {
+    if ((elementOrContent as BuilderElement).children) {
       return (
-        builderContent.children
-          .map((child, index) =>
+        (elementOrContent as BuilderElement).children
+          ?.map((child, index) =>
             recursivelyCheckForChildrenWithSameComponent(
               child,
               componentName,

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -823,9 +823,28 @@ const recursivelyCheckForChildrenWithSameComponent = (
   componentName: string,
   path: string = '',
 ): string => {
-  if ((elementOrContent as BuilderContent).data?.blocks) {
+  if (isBuilderElement(elementOrContent)) {
+    if (elementOrContent.component?.name === componentName) {
+      return path;
+    }
+
     return (
-      (elementOrContent as BuilderContent).data?.blocks
+      elementOrContent.children
+        ?.map((child, index) =>
+          recursivelyCheckForChildrenWithSameComponent(
+            child,
+            componentName,
+            `${path}.children[${index}]`,
+          ),
+        )
+        .find(Boolean) || ''
+    );
+  }
+
+  // do your builder content specific stuff)
+  if (elementOrContent.data?.blocks) {
+    return (
+      elementOrContent.data?.blocks
         ?.map((block, index) =>
           recursivelyCheckForChildrenWithSameComponent(
             block,
@@ -835,23 +854,6 @@ const recursivelyCheckForChildrenWithSameComponent = (
         )
         .find(Boolean) || ''
     );
-  } else {
-    if ((elementOrContent as BuilderElement).component?.name === componentName) {
-      return path;
-    }
-    if ((elementOrContent as BuilderElement).children) {
-      return (
-        (elementOrContent as BuilderElement).children
-          ?.map((child, index) =>
-            recursivelyCheckForChildrenWithSameComponent(
-              child,
-              componentName,
-              `${path}.children[${index}]`,
-            ),
-          )
-          .find(Boolean) || ''
-      );
-    }
   }
   return '';
 };

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -841,7 +841,6 @@ const recursivelyCheckForChildrenWithSameComponent = (
     );
   }
 
-  // do your builder content specific stuff)
   if (elementOrContent.data?.blocks) {
     return (
       elementOrContent.data?.blocks

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -930,15 +930,11 @@ export const componentToBuilder =
       if (isBuilderElement(el)) {
         const value = subComponentMap[el.component?.name!];
         if (value) {
-          if (options.removeCircularReferences) {
-            const path = recursivelyCheckForChildrenWithSameComponent(value, el.component?.name!);
-            if (path) {
-              const arrayPath = path.replace(/\[\d+\]$/, '');
-              const newValue = removeItem(value, arrayPath, Number(path.match(/\[(\d+)\]$/)?.[1]));
-              set(el, 'component.options.symbol.content', newValue);
-            } else {
-              set(el, 'component.options.symbol.content', value);
-            }
+          const path = recursivelyCheckForChildrenWithSameComponent(value, el.component?.name!);
+          if (path) {
+            const arrayPath = path.replace(/\[\d+\]$/, '');
+            const newValue = removeItem(value, arrayPath, Number(path.match(/\[(\d+)\]$/)?.[1]));
+            set(el, 'component.options.symbol.content', newValue);
           } else {
             set(el, 'component.options.symbol.content', value);
           }


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:
   - For symbols or custom components which has a self reference within it's definition, we will remove the self reference a
- Why you made them, and:
   - The `componentToBuilder` generator outputs a Javascript Object instead of a string. When we try to JSON.stringify the builder json object, it throws a circular reference error. It causes error in the `builderContentToMitosisComponent` https://github.com/BuilderIO/mitosis/blob/main/packages/core/src/parsers/builder/builder.ts#L1218

- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
