### PR TITLE
feat: ENG-9092 Correctly convert `For` loop in Mitosis JSX to `repeat.collection` in Builder JSON

### DIFF
--- a/.changeset/thirty-melons-hammer.md
+++ b/.changeset/thirty-melons-hammer.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/mitosis': patch
+'@builder.io/mitosis-cli': patch
+---
+
+Correct the conversion of MitosisJSX `For` component to Builder JSON `repeat.collection`

--- a/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
@@ -158,7 +158,9 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "state.dataBuilderList1",
+              "collection": "Array.from({
+  length: 10
+})",
               "itemName": "_",
             },
           },
@@ -194,7 +196,9 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "state.dataBuilderList1",
+              "collection": "Array.from({
+  length: 10
+})",
             },
           },
           {
@@ -287,7 +291,9 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "state.dataBuilderList1",
+              "collection": "Array.from({
+  length: 10
+})",
               "itemName": "person",
             },
           },
@@ -381,7 +387,9 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "state.dataBuilderList1",
+              "collection": "Array.from({
+  length: 10
+})",
               "itemName": "person",
             },
           },
@@ -397,18 +405,6 @@ exports[`Builder > Advanced For 1`] = `
     "jsCode": "Object.assign(state, { name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
 ",
     "state": {
-      "dataBuilderList1": [
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-      ],
       "name": "'PatrickJS'",
       "names": "['Steve', 'PatrickJS']",
     },
@@ -422,22 +418,7 @@ exports[`Builder > Advanced For 2`] = `
 "import { useStore, For } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useStore({
-    name: \\"PatrickJS\\",
-    names: [\\"Steve\\", \\"PatrickJS\\"],
-    dataBuilderList1: [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ],
-  });
+  const state = useStore({ name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
 
   return (
     <main>
@@ -452,25 +433,19 @@ export default function MyComponent(props) {
       </For>
       <For each={state.names}>{(person, index) => <span>{person}</span>}</For>
       <For each={state.names}>{(item, index) => <br />}</For>
-      <For each={state.dataBuilderList1}>
+      <For
+        each={Array.from({
+          length: 10,
+        })}
+      >
         {(_, index) => <pre>{index}</pre>}
       </For>
-      <For each={state.dataBuilderList1}>{(item, index) => <p>{index}</p>}</For>
-      <For each={state.names}>
-        {(person, index) => (
-          <span>
-            <span>{person}</span>
-            <span>{index}</span>
-          </span>
-        )}
-      </For>
-      <For each={state.dataBuilderList1}>
-        {(person, index) => (
-          <span>
-            <span>{person}</span>
-            <span>{index}</span>
-          </span>
-        )}
+      <For
+        each={Array.from({
+          length: 10,
+        })}
+      >
+        {(item, index) => <p>{index}</p>}
       </For>
       <For each={state.names}>
         {(person, index) => (
@@ -480,7 +455,31 @@ export default function MyComponent(props) {
           </span>
         )}
       </For>
-      <For each={state.dataBuilderList1}>
+      <For
+        each={Array.from({
+          length: 10,
+        })}
+      >
+        {(person, index) => (
+          <span>
+            <span>{person}</span>
+            <span>{index}</span>
+          </span>
+        )}
+      </For>
+      <For each={state.names}>
+        {(person, index) => (
+          <span>
+            <span>{person}</span>
+            <span>{index}</span>
+          </span>
+        )}
+      </For>
+      <For
+        each={Array.from({
+          length: 10,
+        })}
+      >
         {(person, index) => (
           <span>
             <span>{person}</span>

--- a/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
@@ -788,6 +788,10 @@ Object.assign(state, {
 
 state.findAndRunScripts();
 ",
+    "state": {
+      "scriptsInserted": [],
+      "scriptsRun": [],
+    },
     "tsCode": "var props = state;
 
 useStore({
@@ -985,6 +989,10 @@ Object.assign(state, {
 
 state.findAndRunScripts();
 ",
+    "state": {
+      "scriptsInserted": [],
+      "scriptsRun": [],
+    },
     "tsCode": "var props = state;
 
 useStore({

--- a/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
@@ -404,6 +404,10 @@ exports[`Builder > Advanced For 1`] = `
     ],
     "jsCode": "Object.assign(state, { name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
 ",
+    "state": {
+      "name": "'PatrickJS'",
+      "names": "['Steve', 'PatrickJS']",
+    },
     "tsCode": "useStore({ name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
 ",
   },
@@ -1131,6 +1135,12 @@ exports[`Builder > Fragment 1`] = `
     ],
     "jsCode": "Object.assign(state, { people: [\\"Steve\\", \\"Sewell\\"] });
 ",
+    "state": {
+      "people": [
+        "Steve",
+        "Sewell",
+      ],
+    },
     "tsCode": "useStore({ people: [\\"Steve\\", \\"Sewell\\"] });
 ",
   },
@@ -1280,6 +1290,11 @@ if (state.useLazyLoading()) {
   listener();
 }
 ",
+    "state": {
+      "imageLoaded": false,
+      "load": false,
+      "scrollListener": null,
+    },
     "tsCode": "var props = state;
 
 useStore({
@@ -3167,6 +3182,11 @@ fetch(
     state.reviews = data.data;
   });
 ",
+    "state": {
+      "name": "'test'",
+      "reviews": [],
+      "showReviewPrompt": false,
+    },
     "tsCode": "var props = state;
 
 useStore({

--- a/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/builder/__snapshots__/builder.test.ts.snap
@@ -158,9 +158,7 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "Array.from({
-  length: 10
-})",
+              "collection": "state.dataBuilderList1",
               "itemName": "_",
             },
           },
@@ -196,9 +194,7 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "Array.from({
-  length: 10
-})",
+              "collection": "state.dataBuilderList1",
             },
           },
           {
@@ -291,9 +287,7 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "Array.from({
-  length: 10
-})",
+              "collection": "state.dataBuilderList1",
               "itemName": "person",
             },
           },
@@ -387,9 +381,7 @@ exports[`Builder > Advanced For 1`] = `
               "name": "Core:Fragment",
             },
             "repeat": {
-              "collection": "Array.from({
-  length: 10
-})",
+              "collection": "state.dataBuilderList1",
               "itemName": "person",
             },
           },
@@ -405,6 +397,18 @@ exports[`Builder > Advanced For 1`] = `
     "jsCode": "Object.assign(state, { name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
 ",
     "state": {
+      "dataBuilderList1": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ],
       "name": "'PatrickJS'",
       "names": "['Steve', 'PatrickJS']",
     },
@@ -418,7 +422,22 @@ exports[`Builder > Advanced For 2`] = `
 "import { useStore, For } from \\"@builder.io/mitosis\\";
 
 export default function MyComponent(props) {
-  const state = useStore({ name: \\"PatrickJS\\", names: [\\"Steve\\", \\"PatrickJS\\"] });
+  const state = useStore({
+    name: \\"PatrickJS\\",
+    names: [\\"Steve\\", \\"PatrickJS\\"],
+    dataBuilderList1: [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ],
+  });
 
   return (
     <main>
@@ -433,20 +452,10 @@ export default function MyComponent(props) {
       </For>
       <For each={state.names}>{(person, index) => <span>{person}</span>}</For>
       <For each={state.names}>{(item, index) => <br />}</For>
-      <For
-        each={Array.from({
-          length: 10,
-        })}
-      >
+      <For each={state.dataBuilderList1}>
         {(_, index) => <pre>{index}</pre>}
       </For>
-      <For
-        each={Array.from({
-          length: 10,
-        })}
-      >
-        {(item, index) => <p>{index}</p>}
-      </For>
+      <For each={state.dataBuilderList1}>{(item, index) => <p>{index}</p>}</For>
       <For each={state.names}>
         {(person, index) => (
           <span>
@@ -455,11 +464,7 @@ export default function MyComponent(props) {
           </span>
         )}
       </For>
-      <For
-        each={Array.from({
-          length: 10,
-        })}
-      >
+      <For each={state.dataBuilderList1}>
         {(person, index) => (
           <span>
             <span>{person}</span>
@@ -475,11 +480,7 @@ export default function MyComponent(props) {
           </span>
         )}
       </For>
-      <For
-        each={Array.from({
-          length: 10,
-        })}
-      >
+      <For each={state.dataBuilderList1}>
         {(person, index) => (
           <span>
             <span>{person}</span>

--- a/packages/core/src/__tests__/builder/builder.test.ts
+++ b/packages/core/src/__tests__/builder/builder.test.ts
@@ -1688,6 +1688,10 @@ describe('Builder', () => {
           code: '[1,2,3]',
           propertyType: 'normal',
         },
+        fn: {
+          code: 'function () {\n  console.log("fn");\n}',
+          type: 'function',
+        },
       },
       children: [
         {
@@ -1786,7 +1790,12 @@ describe('Builder', () => {
               },
             },
           ],
-          "jsCode": "Object.assign(state, { dataBuilderList1: [1, 2, 3] });
+          "jsCode": "Object.assign(state, {
+        dataBuilderList1: [1, 2, 3],
+        fn: function () {
+          console.log(\\"fn\\");
+        },
+      });
       ",
           "state": {
             "dataBuilderList1": [
@@ -1795,7 +1804,12 @@ describe('Builder', () => {
               3,
             ],
           },
-          "tsCode": "useStore({ dataBuilderList1: [1, 2, 3] });
+          "tsCode": "useStore({
+        dataBuilderList1: [1, 2, 3],
+        fn: function () {
+          console.log(\\"fn\\");
+        },
+      });
       ",
         },
       }
@@ -1805,6 +1819,7 @@ describe('Builder', () => {
     expect(backToMitosis.children[0].name).toBe('For');
     expect(backToMitosis.children[0].bindings.each?.code).toBe('state.dataBuilderList1');
     expect(backToMitosis.state?.dataBuilderList1?.code).toBe('[1, 2, 3]');
+    expect(backToMitosis.state?.fn?.code).toBe('function () {\n  console.log("fn");\n}');
   });
 });
 

--- a/packages/core/src/__tests__/builder/builder.test.ts
+++ b/packages/core/src/__tests__/builder/builder.test.ts
@@ -1688,6 +1688,31 @@ describe('Builder', () => {
           code: '[1,2,3]',
           propertyType: 'normal',
         },
+        stringValue: {
+          type: 'property',
+          code: 'hello',
+          propertyType: 'normal',
+        },
+        numberValue: {
+          type: 'property',
+          code: '1',
+          propertyType: 'normal',
+        },
+        booleanValue: {
+          type: 'property',
+          code: 'true',
+          propertyType: 'normal',
+        },
+        nullValue: {
+          type: 'property',
+          code: 'null',
+          propertyType: 'normal',
+        },
+        undefinedValue: {
+          type: 'property',
+          code: 'undefined',
+          propertyType: 'normal',
+        },
         fn: {
           code: 'function () {\n  console.log("fn");\n}',
           type: 'function',
@@ -1792,20 +1817,34 @@ describe('Builder', () => {
           ],
           "jsCode": "Object.assign(state, {
         dataBuilderList1: [1, 2, 3],
+        stringValue: hello,
+        numberValue: 1,
+        booleanValue: true,
+        nullValue: null,
+        undefinedValue: undefined,
         fn: function () {
           console.log(\\"fn\\");
         },
       });
       ",
           "state": {
+            "booleanValue": true,
             "dataBuilderList1": [
               1,
               2,
               3,
             ],
+            "nullValue": null,
+            "numberValue": 1,
+            "stringValue": "hello",
           },
           "tsCode": "useStore({
         dataBuilderList1: [1, 2, 3],
+        stringValue: hello,
+        numberValue: 1,
+        booleanValue: true,
+        nullValue: null,
+        undefinedValue: undefined,
         fn: function () {
           console.log(\\"fn\\");
         },
@@ -1820,6 +1859,11 @@ describe('Builder', () => {
     expect(backToMitosis.children[0].bindings.each?.code).toBe('state.dataBuilderList1');
     expect(backToMitosis.state?.dataBuilderList1?.code).toBe('[1, 2, 3]');
     expect(backToMitosis.state?.fn?.code).toBe('function () {\n  console.log("fn");\n}');
+    expect(backToMitosis.state?.stringValue?.code).toBe('hello');
+    expect(backToMitosis.state?.numberValue?.code).toBe('1');
+    expect(backToMitosis.state?.booleanValue?.code).toBe('true');
+    expect(backToMitosis.state?.nullValue?.code).toBe('null');
+    expect(backToMitosis.state?.undefinedValue?.code).toBe('undefined');
   });
 });
 

--- a/packages/core/src/__tests__/builder/builder.test.ts
+++ b/packages/core/src/__tests__/builder/builder.test.ts
@@ -1662,6 +1662,11 @@ describe('Builder', () => {
             "propertyType": "normal",
             "type": "property",
           },
+          "dataBuilderList2": {
+            "code": "[1,2,3]",
+            "propertyType": "normal",
+            "type": "property",
+          },
         },
         "subComponents": [],
       }

--- a/packages/core/src/__tests__/builder/builder.test.ts
+++ b/packages/core/src/__tests__/builder/builder.test.ts
@@ -15,6 +15,7 @@ import { compileAwayBuilderComponents } from '@/plugins/compile-away-builder-com
 import { BuilderContent } from '@builder.io/sdk';
 
 import { componentToAngular } from '@/generators/angular';
+import { MitosisComponent } from '@/types/mitosis-component';
 import columns from '../data/blocks/columns.raw.tsx?raw';
 import customCode from '../data/blocks/custom-code.raw.tsx?raw';
 import embed from '../data/blocks/embed.raw.tsx?raw';
@@ -1493,6 +1494,312 @@ describe('Builder', () => {
     // Verify roundtrip conversion
     expect(backToBuilder.data?.blocks?.[0]?.groupLocked).toBe(true);
     expect(backToBuilder.data?.blocks?.[0]?.layerName).toBe('test-layer');
+  });
+
+  test('converts <For> loop to Builder format', () => {
+    const mitosisComponent: MitosisComponent = {
+      '@type': '@builder.io/mitosis/component' as const,
+      imports: [],
+      exports: {},
+      inputs: [],
+      meta: {},
+      refs: {},
+      state: {
+        dataBuilderList1: {
+          // Should not use this key
+          type: 'property',
+          code: '[1,2,3,4,5]',
+          propertyType: 'normal',
+        },
+      },
+      children: [
+        {
+          '@type': '@builder.io/mitosis/node',
+          name: 'For',
+          meta: {},
+          scope: {},
+          properties: {},
+          bindings: {
+            each: {
+              code: '[1, 2, 3]',
+              bindingType: 'expression',
+              type: 'single',
+            },
+          },
+          children: [
+            {
+              '@type': '@builder.io/mitosis/node',
+              name: 'div',
+              meta: {},
+              scope: {},
+              properties: {},
+              bindings: {},
+              children: [],
+            },
+          ],
+        },
+      ],
+      context: {
+        get: {},
+        set: {},
+      },
+      subComponents: [],
+      name: 'MyComponent',
+      hooks: {
+        onMount: [],
+        onEvent: [],
+      },
+    };
+
+    const builderJson = componentToBuilder()({ component: mitosisComponent });
+
+    expect(builderJson).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "blocks": [
+            {
+              "@type": "@builder.io/sdk:Element",
+              "children": [
+                {
+                  "@type": "@builder.io/sdk:Element",
+                  "actions": {},
+                  "bindings": {},
+                  "children": [],
+                  "code": {
+                    "actions": {},
+                    "bindings": {},
+                  },
+                  "properties": {},
+                  "tagName": "div",
+                },
+              ],
+              "component": {
+                "name": "Core:Fragment",
+              },
+              "repeat": {
+                "collection": "state.dataBuilderList2",
+              },
+            },
+          ],
+          "jsCode": "Object.assign(state, { dataBuilderList1: [1, 2, 3, 4, 5] });
+      ",
+          "state": {
+            "dataBuilderList1": [
+              1,
+              2,
+              3,
+              4,
+              5,
+            ],
+            "dataBuilderList2": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "tsCode": "useStore({ dataBuilderList1: [1, 2, 3, 4, 5] });
+      ",
+        },
+      }
+    `);
+
+    // Test roundtrip conversion
+    const backToMitosis = builderContentToMitosisComponent(builderJson);
+    expect(backToMitosis).toMatchInlineSnapshot(`
+      {
+        "@type": "@builder.io/mitosis/component",
+        "children": [
+          {
+            "@type": "@builder.io/mitosis/node",
+            "bindings": {
+              "each": {
+                "bindingType": "expression",
+                "code": "state.dataBuilderList2",
+                "type": "single",
+              },
+            },
+            "children": [
+              {
+                "@type": "@builder.io/mitosis/node",
+                "bindings": {},
+                "children": [],
+                "meta": {},
+                "name": "div",
+                "properties": {},
+                "scope": {},
+                "slots": {},
+              },
+            ],
+            "meta": {},
+            "name": "For",
+            "properties": {},
+            "scope": {
+              "forName": "item",
+            },
+          },
+        ],
+        "context": {
+          "get": {},
+          "set": {},
+        },
+        "exports": {},
+        "hooks": {
+          "onEvent": [],
+          "onMount": [],
+        },
+        "imports": [],
+        "inputs": undefined,
+        "meta": {
+          "useMetadata": {
+            "httpRequests": undefined,
+          },
+        },
+        "name": "MyComponent",
+        "refs": {},
+        "state": {
+          "dataBuilderList1": {
+            "code": "[1, 2, 3, 4, 5]",
+            "propertyType": "normal",
+            "type": "property",
+          },
+        },
+        "subComponents": [],
+      }
+    `);
+  });
+
+  test('converts mitosis component with state to builder json and back', () => {
+    const mitosisComponent: MitosisComponent = {
+      '@type': '@builder.io/mitosis/component',
+      imports: [],
+      exports: {},
+      meta: {
+        useMetadata: {},
+      },
+      refs: {},
+      state: {
+        dataBuilderList1: {
+          type: 'property',
+          code: '[1,2,3]',
+          propertyType: 'normal',
+        },
+      },
+      children: [
+        {
+          '@type': '@builder.io/mitosis/node',
+          name: 'For',
+          meta: {},
+          scope: {
+            forName: 'item',
+          },
+          properties: {},
+          bindings: {
+            each: {
+              code: 'state.dataBuilderList1',
+              bindingType: 'expression',
+              type: 'single',
+            },
+          },
+          children: [
+            {
+              '@type': '@builder.io/mitosis/node',
+              name: 'div',
+              meta: {},
+              scope: {},
+              properties: {},
+              bindings: {},
+              children: [
+                {
+                  '@type': '@builder.io/mitosis/node',
+                  name: 'div',
+                  meta: {},
+                  scope: {},
+                  properties: {
+                    _text: 'Hello',
+                  },
+                  bindings: {},
+                  children: [],
+                },
+              ],
+              slots: {},
+            },
+          ],
+        },
+      ],
+      context: {
+        get: {},
+        set: {},
+      },
+      inputs: [],
+      subComponents: [],
+      name: 'MyComponent',
+      hooks: {
+        onMount: [],
+        onEvent: [],
+      },
+    };
+
+    const builderJson = componentToBuilder()({ component: mitosisComponent });
+    expect(builderJson).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "blocks": [
+            {
+              "@type": "@builder.io/sdk:Element",
+              "children": [
+                {
+                  "@type": "@builder.io/sdk:Element",
+                  "actions": {},
+                  "bindings": {},
+                  "children": [
+                    {
+                      "@type": "@builder.io/sdk:Element",
+                      "bindings": {},
+                      "component": {
+                        "name": "Text",
+                        "options": {
+                          "text": "Hello",
+                        },
+                      },
+                      "tagName": "span",
+                    },
+                  ],
+                  "code": {
+                    "actions": {},
+                    "bindings": {},
+                  },
+                  "properties": {},
+                  "tagName": "div",
+                },
+              ],
+              "component": {
+                "name": "Core:Fragment",
+              },
+              "repeat": {
+                "collection": "state.dataBuilderList1",
+                "itemName": "item",
+              },
+            },
+          ],
+          "jsCode": "Object.assign(state, { dataBuilderList1: [1, 2, 3] });
+      ",
+          "state": {
+            "dataBuilderList1": [
+              1,
+              2,
+              3,
+            ],
+          },
+          "tsCode": "useStore({ dataBuilderList1: [1, 2, 3] });
+      ",
+        },
+      }
+    `);
+
+    const backToMitosis = builderContentToMitosisComponent(builderJson);
+    expect(backToMitosis.children[0].name).toBe('For');
+    expect(backToMitosis.children[0].bindings.each?.code).toBe('state.dataBuilderList1');
+    expect(backToMitosis.state?.dataBuilderList1?.code).toBe('[1, 2, 3]');
   });
 });
 

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -106,15 +106,15 @@ const findStateWithinMitosisNode = (
       const code = node.bindings.each?.code as string;
       try {
         state[newKey] = JSON.parse(code);
+        stateMap.set(code, newKey);
       } catch (parseError) {
         try {
           state[newKey] = eval(code);
+          stateMap.set(code, newKey);
         } catch (evalError) {
           console.log('Failed to evaluate:', code, evalError);
         }
       }
-
-      stateMap.set(code, newKey);
     }
   }
   node.children.forEach((child) => findStateWithinMitosisNode(child, options, state, stateMap));

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -857,17 +857,7 @@ export const componentToBuilder =
             { ...convertMitosisStateToBuilderState(component.state) },
             options.stateMap,
           );
-          // Only include state if it has meaningful data (not just default values)
-          const hasMeaningfulState =
-            Object.keys(stateData).length > 0 &&
-            Object.values(stateData).some(
-              (value) =>
-                value !== null &&
-                value !== undefined &&
-                !(Array.isArray(value) && value.length === 0) &&
-                !(typeof value === 'object' && Object.keys(value).length === 0),
-            );
-          return hasMeaningfulState ? { state: stateData } : {};
+          return { state: stateData };
         })(),
         blocks: component.children
           .filter(filterEmptyTextNodes)

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -102,7 +102,9 @@ const findStateWithinMitosisNode = (
 const findStateWithinMitosisComponent = (
   component: MitosisComponent,
   options: ToBuilderOptions,
-  state: any,
+  state: {
+    [key: string]: any;
+  },
   stateMap: Map<string, string>,
 ) => {
   component.children.forEach((child) =>

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -110,12 +110,11 @@ const findStateWithinMitosisNode = (
         state[newKey] = JSON.parse(code);
         stateMap.set(code, newKey);
       } catch (parseError) {
-        try {
-          state[newKey] = eval(code);
-          stateMap.set(code, newKey);
-        } catch (evalError) {
-          console.log('Failed to evaluate:', code, evalError);
-        }
+        // The parsing error happens when `code` is a function or expression
+        // We would need `eval` to parse the code and then set the state. But because
+        // of security concerns we are not handling this case right now.
+        // Will revisit this if we need to support this.
+        console.log('Failed to parse:', code, parseError);
       }
     }
   }

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -73,10 +73,12 @@ const convertMitosisStateToBuilderState = (state: MitosisComponent['state']) => 
     if (value?.type === 'property' && value?.code) {
       if (value.code === 'true' || value.code === 'false') {
         acc[key] = value.code === 'true';
-      } else if (!Number.isNaN(Number(value.code))) {
-        acc[key] = Number(value.code);
       } else if (value.code === 'null') {
         acc[key] = null;
+      } else if (value.code === 'undefined') {
+        acc[key] = undefined;
+      } else if (!Number.isNaN(Number(value.code))) {
+        acc[key] = Number(value.code);
       } else {
         try {
           acc[key] = JSON.parse(value.code);
@@ -857,6 +859,7 @@ export const componentToBuilder =
             { ...convertMitosisStateToBuilderState(component.state) },
             options.stateMap,
           );
+          console.log('stateData', stateData);
           return { state: stateData };
         })(),
         blocks: component.children

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -86,7 +86,9 @@ const convertMitosisStateToBuilderState = (state: MitosisComponent['state']) => 
 const findStateWithinMitosisNode = (
   node: MitosisNode,
   options: ToBuilderOptions,
-  state: any,
+  state: {
+    [key: string]: any;
+  },
   stateMap: Map<string, string>,
 ) => {
   if (checkIsForNode(node)) {

--- a/packages/core/src/generators/builder/types.ts
+++ b/packages/core/src/generators/builder/types.ts
@@ -2,6 +2,7 @@ import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export interface ToBuilderOptions extends BaseTranspilerOptions {
   includeIds?: boolean;
+  stateMap?: Map<string, string>;
 }
 
 export type BuilderMetadata = {};

--- a/packages/core/src/helpers/get-state-object-string.ts
+++ b/packages/core/src/helpers/get-state-object-string.ts
@@ -35,6 +35,10 @@ const DEFAULT_OPTIONS: RequiredOptions = {
   withType: false,
 };
 
+const quoteKeyIfNeeded = (key: string): string => {
+  return key.includes('-') ? `"${key}"` : key;
+};
+
 const convertStateMemberToString =
   ({
     data,
@@ -68,7 +72,7 @@ const convertStateMemberToString =
           return mapper;
         }
 
-        return `${keyPrefix} ${key} ${keyValueDelimiter} ${mapper}`;
+        return `${keyPrefix} ${quoteKeyIfNeeded(key)} ${keyValueDelimiter} ${mapper}`;
       }
       case 'method': {
         if (!functions) {
@@ -105,7 +109,7 @@ const convertStateMemberToString =
           return mapper;
         }
 
-        return `${keyPrefix} ${key}${type}${keyValueDelimiter} ${mapper}`;
+        return `${keyPrefix} ${quoteKeyIfNeeded(key)}${type}${keyValueDelimiter} ${mapper}`;
       }
       default:
         break;

--- a/packages/core/src/helpers/get-state-object-string.ts
+++ b/packages/core/src/helpers/get-state-object-string.ts
@@ -35,10 +35,6 @@ const DEFAULT_OPTIONS: RequiredOptions = {
   withType: false,
 };
 
-const quoteKeyIfNeeded = (key: string): string => {
-  return key.includes('-') ? `"${key}"` : key;
-};
-
 const convertStateMemberToString =
   ({
     data,
@@ -72,7 +68,7 @@ const convertStateMemberToString =
           return mapper;
         }
 
-        return `${keyPrefix} ${quoteKeyIfNeeded(key)} ${keyValueDelimiter} ${mapper}`;
+        return `${keyPrefix} ${key} ${keyValueDelimiter} ${mapper}`;
       }
       case 'method': {
         if (!functions) {
@@ -109,7 +105,7 @@ const convertStateMemberToString =
           return mapper;
         }
 
-        return `${keyPrefix} ${quoteKeyIfNeeded(key)}${type}${keyValueDelimiter} ${mapper}`;
+        return `${keyPrefix} ${key}${type}${keyValueDelimiter} ${mapper}`;
       }
       default:
         break;

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1098,6 +1098,32 @@ export function extractStateHook(code: string): {
   return { code: newCode, state };
 }
 
+/**
+ * Extracts Mitosis state from Builder state.
+ * @param code
+ * @returns
+ */
+export function extractMitosisStateFromBuilderState(state: MitosisState, builderState: any) {
+  if (!builderState) return;
+  for (const key in builderState) {
+    if (['function', 'object'].includes(typeof builderState[key])) {
+      continue;
+    }
+
+    let value = builderState[key];
+
+    if (!state[key]) {
+      state[key] = {
+        type: 'property',
+        propertyType: 'normal',
+        code: value,
+      };
+    } else {
+      state[key].code = value;
+    }
+  }
+}
+
 export function convertExportDefaultToReturn(code: string) {
   try {
     const { types } = babel;
@@ -1266,7 +1292,7 @@ const builderContentPartToMitosisComponent = (
           ...state,
           ...mapBuilderContentStateToMitosisState(builderContent.data?.state || {}),
         };
-
+  extractMitosisStateFromBuilderState(mitosisState, builderContent.data?.state);
   const componentJson = createMitosisComponent({
     meta: {
       useMetadata: {

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1100,20 +1100,25 @@ export function extractStateHook(code: string): {
 
 /**
  * Extracts Mitosis state from Builder state.
- * @param code
+ * @param mitosisState Mitosis state to update
+ * @param builderState Builder state to extract from
  * @returns
  */
-export function extractMitosisStateFromBuilderState(state: MitosisState, builderState: any) {
+export function extractMitosisStateFromBuilderState(
+  mitosisState: MitosisState,
+  builderState?: {
+    [key: string]: any;
+  },
+) {
   if (!builderState) return;
   for (const key in builderState) {
-    if (['function', 'object'].includes(typeof builderState[key])) {
+    if (['function'].includes(typeof builderState[key])) {
       continue;
     }
 
     let value = builderState[key];
-
-    if (!state[key]) {
-      state[key] = {
+    if (!mitosisState[key]) {
+      mitosisState[key] = {
         type: 'property',
         propertyType: 'normal',
         code: JSON.stringify(value),

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1112,11 +1112,15 @@ export function extractMitosisStateFromBuilderState(
 ) {
   if (!builderState) return;
   for (const key in builderState) {
-    if (['function'].includes(typeof builderState[key])) {
+    let value = builderState[key];
+    if (typeof value === 'function' && !mitosisState[key]) {
+      mitosisState[key] = {
+        type: 'function',
+        code: value.toString(),
+      };
       continue;
     }
 
-    let value = builderState[key];
     if (!mitosisState[key]) {
       mitosisState[key] = {
         type: 'property',

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1116,10 +1116,8 @@ export function extractMitosisStateFromBuilderState(state: MitosisState, builder
       state[key] = {
         type: 'property',
         propertyType: 'normal',
-        code: value,
+        code: JSON.stringify(value),
       };
-    } else {
-      state[key].code = value;
     }
   }
 }


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:
   - Correctly convert `For` loop in Mitosis JSX to `repeat.collection` in Builder JSON 
   
- Why you made them, and:
   -  Mitosis JSX
      ```
      <For each={[1,2,3]}>
        <div>Hello</div>
      </For>
      ```
      Currently the `For` loop in Mitosis JSX is converted to the following in Builder JSON
      
      Builder JSON within a builder block
      ```
      "repeat": {
          "collection": "[1, 2, 3]"
       },
      ```
      Which is not valid builder JSON, and it should be assigned a value in the `data.state` object in Builder JSON. This PR corrects the conversion so that the `repeat.collection` property is populated correctly. 
- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
