### PR TITLE
fix: ENG-9776 AI feature not working because of custom component name which includes colon

### DIFF
--- a/.changeset/kind-steaks-study.md
+++ b/.changeset/kind-steaks-study.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/mitosis': patch
+'@builder.io/mitosis-cli': patch
+---
+
+fix: support for builder custom component with a colon in their name

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -139,7 +139,10 @@ const omitMetaProperties = (obj: Record<string, any>) =>
   omitBy(obj, (_value, key) => key.startsWith('$'));
 
 const builderBlockPrefixes = ['Amp', 'Core', 'Builder', 'Raw', 'Form'];
-const mapComponentName = (name: string) => {
+const mapComponentName = (name: string, meta?: { originalName?: string }) => {
+  if (meta?.originalName) {
+    return meta.originalName;
+  }
   if (name === 'CustomCode') {
     return 'Custom Code';
   }
@@ -792,7 +795,7 @@ export const blockToBuilder = (
       }),
       ...(thisIsComponent && {
         component: {
-          name: mapComponentName(json.name),
+          name: mapComponentName(json.name, json.meta),
           options: componentOptions,
         },
       }),

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -138,10 +138,10 @@ const findStateWithinMitosisComponent = (
 const omitMetaProperties = (obj: Record<string, any>) =>
   omitBy(obj, (_value, key) => key.startsWith('$'));
 
-const builderBlockPrefixes = ['Amp', 'Core', 'Builder', 'Raw', 'Form'];
-const mapComponentName = (name: string, meta?: { originalName?: string }) => {
-  if (meta?.originalName) {
-    return meta.originalName;
+export const builderBlockPrefixes = ['Amp', 'Core', 'Builder', 'Raw', 'Form'];
+const mapComponentName = (name: string, properties?: { [key: string]: string | undefined }) => {
+  if (properties?.['data-builder-originalName']) {
+    return properties['data-builder-originalName'];
   }
   if (name === 'CustomCode') {
     return 'Custom Code';
@@ -795,7 +795,7 @@ export const blockToBuilder = (
       }),
       ...(thisIsComponent && {
         component: {
-          name: mapComponentName(json.name, json.meta),
+          name: mapComponentName(json.name, json.properties),
           options: componentOptions,
         },
       }),
@@ -908,7 +908,6 @@ export const componentToBuilder =
             { ...convertMitosisStateToBuilderState(component.state) },
             options.stateMap,
           );
-          console.log('stateData', stateData);
           return { state: stateData };
         })(),
         blocks: component.children

--- a/packages/core/src/generators/builder/generator.ts
+++ b/packages/core/src/generators/builder/generator.ts
@@ -796,7 +796,7 @@ export const blockToBuilder = (
       ...(thisIsComponent && {
         component: {
           name: mapComponentName(json.name, json.properties),
-          options: componentOptions,
+          options: omit(componentOptions, ['data-builder-originalName']),
         },
       }),
       code: {

--- a/packages/core/src/parsers/builder/builder.test.ts
+++ b/packages/core/src/parsers/builder/builder.test.ts
@@ -83,31 +83,6 @@ describe('Unpaired Surrogates', () => {
       },
     };
 
-    const el = {
-      '@type': '@builder.io/mitosis/node' as const,
-      bindings: {},
-      blocksSlots: {
-        items: [
-          {
-            '@type': '@builder.io/mitosis/node' as const,
-            bindings: {},
-            children: [],
-            meta: {},
-            name: 'br',
-            properties: {},
-            scope: {},
-            slots: {},
-          },
-        ],
-      },
-      children: [],
-      meta: {},
-      name: 'Text123',
-      properties: {},
-      scope: {},
-      slots: {},
-    };
-
     // Convert Builder JSON to Mitosis JSON
     const mitosisCmp = builderContentToMitosisComponent(builderContent);
     expect(mitosisCmp.children[0].name).toBe('Text123');

--- a/packages/core/src/parsers/builder/builder.test.ts
+++ b/packages/core/src/parsers/builder/builder.test.ts
@@ -132,5 +132,8 @@ describe('Unpaired Surrogates', () => {
     // Convert back Mitosis JSON to Builder JSON
     const backToBuilder = componentToBuilder()({ component: backToMitosisCmp });
     expect(backToBuilder?.data?.blocks?.[0]?.component?.name).toBe('Text:123');
+    expect(backToBuilder?.data?.blocks?.[0]?.component?.options).not.toHaveProperty(
+      'data-builder-originalName',
+    );
   });
 });

--- a/packages/core/src/parsers/builder/builder.test.ts
+++ b/packages/core/src/parsers/builder/builder.test.ts
@@ -1,3 +1,4 @@
+import { componentToBuilder } from '@/generators/builder';
 import { BuilderContent } from '@builder.io/sdk';
 import { builderContentToMitosisComponent } from './builder';
 
@@ -27,5 +28,39 @@ describe('Unpaired Surrogates', () => {
     // Verify unpaired surrogates are removed
     expect(output.children[0].children[0].properties._text).not.toContain('\uD800');
     expect(output.children[0].children[0].properties._text).not.toContain('\uDFFF');
+  });
+
+  test('should handle builder component with/without a colon in the name', () => {
+    const builderContent: BuilderContent = {
+      data: {
+        blocks: [
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            component: {
+              name: 'Text:123',
+              options: {
+                text: 'Hello World',
+              },
+            },
+          },
+          {
+            '@type': '@builder.io/sdk:Element' as const,
+            component: {
+              name: 'Text123',
+              options: {
+                text: 'Hello World',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const component = builderContentToMitosisComponent(builderContent);
+    expect(component.children[0].name).toBe('Text123');
+    expect(component.children[1].name).toBe('Text123');
+    const backToBuilder = componentToBuilder()({ component });
+    expect(backToBuilder?.data?.blocks?.[0]?.component?.name).toBe('Text:123');
+    expect(backToBuilder?.data?.blocks?.[1]?.component?.name).toBe('Text123');
   });
 });

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -961,7 +961,18 @@ export const builderElementToMitosisNode = (
       ...slots,
     },
     ...(Object.keys(blocksSlots).length > 0 && { blocksSlots }),
-    meta: getMetaFromBlock(block, options),
+    meta: {
+      ...getMetaFromBlock(block, options),
+      ...(() => {
+        const originalNameMeta: {
+          originalName?: string;
+        } = {};
+        if (block.component?.name && /:/.test(block.component?.name)) {
+          originalNameMeta.originalName = block.component?.name;
+        }
+        return originalNameMeta;
+      })(),
+    },
     ...(Object.keys(localizedValues).length && { localizedValues }),
   });
 

--- a/packages/core/src/parsers/builder/builder.ts
+++ b/packages/core/src/parsers/builder/builder.ts
@@ -1,3 +1,4 @@
+import { builderBlockPrefixes } from '@/generators/builder/generator';
 import { hashCodeAsString } from '@/symbols/symbol-processor';
 import { MitosisComponent, MitosisState } from '@/types/mitosis-component';
 import * as babel from '@babel/core';
@@ -934,6 +935,13 @@ export const builderElementToMitosisNode = (
   if (block.groupLocked !== undefined) {
     dataAttributes['data-builder-groupLocked'] = String(block.groupLocked);
   }
+  if (
+    block.component?.name &&
+    /:/.test(block.component?.name) &&
+    !builderBlockPrefixes.includes(block.component?.name.split(':')[0])
+  ) {
+    dataAttributes['data-builder-originalName'] = block.component?.name;
+  }
 
   const node = createMitosisNode({
     name:
@@ -963,15 +971,6 @@ export const builderElementToMitosisNode = (
     ...(Object.keys(blocksSlots).length > 0 && { blocksSlots }),
     meta: {
       ...getMetaFromBlock(block, options),
-      ...(() => {
-        const originalNameMeta: {
-          originalName?: string;
-        } = {};
-        if (block.component?.name && /:/.test(block.component?.name)) {
-          originalNameMeta.originalName = block.component?.name;
-        }
-        return originalNameMeta;
-      })(),
     },
     ...(Object.keys(localizedValues).length && { localizedValues }),
   });


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:
    - if the component name contains a colon, store the original name in `meta` 
    - during `componentToBuilder` transpilation use the original name in `meta` as the component name.
- Why you made them, and:
    - VE AI removes the colon from the component names 


Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
